### PR TITLE
Refine lock provider layering for hex architecture

### DIFF
--- a/application/locks.py
+++ b/application/locks.py
@@ -1,24 +1,24 @@
 from __future__ import annotations
 
 import asyncio
-import os
 from dataclasses import dataclass
-from typing import Protocol, Tuple, runtime_checkable
+from typing import Protocol, runtime_checkable
 from weakref import WeakValueDictionary
-
-try:
-    from redis.asyncio import Redis  # type: ignore
-except Exception:  # pragma: no cover
-    Redis = None  # type: ignore
 
 """
 Ограничение: InMemory реализация процесс-локальная. Для межпроцессной синхронизации
-используйте RedisLockProvider и configure_from_env().
+используйте set_lock_provider() с адаптером из инфраструктурного слоя.
 Ключ блокировки: (inline_id|chat, biz_id).
 """
 
 
-def _key(scope):
+class ScopeLike(Protocol):
+    inline_id: object | None
+    chat: object | None
+    biz_id: object | None
+
+
+def _key(scope: ScopeLike) -> tuple[object | None, object | None]:
     return (
         getattr(scope, "inline_id", None) or getattr(scope, "chat", None),
         getattr(scope, "biz_id", None),
@@ -37,12 +37,12 @@ class _LockLike(Protocol):
 
 
 @dataclass
-class _LockBox:
+class LockBox:
     lock: _LockLike
 
 
 class LockProvider(Protocol):
-    def box_for(self, key: Tuple[object, object | None]) -> _LockBox: ...
+    def box_for(self, key: tuple[object, object | None]) -> LockBox: ...
 
 
 class _MemLockAdapter:
@@ -66,111 +66,40 @@ class _MemLockAdapter:
 
 class InMemoryLockProvider:
     def __init__(self) -> None:
-        self._locks: "WeakValueDictionary[tuple[object, object | None], _LockBox]" = WeakValueDictionary()
+        self._locks: WeakValueDictionary[
+            tuple[object, object | None], LockBox
+        ] = WeakValueDictionary()
 
-    def box_for(self, key: Tuple[object, object | None]) -> _LockBox:  # type: ignore[override]
+    def box_for(self, key: tuple[object, object | None]) -> LockBox:  # type: ignore[override]
         box = self._locks.get(key)
         if box is None:
-            box = _LockBox(lock=_MemLockAdapter())
+            box = LockBox(lock=_MemLockAdapter())
             self._locks[key] = box
         return box
 
 
-class _AsyncLockAdapter:
-    """
-    Адаптер над асинхронным бэкендом блокировки с честным locked().
-    holder._b должен предоставлять async acquire()/release().
-    """
-
-    def __init__(self, holder) -> None:
-        self._h = holder
-        self._locked = False
-
-    async def acquire(self) -> bool:
-        await self._h._b.acquire()
-        self._locked = True
-        return True
-
-    def release(self) -> None:
-        self._locked = False
-        asyncio.get_running_loop().create_task(self._h._b.release())
-
-    async def release_async(self) -> None:
-        await self._h._b.release()
-        self._locked = False
-
-    def locked(self) -> bool:
-        return bool(self._locked)
+_PROVIDER: list[LockProvider] = [InMemoryLockProvider()]
 
 
-class RedisLockProvider:
-    def __init__(self, url: str, ttl: float, blocking: float) -> None:
-        if Redis is None:
-            raise RuntimeError("redis package not installed")
-        self._r = Redis.from_url(url)
-        self._ttl = float(ttl)
-        self._blocking = float(blocking)
-
-    def box_for(self, key: Tuple[object, object | None]) -> _LockBox:  # type: ignore[override]
-        name = f"nav:lock:{key[0]}:{key[1]}"
-
-        class _RedisBox:
-            def __init__(self, r, name, ttl, blocking):
-                self._r = r
-                self._name = name
-                self._ttl = ttl
-                self._blocking = blocking
-                self._lock = None
-
-            async def acquire(self):
-                self._lock = self._r.lock(self._name, timeout=self._ttl, blocking_timeout=self._blocking)
-                await self._lock.acquire()
-
-            async def release(self):
-                try:
-                    if self._lock:
-                        await self._lock.release()
-                except Exception as e:
-                    # Логируем предупреждение. Семантика Guard не меняется.
-                    import logging
-                    logging.getLogger(__name__).warning("redis_lock_release_failed: %s", type(e).__name__)
-
-        box = _RedisBox(self._r, name, self._ttl, self._blocking)
-
-        class _GuardCompat:
-            def __init__(self, b):
-                self._b = b
-
-        g = _GuardCompat(box)
-        return _LockBox(lock=_AsyncLockAdapter(g))
-
-
-_provider: LockProvider = InMemoryLockProvider()
+def _current_provider() -> LockProvider:
+    return _PROVIDER[0]
 
 
 def set_lock_provider(p: LockProvider) -> None:
-    global _provider
-    _provider = p
-
-
-def configure_from_env() -> None:
-    mode = os.getenv("NAV_LOCKS", "memory").lower()
-    if mode == "redis":
-        url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
-        ttl = float(os.getenv("NAV_LOCK_TTL", "20"))
-        bt = float(os.getenv("NAV_LOCK_BLOCKING", "5"))
-        set_lock_provider(RedisLockProvider(url, ttl, bt))
+    _PROVIDER[0] = p
 
 
 class Guard:
-    def __init__(self, scope) -> None:
+    def __init__(self, scope: ScopeLike) -> None:
         k = _key(scope)
-        self._box = _provider.box_for(k)
+        self._box = _current_provider().box_for(k)
 
     async def __aenter__(self) -> None:
         await self._box.lock.acquire()
 
-    async def __aexit__(self, *a) -> None:
+    async def __aexit__(
+        self, exc_type: object, exc: object, traceback: object
+    ) -> None:
         rel = getattr(self._box.lock, "release_async", None)
         if rel:
             await rel()
@@ -178,5 +107,16 @@ class Guard:
             self._box.lock.release()
 
 
-def guard(scope):
+def guard(scope: ScopeLike) -> Guard:
     return Guard(scope)
+
+
+__all__ = [
+    "LockBox",
+    "LockProvider",
+    "InMemoryLockProvider",
+    "ScopeLike",
+    "Guard",
+    "guard",
+    "set_lock_provider",
+]

--- a/composition/__init__.py
+++ b/composition/__init__.py
@@ -1,9 +1,9 @@
 from typing import Optional, Any
 
 from ..adapters.factory.registry import default as reg_default
-from ..application.locks import configure_from_env
 from ..composition import migrate
 from ..infrastructure.di.container import AppContainer
+from ..infrastructure.locks import configure_from_env
 from ..presentation.navigator import Navigator
 from ..presentation.telegram.scope import make_scope
 

--- a/infrastructure/locks.py
+++ b/infrastructure/locks.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import TYPE_CHECKING, Any
+
+try:
+    from redis.asyncio import Redis  # type: ignore[attr-defined]
+except Exception:  # pragma: no cover - optional dependency
+    Redis = None  # type: ignore[assignment]
+
+if TYPE_CHECKING:
+    from redis.asyncio import Redis as RedisClient  # pragma: no cover
+else:  # pragma: no cover
+    RedisClient = Any
+
+from ..application.locks import LockBox, LockProvider, set_lock_provider
+
+logger = logging.getLogger(__name__)
+
+
+class _RedisLockAdapter:
+    """Adapter that exposes redis lock through the application lock protocol."""
+
+    def __init__(
+        self, redis: RedisClient, name: str, ttl: float, blocking: float
+    ) -> None:
+        self._redis = redis
+        self._name = name
+        self._ttl = ttl
+        self._blocking = blocking
+        self._lock: Any | None = None
+        self._locked = False
+
+    async def acquire(self) -> bool:
+        self._lock = self._redis.lock(
+            self._name,
+            timeout=self._ttl,
+            blocking_timeout=self._blocking,
+        )
+        await self._lock.acquire()
+        self._locked = True
+        return True
+
+    async def release_async(self) -> None:
+        try:
+            if self._lock:
+                await self._lock.release()
+        except Exception as exc:  # pragma: no cover - defensive logging
+            logger.warning("redis_lock_release_failed: %s", type(exc).__name__)
+        finally:
+            self._locked = False
+
+    def release(self) -> None:
+        self._locked = False
+        asyncio.get_running_loop().create_task(self.release_async())
+
+    def locked(self) -> bool:
+        return bool(self._locked)
+
+
+class RedisLockProvider(LockProvider):
+    """Distributed lock provider backed by redis."""
+
+    def __init__(self, url: str, ttl: float, blocking: float) -> None:
+        if Redis is None:  # pragma: no cover - optional dependency
+            raise RuntimeError("redis package not installed")
+        self._redis = Redis.from_url(url)
+        self._ttl = float(ttl)
+        self._blocking = float(blocking)
+
+    def box_for(self, key: tuple[object, object | None]) -> LockBox:  # type: ignore[override]
+        name = f"nav:lock:{key[0]}:{key[1]}"
+        adapter = _RedisLockAdapter(self._redis, name, self._ttl, self._blocking)
+        return LockBox(lock=adapter)
+
+
+def configure_from_env() -> None:
+    """Configure lock provider based on environment variables."""
+
+    mode = os.getenv("NAV_LOCKS", "memory").lower()
+    if mode != "redis":
+        return
+    url = os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    ttl = float(os.getenv("NAV_LOCK_TTL", "20"))
+    blocking = float(os.getenv("NAV_LOCK_BLOCKING", "5"))
+    set_lock_provider(RedisLockProvider(url, ttl, blocking))
+
+
+__all__ = ["RedisLockProvider", "configure_from_env"]
+


### PR DESCRIPTION
## Summary
- refactor the application lock helper to expose a public LockBox/ScopeLike API and drop the redis dependency
- add an infrastructure-level redis lock provider with environment-based configuration
- update the composition bootstrap to source lock configuration from the infrastructure layer

## Testing
- ruff check . (fails: repository already contains numerous lint violations outside the touched files)
- ruff check application/locks.py infrastructure/locks.py


------
https://chatgpt.com/codex/tasks/task_e_68cedd25108c83308adfed453a9fdbb3