### PR TITLE
Inject strict inline media path configuration

### DIFF
--- a/infrastructure/config.py
+++ b/infrastructure/config.py
@@ -7,10 +7,12 @@ class Settings(BaseModel):
     history_limit: int = Field(18, ge=1, le=200)
     chunk: int = Field(100, ge=1, le=100)
     truncate: bool = Field(False)  # управляемое усечение текста/подписи; ENV: NAV_TRUNCATE in {1,true,yes}
+    strict_inline_media_path: bool = Field(True)  # ENV: NAV_STRICT_INLINE_MEDIA_PATH in {1,true,yes}
 
 
 SETTINGS = Settings(
     history_limit=int(os.getenv("NAV_HISTORY_LIMIT", "18")),
     chunk=int(os.getenv("NAV_CHUNK", "100")),
     truncate=os.getenv("NAV_TRUNCATE", "0").lower() in {"1", "true", "yes"},
+    strict_inline_media_path=os.getenv("NAV_STRICT_INLINE_MEDIA_PATH", "1").lower() in {"1", "true", "yes"},
 )

--- a/infrastructure/di/container.py
+++ b/infrastructure/di/container.py
@@ -47,7 +47,12 @@ class AppContainer(containers.DeclarativeContainer):
 
     temp_repo = providers.Factory(TempRepo, state=state)
     entry_mapper = providers.Factory(EntryMapper, registry=registry)
-    inline_strategy = providers.Factory(InlineStrategy, gateway=gateway, is_url_input_file=is_url_input_file)
+    inline_strategy = providers.Factory(
+        InlineStrategy,
+        gateway=gateway,
+        is_url_input_file=is_url_input_file,
+        strict_inline_media_path=providers.Object(SETTINGS.strict_inline_media_path),
+    )
     view_orchestrator = providers.Factory(ViewOrchestrator, gateway=gateway, inline=inline_strategy)
     view_restorer = providers.Factory(
         ViewRestorer, markup_codec=markup_codec, factory_registry=registry


### PR DESCRIPTION
## Summary
- extend application configuration with a strict inline media path flag sourced from `NAV_STRICT_INLINE_MEDIA_PATH`
- pass the strictness flag through the DI container and into `InlineStrategy` instead of reading the environment at module import time

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cee722bf508330bf3a688a074f68a0