### PR TITLE
Inject rendering config for thumb detection

### DIFF
--- a/application/service/view/inline.py
+++ b/application/service/view/inline.py
@@ -8,6 +8,7 @@ from ....domain.entity.history import Entry
 from ....domain.entity.media import MediaType
 from ....domain.log.emit import jlog
 from ....domain.service.rendering import decision as _d
+from ....domain.service.rendering.config import RenderingConfig
 from ....domain.util.path import is_local_path, is_http_url
 from ....logging.code import LogCode
 
@@ -69,7 +70,16 @@ class InlineStrategy:
         except Exception:
             return True
 
-    async def handle_element(self, *, scope, payload, last_message, inline, swap):
+    async def handle_element(
+            self,
+            *,
+            scope,
+            payload,
+            last_message,
+            inline,
+            swap,
+            rendering_config: RenderingConfig,
+    ):
         if inline:
             p = keep_preview_extra(payload, last_message)
             if getattr(p, "group", None):
@@ -94,7 +104,7 @@ class InlineStrategy:
                     return None
                 # Редактируемое медиа: решаем точный тип правки.
                 base = Entry(state=None, view=None, messages=[last_message]) if last_message else None
-                dec0 = _d.decide(base, p)
+                dec0 = _d.decide(base, p, rendering_config)
                 if dec0 is _d.Decision.DELETE_SEND:
                     dec1 = _inline_remap(base_msg, p, inline=True)
                     jlog(self._logger, logging.INFO, LogCode.INLINE_REMAP_DELETE_SEND, from_="DELETE_SEND",

--- a/application/usecase/last.py
+++ b/application/usecase/last.py
@@ -102,7 +102,7 @@ class LastUseCase:
                 break
 
         if last_entry is not None:
-            dec = decision.decide(last_entry, p)
+            dec = decision.decide(last_entry, p, self._orchestrator.rendering_config)
         else:
             if p.media:
                 dec = decision.Decision.EDIT_MEDIA
@@ -149,7 +149,12 @@ class LastUseCase:
         ):
             lm = base.messages[0] if base and base.messages else None
             result = await self._orchestrator._inline.handle_element(
-                scope=scope, payload=p, last_message=lm, inline=True, swap=self._orchestrator.swap
+                scope=scope,
+                payload=p,
+                last_message=lm,
+                inline=True,
+                swap=self._orchestrator.swap,
+                rendering_config=self._orchestrator.rendering_config,
             )
         else:
             result = await self._orchestrator.swap(scope, p, base, dec)

--- a/domain/constants.py
+++ b/domain/constants.py
@@ -1,4 +1,3 @@
-import os
 from typing import Final
 
 TEXT_MAX: Final = 4096
@@ -7,4 +6,4 @@ ALBUM_MIN: Final = 2
 ALBUM_MAX: Final = 10
 ALBUM_MIXED_ALLOWED: Final = {"photo", "video"}
 # Если True: любое присутствие thumb в extra при partial-edit альбомов триггерит EDIT_MEDIA.
-DETECT_THUMB_CHANGE: bool = os.getenv("NAV_DETECT_THUMB_CHANGE", "0").lower() in {"1", "true", "yes"}
+DETECT_THUMB_CHANGE: Final[bool] = False

--- a/domain/service/rendering/config.py
+++ b/domain/service/rendering/config.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class RenderingConfig:
+    detect_thumb_change: bool = False
+

--- a/infrastructure/config.py
+++ b/infrastructure/config.py
@@ -8,6 +8,7 @@ class Settings(BaseModel):
     chunk: int = Field(100, ge=1, le=100)
     truncate: bool = Field(False)  # управляемое усечение текста/подписи; ENV: NAV_TRUNCATE in {1,true,yes}
     strict_inline_media_path: bool = Field(True)  # ENV: NAV_STRICT_INLINE_MEDIA_PATH in {1,true,yes}
+    detect_thumb_change: bool = Field(False)
 
 
 SETTINGS = Settings(
@@ -15,4 +16,5 @@ SETTINGS = Settings(
     chunk=int(os.getenv("NAV_CHUNK", "100")),
     truncate=os.getenv("NAV_TRUNCATE", "0").lower() in {"1", "true", "yes"},
     strict_inline_media_path=os.getenv("NAV_STRICT_INLINE_MEDIA_PATH", "1").lower() in {"1", "true", "yes"},
+    detect_thumb_change=os.getenv("NAV_DETECT_THUMB_CHANGE", "0").lower() in {"1", "true", "yes"},
 )

--- a/infrastructure/di/container.py
+++ b/infrastructure/di/container.py
@@ -21,6 +21,7 @@ from ...application.usecase.rebase import RebaseUseCase
 from ...application.usecase.replace import ReplaceUseCase
 from ...application.usecase.set import SetUseCase
 from ...domain.port.factory import ViewFactoryRegistry
+from ...domain.service.rendering.config import RenderingConfig
 from ...infrastructure.config import SETTINGS
 
 
@@ -53,7 +54,13 @@ class AppContainer(containers.DeclarativeContainer):
         is_url_input_file=is_url_input_file,
         strict_inline_media_path=providers.Object(SETTINGS.strict_inline_media_path),
     )
-    view_orchestrator = providers.Factory(ViewOrchestrator, gateway=gateway, inline=inline_strategy)
+    rendering_config = providers.Object(RenderingConfig(detect_thumb_change=SETTINGS.detect_thumb_change))
+    view_orchestrator = providers.Factory(
+        ViewOrchestrator,
+        gateway=gateway,
+        inline=inline_strategy,
+        rendering_config=rendering_config,
+    )
     view_restorer = providers.Factory(
         ViewRestorer, markup_codec=markup_codec, factory_registry=registry
     )


### PR DESCRIPTION
## Summary
- add a RenderingConfig dataclass to carry the detect_thumb_change flag through rendering
- update decision helpers, view orchestrator, and inline handling to use the injected config instead of the global constant
- surface NAV_DETECT_THUMB_CHANGE via infrastructure settings/DI and remove env lookups from domain constants

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ceed5bef188330a308ddc6dc532204