### PR TITLE
Make log redaction configurable

### DIFF
--- a/application/log/emit.py
+++ b/application/log/emit.py
@@ -1,6 +1,6 @@
 import logging
 
-from ...domain.log.emit import jlog
+from ...domain.log.emit import jlog, set_redaction_mode
 
 
 def debug(logger, code, **fields):
@@ -19,4 +19,4 @@ def error(logger, code, **fields):
     jlog(logger, logging.ERROR, code, **fields)
 
 
-__all__ = ["jlog", "debug", "info", "warning", "error"]
+__all__ = ["jlog", "debug", "info", "warning", "error", "set_redaction_mode"]

--- a/composition/__init__.py
+++ b/composition/__init__.py
@@ -1,7 +1,9 @@
 from typing import Optional, Any
 
 from ..adapters.factory.registry import default as reg_default
+from ..application.log.emit import set_redaction_mode
 from ..composition import migrate
+from ..infrastructure.config import SETTINGS
 from ..infrastructure.di.container import AppContainer
 from ..infrastructure.locks import configure_from_env
 from ..presentation.navigator import Navigator
@@ -9,6 +11,7 @@ from ..presentation.telegram.scope import make_scope
 
 
 async def create_navigator(event: Any, state: Any, registry: Optional[Any] = None) -> Navigator:
+    set_redaction_mode(SETTINGS.log_redaction_mode)
     configure_from_env()
     reg = registry if registry is not None else reg_default
     await migrate.run(state, reg)

--- a/domain/log/emit.py
+++ b/domain/log/emit.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import logging
-import os
 from datetime import datetime, timezone
 from typing import Any, Dict
 
@@ -13,12 +12,23 @@ REDACT_KEYS = {"path", "inline_id", "biz_id", "url", "caption", "thumb"}
 # - debug: без редактирования;
 # - safe (по умолчанию): редактируются ключи из REDACT_KEYS;
 # - paranoid: дополнительно редактируются text и entities.
-REDACTION_MODE = os.getenv("NAV_LOG_REDACTION", "safe").lower()
+_DEFAULT_REDACTION_MODE = "safe"
+_redaction_mode = _DEFAULT_REDACTION_MODE
+
+
+def set_redaction_mode(mode: str) -> None:
+    """Configure log redaction mode."""
+
+    global _redaction_mode
+    normalized = (mode or _DEFAULT_REDACTION_MODE).lower()
+    if normalized not in {"debug", "safe", "paranoid"}:
+        normalized = _DEFAULT_REDACTION_MODE
+    _redaction_mode = normalized
 
 
 def _keys_to_redact() -> set[str]:
     base = set(REDACT_KEYS)
-    if REDACTION_MODE == "paranoid":
+    if _redaction_mode == "paranoid":
         base.update({"text", "entities"})
     return base
 
@@ -29,7 +39,7 @@ def _redact(v: Any) -> Any:
     if isinstance(v, dict):
         keys = _keys_to_redact()
         return {
-            k: ("***" if k in keys and REDACTION_MODE != "debug" else _redact(vv))
+            k: ("***" if k in keys and _redaction_mode != "debug" else _redact(vv))
             for k, vv in v.items()
         }
     if isinstance(v, (list, tuple)):

--- a/infrastructure/config.py
+++ b/infrastructure/config.py
@@ -9,6 +9,7 @@ class Settings(BaseModel):
     truncate: bool = Field(False)  # управляемое усечение текста/подписи; ENV: NAV_TRUNCATE in {1,true,yes}
     strict_inline_media_path: bool = Field(True)  # ENV: NAV_STRICT_INLINE_MEDIA_PATH in {1,true,yes}
     detect_thumb_change: bool = Field(False)
+    log_redaction_mode: str = Field("safe")
 
 
 SETTINGS = Settings(
@@ -17,4 +18,5 @@ SETTINGS = Settings(
     truncate=os.getenv("NAV_TRUNCATE", "0").lower() in {"1", "true", "yes"},
     strict_inline_media_path=os.getenv("NAV_STRICT_INLINE_MEDIA_PATH", "1").lower() in {"1", "true", "yes"},
     detect_thumb_change=os.getenv("NAV_DETECT_THUMB_CHANGE", "0").lower() in {"1", "true", "yes"},
+    log_redaction_mode=os.getenv("NAV_LOG_REDACTION", "safe").lower(),
 )


### PR DESCRIPTION
## Summary
- add a configurable redaction mode to the domain logger and re-export it via the application logging helpers
- load `NAV_LOG_REDACTION` into infrastructure settings and apply it during navigator composition

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ceeefe9d1483308feaf949d9e947c7