### PR TITLE
Introduce NotifyHistoryEmpty use case

### DIFF
--- a/application/usecase/notify_history_empty.py
+++ b/application/usecase/notify_history_empty.py
@@ -1,0 +1,23 @@
+import logging
+
+from ..log.emit import jlog
+from ...domain.port.message import MessageGateway
+from ...domain.value.message import Scope
+from ...logging.code import LogCode
+
+logger = logging.getLogger(__name__)
+
+
+class NotifyHistoryEmptyUseCase:
+    def __init__(self, gateway: MessageGateway) -> None:
+        self._gateway = gateway
+
+    async def execute(self, scope: Scope) -> None:
+        await self._gateway.notify_empty(scope)
+        jlog(
+            logger,
+            logging.INFO,
+            LogCode.GATEWAY_NOTIFY_EMPTY,
+            op="notify_history_empty",
+            scope={"chat": scope.chat, "inline": bool(scope.inline_id)},
+        )

--- a/composition/__init__.py
+++ b/composition/__init__.py
@@ -25,6 +25,6 @@ async def create_navigator(event: Any, state: Any, registry: Optional[Any] = Non
         pop_uc=container.pop_uc(),
         rebase_uc=container.rebase_uc(),
         last_uc=container.last_uc(),
-        gateway=container.gateway(),
+        notify_history_empty_uc=container.notify_history_empty_uc(),
         scope=scope,
     )

--- a/infrastructure/di/container.py
+++ b/infrastructure/di/container.py
@@ -16,6 +16,7 @@ from ...application.service.view.restorer import ViewRestorer
 from ...application.usecase.add import AddUseCase
 from ...application.usecase.back import BackUseCase
 from ...application.usecase.last import LastUseCase
+from ...application.usecase.notify_history_empty import NotifyHistoryEmptyUseCase
 from ...application.usecase.pop import PopUseCase
 from ...application.usecase.rebase import RebaseUseCase
 from ...application.usecase.replace import ReplaceUseCase
@@ -94,4 +95,8 @@ class AppContainer(containers.DeclarativeContainer):
     last_uc = providers.Factory(
         LastUseCase, last_repo=last_repo, history_repo=history_repo, gateway=gateway,
         orchestrator=view_orchestrator,
+    )
+    notify_history_empty_uc = providers.Factory(
+        NotifyHistoryEmptyUseCase,
+        gateway=gateway,
     )

--- a/presentation/navigator.py
+++ b/presentation/navigator.py
@@ -56,11 +56,11 @@ from ..application.map.payload import to_node_payload, to_payload
 from ..application.usecase.add import AddUseCase
 from ..application.usecase.back import BackUseCase
 from ..application.usecase.last import LastUseCase
+from ..application.usecase.notify_history_empty import NotifyHistoryEmptyUseCase
 from ..application.usecase.pop import PopUseCase
 from ..application.usecase.rebase import RebaseUseCase
 from ..application.usecase.replace import ReplaceUseCase
 from ..application.usecase.set import SetUseCase
-from ..domain.port.message import MessageGateway
 from ..domain.service.scope import scope_kv
 from ..domain.value.message import Scope
 from ..logging.code import LogCode
@@ -115,7 +115,7 @@ class Navigator:
             pop_uc: PopUseCase,
             rebase_uc: RebaseUseCase,
             last_uc: LastUseCase,
-            gateway: MessageGateway,
+            notify_history_empty_uc: NotifyHistoryEmptyUseCase,
             scope: Scope,
     ):
         self._add = add_uc
@@ -124,7 +124,7 @@ class Navigator:
         self._set = set_uc
         self._pop = pop_uc
         self._rebase = rebase_uc
-        self._gateway = gateway
+        self._notify_history_empty = notify_history_empty_uc
         self._scope = scope
         self.last = _LastAPI(use_case=last_uc, scope=scope)
 
@@ -197,4 +197,4 @@ class Navigator:
     async def inform_history_is_empty(self) -> None:
         jlog(logger, logging.INFO, LogCode.NAVIGATOR_API, method="notify_empty", scope=scope_kv(self._scope))
         async with locks.guard(self._scope):
-            await self._gateway.notify_empty(self._scope)
+            await self._notify_history_empty.execute(self._scope)


### PR DESCRIPTION
## Summary
- add a dedicated NotifyHistoryEmptyUseCase that wraps gateway.notify_empty
- register the new use case in the DI container and request it when building Navigator
- update Navigator to depend on the new use case when informing about an empty history

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cef28b22f48330b8503f8c0f83f11f