### PR TITLE
Add reply policy helper and prefilter payloads

### DIFF
--- a/adapters/telegram/gateway/common.py
+++ b/adapters/telegram/gateway/common.py
@@ -13,18 +13,8 @@ from ....logging.code import LogCode
 logger = logging.getLogger(__name__)
 
 
-def reply_for_send(codec, scope, reply):
-    obj = serializer.decode_reply(codec, reply)
-    if obj is None:
-        return None
-    if bool(scope.biz_id):
-        return obj if isinstance(obj, InlineKeyboardMarkup) else None
-    ct = getattr(scope, "chat_kind", None)
-    if ct == "private":
-        return obj  # приватные чаты: разрешить все поддерживаемые reply-объекты
-    if ct == "group":
-        return obj  # группы: разрешить все поддерживаемые reply-объекты
-    return obj if isinstance(obj, InlineKeyboardMarkup) else None
+def reply_for_send(codec, reply):
+    return serializer.decode_reply(codec, reply)
 
 
 def reply_for_edit(codec, reply):

--- a/adapters/telegram/gateway/send.py
+++ b/adapters/telegram/gateway/send.py
@@ -140,7 +140,7 @@ async def do_send(bot, codec: MarkupCodec, scope: Scope, payload, *, truncate: b
             call_kwargs: Dict[str, Any] = {
                 **context,
                 **{payload.media.type.value: tg_media},
-                "reply_markup": reply_for_send(codec, scope, payload.reply),
+                "reply_markup": reply_for_send(codec, payload.reply),
                 **caption_kwargs,
                 **media_kwargs,
             }
@@ -166,7 +166,7 @@ async def do_send(bot, codec: MarkupCodec, scope: Scope, payload, *, truncate: b
                 bot.send_message,
                 **context,
                 text=raw,
-                reply_markup=reply_for_send(codec, scope, payload.reply),
+                reply_markup=reply_for_send(codec, payload.reply),
                 link_preview_options=serializer.map_preview(payload.preview),
                 **text_kwargs,
             )

--- a/application/service/view/orchestrator.py
+++ b/application/service/view/orchestrator.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import Optional, List, Any
 
 from ..view.inline import InlineStrategy
+from .policy import payload_with_allowed_reply
 from ...internal import policy as _pol
 from ...internal.policy import inline_guard
 from ...log.decorators import log_io
@@ -134,6 +135,7 @@ class ViewOrchestrator:
             dec: decision.Decision,
     ) -> Optional[RenderResult]:
         inline_guard(scope, payload)
+        payload = payload_with_allowed_reply(scope, payload)
 
         def _head_msg(e):
             return self._head_msg(e)
@@ -265,7 +267,7 @@ class ViewOrchestrator:
             last_node: Optional[Entry],
             inline: bool,
     ) -> Optional[RenderResultNode]:
-        new = list(payloads)
+        new = [payload_with_allowed_reply(scope, p) for p in payloads]
         if inline:
             original_len = len(new)
             if original_len > 1:

--- a/application/service/view/policy.py
+++ b/application/service/view/policy.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from ....domain.entity.markup import Markup
+from ....domain.value.content import Payload
+from ....domain.value.message import Scope
+
+_INLINE_KEYBOARD_KIND = "InlineKeyboardMarkup"
+
+
+def allowed_reply(scope: Scope, reply: Optional[Markup]) -> Optional[Markup]:
+    """Return reply markup allowed for the given scope.
+
+    Scope-specific restrictions limit business chats and non-private/group chats to
+    inline keyboards only. Private and group chats may use any supported markup.
+    """
+    if reply is None:
+        return None
+
+    if bool(getattr(scope, "biz_id", None)):
+        return reply if reply.kind == _INLINE_KEYBOARD_KIND else None
+
+    chat_kind = getattr(scope, "chat_kind", None)
+    if chat_kind in {"private", "group"}:
+        return reply
+
+    return reply if reply.kind == _INLINE_KEYBOARD_KIND else None
+
+
+def payload_with_allowed_reply(scope: Scope, payload: Payload) -> Payload:
+    allowed = allowed_reply(scope, payload.reply)
+    if allowed is payload.reply:
+        return payload
+    return payload.with_(reply=allowed)
+
+
+__all__ = ["allowed_reply", "payload_with_allowed_reply"]

--- a/application/usecase/add.py
+++ b/application/usecase/add.py
@@ -5,6 +5,7 @@ from ..log.decorators import log_io
 from ..log.emit import jlog
 from ..map.entry import EntryMapper, NodeResult
 from ..service.view.orchestrator import ViewOrchestrator
+from ..service.view.policy import payload_with_allowed_reply
 from ...domain.port.history import HistoryRepository
 from ...domain.port.last import LastMessageRepository
 from ...domain.port.state import StateRepository
@@ -42,7 +43,7 @@ class AddUseCase:
             view: Optional[str],
             root: bool = False,
     ) -> None:
-        resolved = [resolve_content(p) for p in payloads]
+        resolved = [payload_with_allowed_reply(scope, resolve_content(p)) for p in payloads]
         history = await self._history_repo.get_history()
         jlog(
             logger,

--- a/application/usecase/replace.py
+++ b/application/usecase/replace.py
@@ -5,6 +5,7 @@ from ..log.decorators import log_io
 from ..log.emit import jlog
 from ..map.entry import EntryMapper, NodeResult
 from ..service.view.orchestrator import ViewOrchestrator
+from ..service.view.policy import payload_with_allowed_reply
 from ...domain.port.history import HistoryRepository
 from ...domain.port.last import LastMessageRepository
 from ...domain.port.state import StateRepository
@@ -35,7 +36,7 @@ class ReplaceUseCase:
 
     @log_io(None, None, None)
     async def execute(self, scope: Scope, payloads: List[Payload]) -> None:
-        resolved = [resolve_content(p) for p in payloads]
+        resolved = [payload_with_allowed_reply(scope, resolve_content(p)) for p in payloads]
         history = await self._history_repo.get_history()
         jlog(logger, logging.DEBUG, LogCode.HISTORY_LOAD, op="replace", history={"len": len(history)})
         last_entry = history[-1] if history else None

--- a/tests/application/service/view/test_policy.py
+++ b/tests/application/service/view/test_policy.py
@@ -1,0 +1,84 @@
+import pytest
+
+from navigator.application.service.view.policy import allowed_reply, payload_with_allowed_reply
+from navigator.domain.entity.markup import Markup
+from navigator.domain.value.content import Payload
+from navigator.domain.value.message import Scope
+
+
+def make_scope(**kwargs) -> Scope:
+    return Scope(chat=kwargs.pop("chat", 1), **kwargs)
+
+
+def make_markup(kind: str) -> Markup:
+    return Markup(kind=kind, data={})
+
+
+def test_allowed_reply_none_returns_none() -> None:
+    scope = make_scope()
+    assert allowed_reply(scope, None) is None
+
+
+def test_allowed_reply_private_accepts_reply_keyboard() -> None:
+    scope = make_scope(chat_kind="private")
+    markup = make_markup("ReplyKeyboardMarkup")
+    assert allowed_reply(scope, markup) is markup
+
+
+def test_allowed_reply_group_accepts_force_reply() -> None:
+    scope = make_scope(chat_kind="group")
+    markup = make_markup("ForceReply")
+    assert allowed_reply(scope, markup) is markup
+
+
+def test_allowed_reply_channel_rejects_custom_markup() -> None:
+    scope = make_scope(chat_kind="channel")
+    markup = make_markup("ReplyKeyboardMarkup")
+    assert allowed_reply(scope, markup) is None
+
+
+def test_allowed_reply_channel_accepts_inline_markup() -> None:
+    scope = make_scope(chat_kind="channel")
+    markup = make_markup("InlineKeyboardMarkup")
+    assert allowed_reply(scope, markup) is markup
+
+
+def test_allowed_reply_biz_scope_accepts_only_inline() -> None:
+    scope = make_scope(biz_id="corp", chat_kind="private")
+    inline = make_markup("InlineKeyboardMarkup")
+    keyboard = make_markup("ReplyKeyboardMarkup")
+    assert allowed_reply(scope, inline) is inline
+    assert allowed_reply(scope, keyboard) is None
+
+
+def test_payload_with_allowed_reply_keeps_payload_when_allowed() -> None:
+    scope = make_scope(chat_kind="private")
+    payload = Payload(text="hi", reply=make_markup("ReplyKeyboardMarkup"))
+    assert payload_with_allowed_reply(scope, payload) is payload
+
+
+def test_payload_with_allowed_reply_strips_disallowed_markup() -> None:
+    scope = make_scope(chat_kind="channel")
+    payload = Payload(text="hi", reply=make_markup("ReplyKeyboardMarkup"))
+    sanitized = payload_with_allowed_reply(scope, payload)
+    assert sanitized is not payload
+    assert sanitized.reply is None
+    assert sanitized.text == payload.text
+
+
+def test_payload_with_allowed_reply_handles_none_reply() -> None:
+    scope = make_scope(chat_kind="channel")
+    payload = Payload(text="hi", reply=None)
+    assert payload_with_allowed_reply(scope, payload) is payload
+
+
+@pytest.mark.parametrize(
+    "chat_kind",
+    [None, "supergroup", "channel"],
+)
+def test_allowed_reply_default_to_inline_only(chat_kind: str | None) -> None:
+    scope = make_scope(chat_kind=chat_kind)
+    inline = make_markup("InlineKeyboardMarkup")
+    keyboard = make_markup("ReplyKeyboardMarkup")
+    assert allowed_reply(scope, inline) is inline
+    assert allowed_reply(scope, keyboard) is None


### PR DESCRIPTION
## Summary
- add an application-level policy helper that enforces scope-based reply markup restrictions and reuse it when preparing payloads
- rely on the new helper in the view orchestrator and use cases so Telegram sends receive pre-filtered markup
- simplify the Telegram gateway to only decode reply markups and add tests covering the new policy helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cef865a9808330be0f61067178c478