### PR TITLE
Move Telegram lexicon to presentation layer

### DIFF
--- a/adapters/telegram/gateway/__init__.py
+++ b/adapters/telegram/gateway/__init__.py
@@ -14,7 +14,7 @@ from ....domain.port.markup import MarkupCodec
 from ....domain.port.message import MessageGateway, Result
 from ....domain.service.scope import scope_kv
 from ....domain.value.content import Payload
-from ....domain.value.lexicon import lexeme
+from ....presentation.telegram.lexicon import lexeme
 from ....domain.value.message import Scope
 from ....domain.log.code import LogCode
 

--- a/presentation/telegram/lexicon.py
+++ b/presentation/telegram/lexicon.py
@@ -1,3 +1,6 @@
+"""Telegram presentation lexicon helper."""
+from __future__ import annotations
+
 from typing import Dict
 
 _LEXICON: Dict[str, Dict[str, str]] = {
@@ -17,6 +20,7 @@ _LEXICON: Dict[str, Dict[str, str]] = {
 
 
 def lexeme(key: str, lang: str = "en") -> str:
+    """Return a localized lexeme for Telegram presentation."""
     lang_norm = (lang or "en").split("-")[0].lower()
     d = _LEXICON.get(key, {})
     return d.get(lang_norm) or d.get("en") or ""

--- a/presentation/telegram/router.py
+++ b/presentation/telegram/router.py
@@ -9,7 +9,7 @@ from aiogram.types import CallbackQuery, Message
 from ..navigator import Navigator
 from ...application.log.emit import jlog
 from ...domain.error import HistoryEmpty, InlineUnsupported
-from ...domain.value.lexicon import lexeme
+from .lexicon import lexeme
 from ...domain.log.code import LogCode
 
 router = Router(name="navigator_handlers")


### PR DESCRIPTION
## Summary
- move the Telegram lexicon dictionary into the presentation layer
- update Telegram gateway and router to use the presentation helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ceff32d3e883309da406c9c7e214f8