### PR TITLE
Validate explicit caption clearing flow

### DIFF
--- a/adapters/telegram/serializer.py
+++ b/adapters/telegram/serializer.py
@@ -45,16 +45,15 @@ def caption_for_edit(payload: Payload) -> Optional[str]:
     """
     Правило для edit_caption:
     - вернуть текст подписи, если он вычисляется (caption_of(payload));
-    - если payload.text задан (в т.ч. пустая строка) и медиа есть — вернуть "" для очистки подписи;
+    - если payload.clear_caption установлен — вернуть "" для очистки подписи;
     - иначе вернуть None (не менять подпись).
     Пустая строка → явная очистка подписи на стороне Telegram.
-    Примечание: пустая строка не должна поступать из маппера без clear_caption=True; вариант с пустой строкой
-    без флага считается устаревшим и маппером игнорируется.
+    Примечание: пустая строка из payload.text без маркера clear_caption игнорируется и приводит к no-op.
     """
     cap = caption_of(payload)
     if cap is not None:
         return cap
-    if payload.text is not None:
+    if payload.clear_caption:
         return ""
     return None
 

--- a/application/dto/content.py
+++ b/application/dto/content.py
@@ -24,8 +24,9 @@ class Content:
     - Попытка изменить только эффект без изменения текста/медиа/markup логически приводит к NO_CHANGE.
 
     Очистка подписи:
-    - Если media и clear_caption=True и text is None → в payload.text будет установлен "".
-    - Если media и text == "" и clear_caption=False → пустая строка считается устаревшим способом и игнорируется (text=None).
+    - Если media и clear_caption=True и text в значении None/"" →
+      в payload.text будет установлен "" и установлен маркер явной очистки.
+    - Если media и text == "" при clear_caption=False → выбрасывается ValueError.
     """
     text: Optional[str] = None
     media: Optional[Media] = None

--- a/application/map/payload.py
+++ b/application/map/payload.py
@@ -65,11 +65,15 @@ def _to_group(items: Optional[List[Media]]) -> Optional[List[MediaItem]]:
 def to_payload(dto: Content) -> Payload:
     # При media и clear_caption=True — выставляем text="" для явной очистки подписи.
     text = dto.text
-    if dto.media and dto.clear_caption and text is None:
-        text = ""
-    # Пустая строка без флага очистки — устаревший способ. Игнорируем.
+    clear_caption = False
+    if dto.media and dto.clear_caption:
+        if text is None or text == "":
+            text = ""
+            clear_caption = True
+        else:
+            clear_caption = False
     if dto.media and text == "" and not dto.clear_caption:
-        text = None
+        raise ValueError("empty_caption_without_clear_flag")
     return Payload(
         text=text,
         media=_to_media(dto.media),
@@ -77,6 +81,7 @@ def to_payload(dto: Content) -> Payload:
         reply=dto.reply,
         preview=dto.preview,
         extra=dto.extra,
+        clear_caption=clear_caption,
     )
 
 

--- a/application/service/view/orchestrator.py
+++ b/application/service/view/orchestrator.py
@@ -91,7 +91,7 @@ class ViewOrchestrator:
         Нормализация meta:
         - Для media: восстанавливает media_type/file_id/caption при edit_*, когда Telegram вернул bool.
         - Для text: восстанавливает text при edit_*, когда Telegram вернул bool.
-        - Очистка подписи: payload.text is not None при media -> caption == "".
+        - Очистка подписи: payload.clear_caption -> caption == "".
         """
         m = dict(meta or {})
         kind = m.get("kind")
@@ -117,8 +117,8 @@ class ViewOrchestrator:
                     m["caption"] = new_cap
                 elif (getattr(payload, "media", None) and getattr(payload.media, "caption", None) == ""):
                     m["caption"] = ""  # очистка через media.caption=""
-                elif payload.text is not None:
-                    m["caption"] = ""  # явная очистка через text
+                elif payload.clear_caption:
+                    m["caption"] = ""  # явная очистка через clear_caption
                 else:
                     m["caption"] = base_msg.media.caption
         elif kind == "text" and base_msg and (getattr(base_msg, "text", None) is not None):

--- a/domain/value/content.py
+++ b/domain/value/content.py
@@ -28,6 +28,7 @@ class Payload:
     reply: Optional[Markup] = None
     preview: Optional[Preview] = None
     extra: Optional[Extra] = None
+    clear_caption: bool = False
 
     def with_(self, **kw: Any) -> "Payload":
         return replace(self, **kw)
@@ -49,6 +50,7 @@ def resolve_content(payload: Payload) -> Payload:
         reply=payload.reply,
         preview=payload.preview,
         extra=payload.extra,
+        clear_caption=payload.clear_caption and not bool(group),
     )
 
 

--- a/tests/adapters/telegram/test_serializer.py
+++ b/tests/adapters/telegram/test_serializer.py
@@ -1,0 +1,24 @@
+from navigator.adapters.telegram.serializer import caption_for_edit
+from navigator.domain.entity.media import MediaItem, MediaType
+from navigator.domain.value.content import Payload
+
+
+_DEF_MEDIA = MediaItem(type=MediaType.PHOTO, path="file-id")
+
+
+def test_caption_for_edit_returns_empty_when_marker_present():
+    payload = Payload(text="", media=_DEF_MEDIA, clear_caption=True)
+
+    assert caption_for_edit(payload) == ""
+
+
+def test_caption_for_edit_ignores_empty_text_without_marker():
+    payload = Payload(text="", media=_DEF_MEDIA, clear_caption=False)
+
+    assert caption_for_edit(payload) is None
+
+
+def test_caption_for_edit_prefers_caption_text():
+    payload = Payload(text="  actual  ", media=_DEF_MEDIA, clear_caption=False)
+
+    assert caption_for_edit(payload) == "actual"

--- a/tests/application/map/test_payload.py
+++ b/tests/application/map/test_payload.py
@@ -1,0 +1,29 @@
+import pytest
+
+from navigator.application.dto.content import Content, Media
+from navigator.application.map.payload import to_payload
+
+
+def test_to_payload_marks_clear_caption_for_media():
+    dto = Content(text=None, media=Media(path="photo.jpg"), clear_caption=True)
+
+    payload = to_payload(dto)
+
+    assert payload.text == ""
+    assert payload.clear_caption is True
+
+
+def test_to_payload_keeps_clear_caption_with_explicit_empty_text():
+    dto = Content(text="", media=Media(path="photo.jpg"), clear_caption=True)
+
+    payload = to_payload(dto)
+
+    assert payload.text == ""
+    assert payload.clear_caption is True
+
+
+def test_to_payload_rejects_legacy_empty_caption_without_flag():
+    dto = Content(text="", media=Media(path="photo.jpg"), clear_caption=False)
+
+    with pytest.raises(ValueError, match="empty_caption_without_clear_flag"):
+        to_payload(dto)


### PR DESCRIPTION
## Summary
- raise an error when media edits provide an empty caption without the clear flag and propagate the explicit clear-caption marker
- extend payloads with a clear_caption marker and tighten the Telegram serializer to only emit empty captions when it is set
- add unit tests covering the stricter mapping contract and serializer behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf0656f56c8330b0087f02fb9c4d25