### PR TITLE
Adopt single-word naming across navigator

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,4 @@
-from .composition import create_navigator
+from .composition import assemble, create_navigator
 from .presentation.navigator import Navigator
 
-__all__ = ["Navigator", "create_navigator"]
+__all__ = ["Navigator", "assemble", "create_navigator"]

--- a/adapters/storage/historyrepo.py
+++ b/adapters/storage/historyrepo.py
@@ -164,9 +164,9 @@ class HistoryRepo:
                     "markup": self._encode_reply(m.markup),
                     "preview": self._encode_preview(m.preview),
                     "extra": m.extra,
-                    "aux_ids": list(m.aux_ids),
+                    "extras": list(m.extras),
                     "inline_id": m.inline_id,
-                    "by_bot": m.by_bot,
+                    "automated": m.automated,
                     "ts": self._encode_dt(m.ts),
                 }
                 for m in entry.messages
@@ -197,9 +197,22 @@ class HistoryRepo:
                         markup=self._decode_reply(d.get("markup")),
                         preview=self._decode_preview(d.get("preview")),
                         extra=d.get("extra"),
-                        aux_ids=[int(x) for x in (d.get("aux_ids") or [])],
+                        extras=[
+                            int(x)
+                            for x in (
+                                d.get("extras")
+                                if d.get("extras") is not None
+                                else d.get("aux_ids")
+                                or []
+                            )
+                        ],
                         inline_id=d.get("inline_id"),
-                        by_bot=bool(d.get("by_bot", True)),
+                        automated=bool(
+                            d.get(
+                                "automated",
+                                d.get("by_bot", True),
+                            )
+                        ),
                         ts=self._decode_dt(d.get("ts")),
                     )
                 )

--- a/adapters/telegram/gateway/__init__.py
+++ b/adapters/telegram/gateway/__init__.py
@@ -12,7 +12,7 @@ from ....domain.error import InlineUnsupported
 from ....domain.log.emit import jlog
 from ....domain.port.markup import MarkupCodec
 from ....domain.port.message import MessageGateway, Result
-from ....domain.service.scope import scope_kv
+from ....domain.service.scope import profile
 from ....domain.value.content import Payload
 from ....presentation.telegram.lexicon import lexeme
 from ....domain.value.message import Scope
@@ -29,7 +29,7 @@ class TelegramGateway(MessageGateway):
         self._truncate = bool(truncate)
 
     async def send(self, scope: Scope, payload: Payload) -> Result:
-        if scope.inline_id:
+        if scope.inline:
             raise InlineUnsupported("inline_send_not_supported")
         return await do_send(self._bot, self._codec, scope, payload, truncate=self._truncate)
 
@@ -50,13 +50,13 @@ class TelegramGateway(MessageGateway):
         await runner.run(scope, ids)
 
     async def notify_empty(self, scope: Scope) -> None:
-        if not scope.inline_id:
+        if not scope.inline:
             await self._bot.send_message(scope.chat, lexeme("prev_not_found", scope.lang or "en"))
             jlog(
                 logger,
                 logging.INFO,
                 LogCode.GATEWAY_NOTIFY_EMPTY,
-                scope=scope_kv(scope),
+                scope=profile(scope),
             )
 
 

--- a/adapters/telegram/gateway/common.py
+++ b/adapters/telegram/gateway/common.py
@@ -7,7 +7,7 @@ from .. import serializer
 from ....domain.log.emit import jlog
 from ....domain.port.message import Result
 from ....domain.service.rendering.helpers import payload_kind
-from ....domain.service.scope import scope_kv
+from ....domain.service.scope import profile
 from ....domain.log.code import LogCode
 
 logger = logging.getLogger(__name__)
@@ -23,19 +23,19 @@ def reply_for_edit(codec, reply):
 
 
 def actual_id(scope, fallback, result):
-    if scope.inline_id:
+    if scope.inline:
         return fallback
     mid = getattr(result, "message_id", None)
     return mid if mid is not None else fallback
 
 
 def log_edit_fail(scope, payload, note):
-    jlog(logger, logging.WARNING, LogCode.GATEWAY_EDIT_FAIL, scope=scope_kv(scope), payload=payload_kind(payload),
+    jlog(logger, logging.WARNING, LogCode.GATEWAY_EDIT_FAIL, scope=profile(scope), payload=payload_kind(payload),
          note=note)
 
 
 def log_edit_ok(scope, payload, mid):
-    jlog(logger, logging.INFO, LogCode.GATEWAY_EDIT_OK, scope=scope_kv(scope), payload=payload_kind(payload),
+    jlog(logger, logging.INFO, LogCode.GATEWAY_EDIT_OK, scope=profile(scope), payload=payload_kind(payload),
          message={"id": mid, "extra_len": 0})
 
 

--- a/adapters/telegram/gateway/util.py
+++ b/adapters/telegram/gateway/util.py
@@ -6,14 +6,14 @@ from ....domain.value.message import Scope
 
 
 def targets(scope: Scope, message_id: Optional[int] = None) -> Dict[str, Any]:
-    if scope.inline_id:
-        data: Dict[str, Any] = {"inline_message_id": scope.inline_id}
+    if scope.inline:
+        data: Dict[str, Any] = {"inline_message_id": scope.inline}
     else:
         data = {"chat_id": scope.chat}
         if message_id is not None:
             data["message_id"] = message_id
-    if scope.biz_id:
-        data["business_connection_id"] = scope.biz_id
+    if scope.business:
+        data["business_connection_id"] = scope.business
     return data
 
 
@@ -59,7 +59,7 @@ def extract_meta(result_msg_or_bool: Any, payload: Any, scope: Scope) -> dict:
     Для inline всегда проставлять inline_id из scope.
     Для media_group собирать group_items в send.py и передавать сюда готовым dict.
     """
-    inline_id = getattr(scope, "inline_id", None)
+    inline_id = getattr(scope, "inline", None)
     if hasattr(result_msg_or_bool, "message_id"):
         m = _msg_to_meta(result_msg_or_bool)
         m["inline_id"] = inline_id

--- a/application/log/decorators.py
+++ b/application/log/decorators.py
@@ -14,8 +14,8 @@ def _extract_scope_payload(fn: Callable[..., Any], args: Tuple[Any, ...], kwargs
     scope = ba.arguments.get("scope")
     payload = ba.arguments.get("payload")
     try:
-        from ...domain.service.scope import scope_kv
-        scope_val = scope_kv(scope) if scope is not None else None
+        from ...domain.service.scope import profile
+        scope_val = profile(scope) if scope is not None else None
     except (AttributeError, ImportError, TypeError, ValueError):
         scope_val = None
     try:

--- a/application/map/entry.py
+++ b/application/map/entry.py
@@ -90,9 +90,9 @@ class EntryMapper:
                     markup=payload.reply,
                     preview=payload.preview,
                     extra=extra,
-                    aux_ids=list(aux),
+                    extras=list(aux),
                     inline_id=inline_id,
-                    by_bot=True,
+                    automated=True,
                     ts=now,
                 )
             )

--- a/application/service/ops.py
+++ b/application/service/ops.py
@@ -48,9 +48,9 @@ def patch_entry_ids(entry: Entry, new_ids: List[int], new_extras: Optional[List[
                 markup=entry.messages[i].markup,
                 preview=entry.messages[i].preview,
                 extra=entry.messages[i].extra,
-                aux_ids=(new_extras[i] if new_extras and i < len(new_extras) else entry.messages[i].aux_ids),
+                extras=(new_extras[i] if new_extras and i < len(new_extras) else entry.messages[i].extras),
                 inline_id=entry.messages[i].inline_id,
-                by_bot=entry.messages[i].by_bot,
+                automated=entry.messages[i].automated,
                 ts=entry.messages[i].ts,
             )
         )

--- a/application/service/view/policy.py
+++ b/application/service/view/policy.py
@@ -18,10 +18,10 @@ def allowed_reply(scope: Scope, reply: Optional[Markup]) -> Optional[Markup]:
     if reply is None:
         return None
 
-    if bool(getattr(scope, "biz_id", None)):
+    if bool(getattr(scope, "business", None)):
         return reply if reply.kind == _INLINE_KEYBOARD_KIND else None
 
-    chat_kind = getattr(scope, "chat_kind", None)
+    chat_kind = getattr(scope, "category", None)
     if chat_kind in {"private", "group"}:
         return reply
 
@@ -32,7 +32,7 @@ def payload_with_allowed_reply(scope: Scope, payload: Payload) -> Payload:
     allowed = allowed_reply(scope, payload.reply)
     if allowed is payload.reply:
         return payload
-    return payload.with_(reply=allowed)
+    return payload.morph(reply=allowed)
 
 
 __all__ = ["allowed_reply", "payload_with_allowed_reply"]

--- a/application/usecase/back.py
+++ b/application/usecase/back.py
@@ -10,14 +10,14 @@ from ...domain.port.history import HistoryRepository
 from ...domain.port.last import LastMessageRepository
 from ...domain.port.message import MessageGateway
 from ...domain.port.state import StateRepository
-from ...domain.value.content import resolve_content
+from ...domain.value.content import normalize
 from ...domain.value.message import Scope
 from ...domain.log.code import LogCode
 
 logger = logging.getLogger(__name__)
 
 
-class BackUseCase:
+class Rewinder:
     def __init__(
             self,
             history_repo: HistoryRepository,
@@ -43,17 +43,17 @@ class BackUseCase:
             LogCode.HISTORY_LOAD,
             op="back",
             history={"len": len(history)},
-            scope={"chat": scope.chat, "inline": bool(scope.inline_id)},
+            scope={"chat": scope.chat, "inline": bool(scope.inline)},
         )
         if len(history) < 2:
             raise HistoryEmpty("Cannot go back, history is too short.")
         entry_from = history[-1]
         entry_to = history[-2]
-        is_inline = bool(scope.inline_id)
+        is_inline = bool(scope.inline)
         fsm_data: Dict[str, Any] = await self._state_repo.get_data()
         merged_handler_data = {**fsm_data, **handler_data}
         restored_payloads = await self._restorer.restore_node(entry_to, merged_handler_data, inline=is_inline)
-        resolved_payloads = [resolve_content(p) for p in restored_payloads]
+        resolved_payloads = [normalize(p) for p in restored_payloads]
         if not is_inline:
             render_result = await self._orchestrator.render_node(
                 "back",
@@ -71,13 +71,13 @@ class BackUseCase:
                 inline=True,
             )
 
-        # Политика хвоста: удаление при inline и наличии biz_id.
+        # Политика хвоста: удаление при inline и наличии business.
         from ..internal import policy as _pol
-        if is_inline and _pol.INLINE_TAIL_MODE in ("delete", "collapse") and getattr(scope, "biz_id", None):
+        if is_inline and _pol.TailMode in ("delete", "collapse") and getattr(scope, "business", None):
             to_delete = []
             for m in entry_from.messages[1:]:
                 to_delete.append(m.id)
-                to_delete.extend(list(getattr(m, "aux_ids", []) or []))
+                to_delete.extend(list(getattr(m, "extras", []) or []))
             if to_delete:
                 first_n = to_delete[:20]
                 jlog(
@@ -109,9 +109,9 @@ class BackUseCase:
                 markup=entry_to.messages[i].markup,
                 preview=entry_to.messages[i].preview,
                 extra=entry_to.messages[i].extra,
-                aux_ids=render_result.extras[i],
+                extras=render_result.extras[i],
                 inline_id=entry_to.messages[i].inline_id,
-                by_bot=entry_to.messages[i].by_bot,
+                automated=entry_to.messages[i].automated,
                 ts=entry_to.messages[i].ts,
             )
             for i in range(patched_len)

--- a/application/usecase/notify_history_empty.py
+++ b/application/usecase/notify_history_empty.py
@@ -8,7 +8,7 @@ from ...domain.log.code import LogCode
 logger = logging.getLogger(__name__)
 
 
-class NotifyHistoryEmptyUseCase:
+class Alarm:
     def __init__(self, gateway: MessageGateway) -> None:
         self._gateway = gateway
 
@@ -19,5 +19,5 @@ class NotifyHistoryEmptyUseCase:
             logging.INFO,
             LogCode.GATEWAY_NOTIFY_EMPTY,
             op="notify_history_empty",
-            scope={"chat": scope.chat, "inline": bool(scope.inline_id)},
+            scope={"chat": scope.chat, "inline": bool(scope.inline)},
         )

--- a/application/usecase/pop.py
+++ b/application/usecase/pop.py
@@ -9,7 +9,7 @@ from ...domain.log.code import LogCode
 logger = logging.getLogger(__name__)
 
 
-class PopUseCase:
+class Trimmer:
     def __init__(self, history_repo: HistoryRepository, last_repo: LastMessageRepository):
         self._history_repo = history_repo
         self._last_repo = last_repo

--- a/application/usecase/rebase.py
+++ b/application/usecase/rebase.py
@@ -12,7 +12,7 @@ from ...domain.log.code import LogCode
 logger = logging.getLogger(__name__)
 
 
-class RebaseUseCase:
+class Shifter:
     def __init__(self, history_repo: HistoryRepository, temp_repo: TemporaryRepository,
                  last_repo: LastMessageRepository):
         self._history_repo = history_repo
@@ -45,9 +45,9 @@ class RebaseUseCase:
             markup=first.markup,
             preview=first.preview,
             extra=first.extra,
-            aux_ids=first.aux_ids,
+            extras=first.extras,
             inline_id=first.inline_id,
-            by_bot=first.by_bot,
+            automated=first.automated,
             ts=first.ts,
         )
         rebased_last = Entry(

--- a/composition/migrate.py
+++ b/composition/migrate.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from typing import Any
 
 from ..adapters.factory.registry import default as _default_registry
@@ -11,7 +12,7 @@ from ..domain.log.emit import jlog
 logger = logging.getLogger(__name__)
 
 
-async def purge_invalid_views(state: Any, registry=_default_registry) -> None:
+async def cleanse(state: Any, registry=_default_registry) -> None:
     """Clear history entries that point to unregistered views."""
 
     registry_to_use = registry if registry is not None else _default_registry
@@ -42,3 +43,8 @@ async def purge_invalid_views(state: Any, registry=_default_registry) -> None:
         keys=cleared,
         note="views_purged",
     )
+
+
+async def purge_invalid_views(state: Any, registry=_default_registry) -> None:
+    warnings.warn("purge_invalid_views is deprecated; use cleanse", DeprecationWarning, stacklevel=2)
+    await cleanse(state, registry)

--- a/domain/constants.py
+++ b/domain/constants.py
@@ -1,9 +1,28 @@
+import warnings
 from typing import Final
 
-TEXT_MAX: Final = 4096
-CAPTION_MAX: Final = 1024
-ALBUM_MIN: Final = 2
-ALBUM_MAX: Final = 10
-ALBUM_MIXED_ALLOWED: Final = {"photo", "video"}
+__all__ = ["TextLimit", "CaptionLimit", "AlbumFloor", "AlbumCeiling", "AlbumBlend", "ThumbWatch"]
+
+TextLimit: Final = 4096
+CaptionLimit: Final = 1024
+AlbumFloor: Final = 2
+AlbumCeiling: Final = 10
+AlbumBlend: Final = {"photo", "video"}
 # Если True: любое присутствие thumb в extra при partial-edit альбомов триггерит EDIT_MEDIA.
-DETECT_THUMB_CHANGE: Final[bool] = False
+ThumbWatch: Final[bool] = False
+
+_DEPRECATED = {
+    "TEXT_MAX": TextLimit,
+    "CAPTION_MAX": CaptionLimit,
+    "ALBUM_MIN": AlbumFloor,
+    "ALBUM_MAX": AlbumCeiling,
+    "ALBUM_MIXED_ALLOWED": AlbumBlend,
+    "DETECT_THUMB_CHANGE": ThumbWatch,
+}
+
+
+def __getattr__(name: str):
+    if name in _DEPRECATED:
+        warnings.warn(f"{name} is deprecated; use the new single-word constant", DeprecationWarning, stacklevel=2)
+        return _DEPRECATED[name]
+    raise AttributeError(f"module 'domain.constants' has no attribute {name!r}")

--- a/domain/entity/history.py
+++ b/domain/entity/history.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Optional, List, Dict, Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .markup import Markup
 from .media import MediaItem
@@ -14,21 +15,41 @@ if TYPE_CHECKING:
 @dataclass(frozen=True, slots=True)
 class Msg:
     id: int
-    text: Optional[str]
-    media: Optional[MediaItem]  # В истории path = Telegram file_id
-    group: Optional[List[MediaItem]]  # В истории path = Telegram file_id
-    markup: Optional[Markup]
-    preview: Optional["Preview"] = None
-    extra: Optional[Dict[str, Any]] = None
-    aux_ids: List[int] = field(default_factory=list)
-    inline_id: Optional[str] = None  # inline_message_id, если есть
-    by_bot: bool = True
+    text: str | None
+    media: MediaItem | None  # В истории path = Telegram file_id
+    group: list[MediaItem] | None  # В истории path = Telegram file_id
+    markup: Markup | None
+    preview: "Preview" | None = None
+    extra: dict[str, Any] | None = None
+    extras: list[int] = field(default_factory=list)
+    inline_id: str | None = None  # inline_message_id, если есть
+    automated: bool = True
     ts: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    @property
+    def aux_ids(self) -> list[int]:
+        warnings.warn("Msg.aux_ids is deprecated; use Msg.extras", DeprecationWarning, stacklevel=2)
+        return self.extras
+
+    @aux_ids.setter
+    def aux_ids(self, value: list[int]) -> None:
+        warnings.warn("Msg.aux_ids is deprecated; use Msg.extras", DeprecationWarning, stacklevel=2)
+        self.extras = value
+
+    @property
+    def by_bot(self) -> bool:
+        warnings.warn("Msg.by_bot is deprecated; use Msg.automated", DeprecationWarning, stacklevel=2)
+        return self.automated
+
+    @by_bot.setter
+    def by_bot(self, value: bool) -> None:
+        warnings.warn("Msg.by_bot is deprecated; use Msg.automated", DeprecationWarning, stacklevel=2)
+        self.automated = value
 
 
 @dataclass(frozen=True, slots=True)
 class Entry:
-    state: Optional[str]
-    view: Optional[str]
-    messages: List[Msg]
+    state: str | None
+    view: str | None
+    messages: list[Msg]
     root: bool = False

--- a/domain/log/emit.py
+++ b/domain/log/emit.py
@@ -7,7 +7,7 @@ from typing import Any, Dict
 
 from .code import LogCode
 
-REDACT_KEYS = {"path", "inline_id", "biz_id", "url", "caption", "thumb"}
+REDACT_KEYS = {"path", "inline", "business", "url", "caption", "thumb"}
 # Режимы:
 # - debug: без редактирования;
 # - safe (по умолчанию): редактируются ключи из REDACT_KEYS;

--- a/domain/service/history/extra.py
+++ b/domain/service/history/extra.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any, Dict, Optional
 
 from ...log.emit import jlog
-from ...util.entities import validate_entities
+from ...util.entities import sanitize as sanitize_entities
 from ....domain.log.code import LogCode
 
 logger = logging.getLogger(__name__)
@@ -45,7 +45,7 @@ def sanitize_extra(extra: Any, *, text_len: int) -> Optional[Dict[str, Any]]:
         cleaned["has_thumb"] = True
 
     if "entities" in cleaned:
-        valid_entities = validate_entities(cleaned.get("entities"), text_len)
+        valid_entities = sanitize_entities(cleaned.get("entities"), text_len)
         if valid_entities:
             cleaned["entities"] = valid_entities
         else:

--- a/domain/service/rendering/album.py
+++ b/domain/service/rendering/album.py
@@ -1,6 +1,6 @@
 from typing import Optional, List, Set, Literal
 
-from ...constants import ALBUM_MIN, ALBUM_MAX, ALBUM_MIXED_ALLOWED
+from ...constants import AlbumBlend, AlbumCeiling, AlbumFloor
 from ...entity.media import MediaItem, MediaType
 from ...error import NavigatorError
 
@@ -28,7 +28,7 @@ def _group_invalid_reasons(items: Optional[List[MediaItem]]) -> List[str]:
     if not items:
         reasons.append("empty")
         return reasons
-    if len(items) < ALBUM_MIN or len(items) > ALBUM_MAX:
+    if len(items) < AlbumFloor or len(items) > AlbumCeiling:
         reasons.append("size")
     types: Set[MediaType] = {i.type for i in items}
     if types & {MediaType.ANIMATION, MediaType.VOICE, MediaType.VIDEO_NOTE}:
@@ -69,4 +69,4 @@ def album_compatible(old: List[MediaItem], new: List[MediaItem]) -> bool:
         return all(i.type == MediaType.AUDIO for i in new)
     if k == "document":
         return all(i.type == MediaType.DOCUMENT for i in new)
-    return all(i.type.value in ALBUM_MIXED_ALLOWED for i in new)
+    return all(i.type.value in AlbumBlend for i in new)

--- a/domain/service/rendering/config.py
+++ b/domain/service/rendering/config.py
@@ -3,5 +3,5 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True, slots=True)
 class RenderingConfig:
-    detect_thumb_change: bool = False
+    thumb_watch: bool = False
 

--- a/domain/service/rendering/decision.py
+++ b/domain/service/rendering/decision.py
@@ -5,7 +5,7 @@ from typing import Optional, Any
 from .helpers import reply_equal as _reply_equal_markups
 from ...entity.history import Entry
 from ...entity.media import MediaType
-from ...value.content import Payload, caption_of
+from ...value.content import Payload, caption
 from .config import RenderingConfig
 
 
@@ -103,7 +103,7 @@ def _media_opts_split(e, config: RenderingConfig) -> tuple[_MediaCaptionOpts, _M
     edt = _MediaEditOpts(
         spoiler=bool(x.get("spoiler")),
         start=st,
-        thumb_present=(present if config.detect_thumb_change else False),
+        thumb_present=(present if config.thumb_watch else False),
     )
     return cap, edt
 
@@ -222,7 +222,7 @@ def decide(old: Optional[object], new: Payload, config: RenderingConfig) -> Deci
             if edt_o != edt_n:
                 return Decision.EDIT_MEDIA
 
-            same_caption_text = (caption_of(o) or "") == (caption_of(n) or "")
+            same_caption_text = (caption(o) or "") == (caption(n) or "")
             same_caption_extra = _caption_extra_equal(o, n)
             same_caption_pos = (cap_o == cap_n)
             if same_caption_text and same_caption_extra and same_caption_pos:

--- a/domain/service/scope.py
+++ b/domain/service/scope.py
@@ -1,7 +1,13 @@
+import warnings
 from typing import Dict, Any
 
 from ..value.message import Scope
 
 
+def profile(s: Scope) -> Dict[str, Any]:
+    return {"chat": s.chat, "inline": bool(s.inline), "category": s.category}
+
+
 def scope_kv(s: Scope) -> Dict[str, Any]:
-    return {"chat": s.chat, "inline": bool(s.inline_id), "chat_kind": s.chat_kind}
+    warnings.warn("scope_kv is deprecated; use profile", DeprecationWarning, stacklevel=2)
+    return profile(s)

--- a/domain/util/entities.py
+++ b/domain/util/entities.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from typing import Any, Dict, List
 
 from ..log.emit import jlog
@@ -29,7 +30,7 @@ _ALLOWED_ENTITY_TYPES = {
 }
 
 
-def validate_entities(entities: Any, text_len: int) -> List[Dict[str, Any]]:
+def sanitize(entities: Any, text_len: int) -> List[Dict[str, Any]]:
     out: List[Dict[str, Any]] = []
     if not isinstance(entities, list):
         return out
@@ -63,3 +64,8 @@ def validate_entities(entities: Any, text_len: int) -> List[Dict[str, Any]]:
     if entities and not out:
         jlog(logging.getLogger(__name__), logging.DEBUG, LogCode.EXTRA_UNKNOWN_DROPPED, note="entities_dropped_all")
     return out
+
+
+def validate_entities(entities: Any, text_len: int) -> List[Dict[str, Any]]:
+    warnings.warn("validate_entities is deprecated; use sanitize", DeprecationWarning, stacklevel=2)
+    return sanitize(entities, text_len)

--- a/domain/util/path.py
+++ b/domain/util/path.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import os
+import warnings
 from urllib.parse import urlparse
 
 
-def is_http_url(s: str) -> bool:
+def remote(s: str) -> bool:
     try:
         u = urlparse(str(s))
         return u.scheme in {"http", "https"} and bool(u.netloc)
@@ -12,7 +13,7 @@ def is_http_url(s: str) -> bool:
         return False
 
 
-def is_local_path(s: str) -> bool:
+def local(s: str) -> bool:
     if not isinstance(s, str):
         return False
     if s.startswith(("./", "../")):
@@ -23,3 +24,13 @@ def is_local_path(s: str) -> bool:
     if "/" in s or "\\" in s:
         return True
     return False
+
+
+def is_http_url(s: str) -> bool:
+    warnings.warn("is_http_url is deprecated; use remote", DeprecationWarning, stacklevel=2)
+    return remote(s)
+
+
+def is_local_path(s: str) -> bool:
+    warnings.warn("is_local_path is deprecated; use local", DeprecationWarning, stacklevel=2)
+    return local(s)

--- a/domain/value/ids.py
+++ b/domain/value/ids.py
@@ -1,9 +1,10 @@
-from typing import Iterable, List
+import warnings
+from collections.abc import Iterable
 
 
-def unique_ids(ids: Iterable[int], sort: bool = False) -> List[int]:
+def dedupe(ids: Iterable[int], sort: bool = False) -> list[int]:
     if sort:
-        return unique_sorted(ids)
+        return order(ids)
     seen = set()
     out = []
     for x in ids or []:
@@ -14,5 +15,15 @@ def unique_ids(ids: Iterable[int], sort: bool = False) -> List[int]:
     return out
 
 
-def unique_sorted(ids: Iterable[int]) -> List[int]:
+def order(ids: Iterable[int]) -> list[int]:
     return sorted({int(x) for x in ids or []})
+
+
+def unique_ids(ids: Iterable[int], sort: bool = False) -> list[int]:
+    warnings.warn("unique_ids is deprecated; use dedupe", DeprecationWarning, stacklevel=2)
+    return dedupe(ids, sort=sort)
+
+
+def unique_sorted(ids: Iterable[int]) -> list[int]:
+    warnings.warn("unique_sorted is deprecated; use order", DeprecationWarning, stacklevel=2)
+    return order(ids)

--- a/domain/value/message.py
+++ b/domain/value/message.py
@@ -1,13 +1,55 @@
+from __future__ import annotations
+
+import warnings
 from dataclasses import dataclass
-from typing import Optional
 
 
 @dataclass(frozen=True, slots=True)
 class Scope:
-    chat: Optional[int]
-    lang: Optional[str] = None
-    user_id: Optional[int] = None
-    id: Optional[int] = None
-    inline_id: Optional[str] = None
-    biz_id: Optional[str] = None
-    chat_kind: Optional[str] = None
+    chat: int | None
+    lang: str | None = None
+    user: int | None = None
+    id: int | None = None
+    inline: str | None = None
+    business: str | None = None
+    category: str | None = None
+
+    @property
+    def user_id(self) -> int | None:
+        warnings.warn("Scope.user_id is deprecated; use Scope.user", DeprecationWarning, stacklevel=2)
+        return self.user
+
+    @user_id.setter
+    def user_id(self, value: int | None) -> None:
+        warnings.warn("Scope.user_id is deprecated; use Scope.user", DeprecationWarning, stacklevel=2)
+        self.user = value
+
+    @property
+    def inline_id(self) -> str | None:
+        warnings.warn("Scope.inline_id is deprecated; use Scope.inline", DeprecationWarning, stacklevel=2)
+        return self.inline
+
+    @inline_id.setter
+    def inline_id(self, value: str | None) -> None:
+        warnings.warn("Scope.inline_id is deprecated; use Scope.inline", DeprecationWarning, stacklevel=2)
+        self.inline = value
+
+    @property
+    def biz_id(self) -> str | None:
+        warnings.warn("Scope.biz_id is deprecated; use Scope.business", DeprecationWarning, stacklevel=2)
+        return self.business
+
+    @biz_id.setter
+    def biz_id(self, value: str | None) -> None:
+        warnings.warn("Scope.biz_id is deprecated; use Scope.business", DeprecationWarning, stacklevel=2)
+        self.business = value
+
+    @property
+    def chat_kind(self) -> str | None:
+        warnings.warn("Scope.chat_kind is deprecated; use Scope.category", DeprecationWarning, stacklevel=2)
+        return self.category
+
+    @chat_kind.setter
+    def chat_kind(self, value: str | None) -> None:
+        warnings.warn("Scope.chat_kind is deprecated; use Scope.category", DeprecationWarning, stacklevel=2)
+        self.category = value

--- a/infrastructure/config.py
+++ b/infrastructure/config.py
@@ -8,7 +8,7 @@ class Settings(BaseModel):
     chunk: int = Field(100, ge=1, le=100)
     truncate: bool = Field(False)  # управляемое усечение текста/подписи; ENV: NAV_TRUNCATE in {1,true,yes}
     strict_inline_media_path: bool = Field(True)  # ENV: NAV_STRICT_INLINE_MEDIA_PATH in {1,true,yes}
-    detect_thumb_change: bool = Field(False)
+    thumb_watch: bool = Field(False)
     log_redaction_mode: str = Field("safe")
 
 
@@ -17,6 +17,6 @@ SETTINGS = Settings(
     chunk=int(os.getenv("NAV_CHUNK", "100")),
     truncate=os.getenv("NAV_TRUNCATE", "0").lower() in {"1", "true", "yes"},
     strict_inline_media_path=os.getenv("NAV_STRICT_INLINE_MEDIA_PATH", "1").lower() in {"1", "true", "yes"},
-    detect_thumb_change=os.getenv("NAV_DETECT_THUMB_CHANGE", "0").lower() in {"1", "true", "yes"},
+    thumb_watch=os.getenv("NAV_DETECT_THUMB_CHANGE", "0").lower() in {"1", "true", "yes"},
     log_redaction_mode=os.getenv("NAV_LOG_REDACTION", "safe").lower(),
 )

--- a/infrastructure/di/container.py
+++ b/infrastructure/di/container.py
@@ -13,14 +13,14 @@ from ...application.map.entry import EntryMapper
 from ...application.service.view.inline import InlineStrategy
 from ...application.service.view.orchestrator import ViewOrchestrator
 from ...application.service.view.restorer import ViewRestorer
-from ...application.usecase.add import AddUseCase
-from ...application.usecase.back import BackUseCase
-from ...application.usecase.last import LastUseCase
-from ...application.usecase.notify_history_empty import NotifyHistoryEmptyUseCase
-from ...application.usecase.pop import PopUseCase
-from ...application.usecase.rebase import RebaseUseCase
-from ...application.usecase.replace import ReplaceUseCase
-from ...application.usecase.set import SetUseCase
+from ...application.usecase.add import Appender
+from ...application.usecase.back import Rewinder
+from ...application.usecase.last import Tailer
+from ...application.usecase.notify_history_empty import Alarm
+from ...application.usecase.pop import Trimmer
+from ...application.usecase.rebase import Shifter
+from ...application.usecase.replace import Swapper
+from ...application.usecase.set import Setter
 from ...domain.port.factory import ViewFactoryRegistry
 from ...domain.service.rendering.config import RenderingConfig
 from ...infrastructure.config import SETTINGS
@@ -55,7 +55,7 @@ class AppContainer(containers.DeclarativeContainer):
         is_url_input_file=is_url_input_file,
         strict_inline_media_path=providers.Object(SETTINGS.strict_inline_media_path),
     )
-    rendering_config = providers.Object(RenderingConfig(detect_thumb_change=SETTINGS.detect_thumb_change))
+    rendering_config = providers.Object(RenderingConfig(thumb_watch=SETTINGS.thumb_watch))
     view_orchestrator = providers.Factory(
         ViewOrchestrator,
         gateway=gateway,
@@ -66,37 +66,37 @@ class AppContainer(containers.DeclarativeContainer):
         ViewRestorer, markup_codec=markup_codec, factory_registry=registry
     )
 
-    add_uc = providers.Factory(
-        AddUseCase,
+    appender = providers.Factory(
+        Appender,
         history_repo=history_repo, state_repo=state_repo, last_repo=last_repo,
         orchestrator=view_orchestrator,
         mapper=entry_mapper, history_limit=history_limit,
     )
-    replace_uc = providers.Factory(
-        ReplaceUseCase,
+    swapper = providers.Factory(
+        Swapper,
         history_repo=history_repo, state_repo=state_repo, last_repo=last_repo,
         orchestrator=view_orchestrator,
         mapper=entry_mapper, history_limit=history_limit,
     )
-    back_uc = providers.Factory(
-        BackUseCase,
+    rewinder = providers.Factory(
+        Rewinder,
         history_repo=history_repo, state_repo=state_repo,
         gateway=gateway, restorer=view_restorer,
         orchestrator=view_orchestrator, last_repo=last_repo,
     )
-    set_uc = providers.Factory(
-        SetUseCase,
+    setter = providers.Factory(
+        Setter,
         history_repo=history_repo, state_repo=state_repo,
         gateway=gateway, restorer=view_restorer,
         orchestrator=view_orchestrator, last_repo=last_repo,
     )
-    pop_uc = providers.Factory(PopUseCase, history_repo=history_repo, last_repo=last_repo)
-    rebase_uc = providers.Factory(RebaseUseCase, history_repo=history_repo, temp_repo=temp_repo, last_repo=last_repo)
-    last_uc = providers.Factory(
-        LastUseCase, last_repo=last_repo, history_repo=history_repo, gateway=gateway,
+    trimmer = providers.Factory(Trimmer, history_repo=history_repo, last_repo=last_repo)
+    shifter = providers.Factory(Shifter, history_repo=history_repo, temp_repo=temp_repo, last_repo=last_repo)
+    tailer = providers.Factory(
+        Tailer, last_repo=last_repo, history_repo=history_repo, gateway=gateway,
         orchestrator=view_orchestrator,
     )
-    notify_history_empty_uc = providers.Factory(
-        NotifyHistoryEmptyUseCase,
+    alarm = providers.Factory(
+        Alarm,
         gateway=gateway,
     )

--- a/presentation/telegram/router.py
+++ b/presentation/telegram/router.py
@@ -60,7 +60,7 @@ async def back_text_handler(msg: Message, navigator: Navigator, **data: Dict[str
              scope={"chat": msg.chat.id, "inline": False})
     except HistoryEmpty:
         jlog(logger, logging.WARNING, LogCode.ROUTER_BACK_FAIL, kind="text", note="history_empty")
-        await navigator.inform_history_is_empty()
+        await navigator.alert()
     except Exception:
         jlog(logger, logging.WARNING, LogCode.ROUTER_BACK_FAIL, kind="text", note="generic")
-        await navigator.inform_history_is_empty()
+        await navigator.alert()

--- a/presentation/telegram/scope.py
+++ b/presentation/telegram/scope.py
@@ -7,7 +7,7 @@ def make_scope(event) -> Scope:
     inline_id = getattr(event, "inline_message_id", None)
     if inline_id:
         user_id = getattr(getattr(event, "from_user", None), "id", None)
-        return Scope(chat=None, lang=lang, user_id=user_id, inline_id=inline_id, chat_kind=None)
+        return Scope(chat=None, lang=lang, user=user_id, inline=inline_id, category=None)
     msg = event.message if hasattr(event, "message") else event
     chat_obj = getattr(msg, "chat", None)
     chat_id = getattr(chat_obj, "id", None)
@@ -20,9 +20,9 @@ def make_scope(event) -> Scope:
     return Scope(
         chat=chat_id,
         lang=lang,
-        user_id=user_id,
+        user=user_id,
         id=mid,
-        inline_id=None,
-        biz_id=biz,
-        chat_kind=chat_kind,
+        inline=None,
+        business=biz,
+        category=chat_kind,
     )

--- a/tests/adapters/storage/test_historyrepo.py
+++ b/tests/adapters/storage/test_historyrepo.py
@@ -32,9 +32,9 @@ def test_history_repo_persists_extra_without_mutation() -> None:
             markup=None,
             preview=None,
             extra={"unexpected": "value"},
-            aux_ids=[],
+            extras=[],
             inline_id=None,
-            by_bot=True,
+            automated=True,
             ts=datetime.now(timezone.utc),
         )
         entry = Entry(state="state", view="view", messages=[msg], root=False)

--- a/tests/application/map/test_entry_mapper.py
+++ b/tests/application/map/test_entry_mapper.py
@@ -79,7 +79,7 @@ def test_entry_mapper_maps_media_metadata() -> None:
     assert msg.text is None
     assert msg.group is None
     assert msg.inline_id == "inline"
-    assert msg.aux_ids == [42]
+    assert msg.extras == [42]
 
 
 def test_entry_mapper_maps_group_metadata() -> None:

--- a/tests/application/service/view/test_policy.py
+++ b/tests/application/service/view/test_policy.py
@@ -20,31 +20,31 @@ def test_allowed_reply_none_returns_none() -> None:
 
 
 def test_allowed_reply_private_accepts_reply_keyboard() -> None:
-    scope = make_scope(chat_kind="private")
+    scope = make_scope(category="private")
     markup = make_markup("ReplyKeyboardMarkup")
     assert allowed_reply(scope, markup) is markup
 
 
 def test_allowed_reply_group_accepts_force_reply() -> None:
-    scope = make_scope(chat_kind="group")
+    scope = make_scope(category="group")
     markup = make_markup("ForceReply")
     assert allowed_reply(scope, markup) is markup
 
 
 def test_allowed_reply_channel_rejects_custom_markup() -> None:
-    scope = make_scope(chat_kind="channel")
+    scope = make_scope(category="channel")
     markup = make_markup("ReplyKeyboardMarkup")
     assert allowed_reply(scope, markup) is None
 
 
 def test_allowed_reply_channel_accepts_inline_markup() -> None:
-    scope = make_scope(chat_kind="channel")
+    scope = make_scope(category="channel")
     markup = make_markup("InlineKeyboardMarkup")
     assert allowed_reply(scope, markup) is markup
 
 
-def test_allowed_reply_biz_scope_accepts_only_inline() -> None:
-    scope = make_scope(biz_id="corp", chat_kind="private")
+def test_allowed_reply_business_scope_accepts_only_inline() -> None:
+    scope = make_scope(business="corp", category="private")
     inline = make_markup("InlineKeyboardMarkup")
     keyboard = make_markup("ReplyKeyboardMarkup")
     assert allowed_reply(scope, inline) is inline
@@ -52,13 +52,13 @@ def test_allowed_reply_biz_scope_accepts_only_inline() -> None:
 
 
 def test_payload_with_allowed_reply_keeps_payload_when_allowed() -> None:
-    scope = make_scope(chat_kind="private")
+    scope = make_scope(category="private")
     payload = Payload(text="hi", reply=make_markup("ReplyKeyboardMarkup"))
     assert payload_with_allowed_reply(scope, payload) is payload
 
 
 def test_payload_with_allowed_reply_strips_disallowed_markup() -> None:
-    scope = make_scope(chat_kind="channel")
+    scope = make_scope(category="channel")
     payload = Payload(text="hi", reply=make_markup("ReplyKeyboardMarkup"))
     sanitized = payload_with_allowed_reply(scope, payload)
     assert sanitized is not payload
@@ -67,17 +67,17 @@ def test_payload_with_allowed_reply_strips_disallowed_markup() -> None:
 
 
 def test_payload_with_allowed_reply_handles_none_reply() -> None:
-    scope = make_scope(chat_kind="channel")
+    scope = make_scope(category="channel")
     payload = Payload(text="hi", reply=None)
     assert payload_with_allowed_reply(scope, payload) is payload
 
 
 @pytest.mark.parametrize(
-    "chat_kind",
+    "category",
     [None, "supergroup", "channel"],
 )
-def test_allowed_reply_default_to_inline_only(chat_kind: str | None) -> None:
-    scope = make_scope(chat_kind=chat_kind)
+def test_allowed_reply_default_to_inline_only(category: str | None) -> None:
+    scope = make_scope(category=category)
     inline = make_markup("InlineKeyboardMarkup")
     keyboard = make_markup("ReplyKeyboardMarkup")
     assert allowed_reply(scope, inline) is inline


### PR DESCRIPTION
## Summary
- rename the navigator surface and DI wiring to the new single-word use case names while keeping deprecated entry points for compatibility
- migrate scope/message data, storage, and tests to the updated field vocabulary with warning-based shims
- refresh domain helpers, constants, and locking infrastructure to the single-word terminology, adding legacy aliases for callers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf0e2235fc833096a7aad160421d21