### PR TITLE
Rename history extra sanitization identifiers

### DIFF
--- a/application/internal/policy.py
+++ b/application/internal/policy.py
@@ -1,10 +1,9 @@
 from datetime import datetime, timezone
 from typing import Literal
-import warnings
 
 from ...domain.entity.history import Entry, Msg
 from ...domain.entity.media import MediaItem
-from ...domain.service.history.extra import sanitize_extra
+from ...domain.service.history.extra import cleanse
 from ...domain.value.content import Payload, caption
 
 SHIELD_MESSAGE = "Inline message does not support media groups"
@@ -17,15 +16,15 @@ def prime(id: int, payload: Payload) -> Entry:
 
     if payload.group:
         first = payload.group[0] if payload.group else None
-        text_len = len((getattr(first, "caption", None) or ""))
+        length = len((getattr(first, "caption", None) or ""))
     elif payload.media:
-        text_len = len((caption(payload) or ""))
+        length = len((caption(payload) or ""))
     elif isinstance(payload.text, str):
-        text_len = len(payload.text)
+        length = len(payload.text)
     else:
-        text_len = 0
+        length = 0
 
-    extra = sanitize_extra(payload.extra, text_len=text_len)
+    extra = cleanse(payload.extra, length=length)
     msg = Msg(
         id=id,
         text=None if (payload.media or payload.group) else payload.text,
@@ -73,18 +72,6 @@ ImplicitCaption: bool = True  # для сохранения текущего п�
 
 # Поднимать исключения в swap() вместо тихого skip?
 StrictAbort: bool = False  # для сохранения текущей семантики
-
-
-def make_dummy_entry_for_last(id: int, payload: Payload) -> Entry:
-    warnings.warn("make_dummy_entry_for_last is deprecated; use prime", DeprecationWarning, stacklevel=2)
-    return prime(id, payload)
-
-
-def inline_guard(scope, payload):
-    warnings.warn("inline_guard is deprecated; use shield", DeprecationWarning, stacklevel=2)
-    return shield(scope, payload)
-
-
 INLINE_DELETE_TRIMS_HISTORY = TailPrune
 INLINE_TAIL_MODE = TailMode
 RESEND_FALLBACK_ON_FORBIDDEN = ResendOnBan

--- a/application/service/ops.py
+++ b/application/service/ops.py
@@ -18,7 +18,7 @@ def keep_preview_extra(p, e):
 
 
 async def save_history_and_last(history_repo, last_repo, history_policy, history_limit, new_history, *, op: str):
-    trimmed = history_policy.trim(new_history, history_limit)
+    trimmed = history_policy.prune(new_history, history_limit)
     if len(trimmed) != len(new_history):
         jlog(
             logger,

--- a/application/usecase/add.py
+++ b/application/usecase/add.py
@@ -62,7 +62,7 @@ class Appender:
         jlog(logger, logging.INFO, LogCode.STATE_GET, op="add", state={"current": current_state})
 
         effective_payloads = resolved[:len(rr.ids)]
-        new_entry = self._mapper.from_node_result(
+        new_entry = self._mapper.convert(
             NodeResult(rr.ids, rr.extras, rr.metas),
             effective_payloads,
             current_state,

--- a/application/usecase/replace.py
+++ b/application/usecase/replace.py
@@ -49,7 +49,7 @@ class Swapper:
         current_state = await self._state_repo.get_state()
 
         effective_payloads = resolved[:len(rr.ids)]
-        new_entry = self._mapper.from_node_result(
+        new_entry = self._mapper.convert(
             NodeResult(rr.ids, rr.extras, rr.metas),
             effective_payloads,
             current_state,

--- a/domain/service/history/policy.py
+++ b/domain/service/history/policy.py
@@ -3,10 +3,10 @@ from typing import List
 from ...entity.history import Entry
 
 
-def trim(history: List[Entry], max_len: int) -> List[Entry]:
-    if len(history) <= max_len:
+def prune(history: List[Entry], limit: int) -> List[Entry]:
+    if len(history) <= limit:
         return history
-    overflow = len(history) - max_len
+    overflow = len(history) - limit
     if history and getattr(history[0], "root", False):
         cut_from = 1 + overflow
         return [history[0]] + history[cut_from:]

--- a/tests/domain/service/history/testextra.py
+++ b/tests/domain/service/history/testextra.py
@@ -1,12 +1,12 @@
-from navigator.domain.service.history.extra import sanitize_extra
+from navigator.domain.service.history.extra import cleanse
 
 
-def test_sanitize_extra_returns_none_for_non_dict():
-    assert sanitize_extra(None, text_len=10) is None
-    assert sanitize_extra([], text_len=10) is None  # type: ignore[arg-type]
+def testNullity():
+    assert cleanse(None, length=10) is None
+    assert cleanse([], length=10) is None  # type: ignore[arg-type]
 
 
-def test_sanitize_extra_filters_unknown_keys_and_tracks_thumb():
+def testFiltration():
     extra = {
         "mode": "HTML",
         "spoiler": True,
@@ -14,12 +14,12 @@ def test_sanitize_extra_filters_unknown_keys_and_tracks_thumb():
         "unexpected": 42,
     }
 
-    sanitized = sanitize_extra(extra, text_len=0)
+    cleansed = cleanse(extra, length=0)
 
-    assert sanitized == {"mode": "HTML", "spoiler": True, "has_thumb": True}
+    assert cleansed == {"mode": "HTML", "spoiler": True, "has_thumb": True}
 
 
-def test_sanitize_extra_validates_entities_against_text_length():
+def testEntities():
     extra = {
         "mode": "HTML",
         "entities": [
@@ -35,15 +35,15 @@ def test_sanitize_extra_validates_entities_against_text_length():
         ],
     }
 
-    sanitized = sanitize_extra(extra, text_len=6)
+    cleansed = cleanse(extra, length=6)
 
-    assert sanitized["entities"] == [
+    assert cleansed["entities"] == [
         {"type": "bold", "offset": 0, "length": 4},
         {"type": "text_link", "offset": 1, "length": 3, "url": "https://example.com"},
     ]
 
 
-def test_sanitize_extra_drops_entities_if_none_valid_and_returns_none():
+def testVanish():
     extra = {"entities": [{"type": "bold", "offset": 0, "length": 10}]}
 
-    assert sanitize_extra(extra, text_len=5) is None
+    assert cleanse(extra, length=5) is None


### PR DESCRIPTION
## Summary
- rename the history extra sanitizer to `cleanse` and update all call sites to use the new naming
- switch the entry mapper API to a `convert` method with single-word locals and rename the history trimming helper to `prune`
- refresh accompanying tests to the new identifiers and remove obsolete wrappers in the internal policy module

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf21eb87c48330a5668540c8a86dbb