### PR TITLE
Rename caption clear flag to erase

### DIFF
--- a/adapters/telegram/serializer.py
+++ b/adapters/telegram/serializer.py
@@ -45,15 +45,15 @@ def caption_for_edit(payload: Payload) -> Optional[str]:
     """
     Правило для edit_caption:
     - вернуть текст подписи, если он вычисляется (caption(payload));
-    - если payload.clear_caption установлен — вернуть "" для очистки подписи;
+    - если payload.erase установлен — вернуть "" для очистки подписи;
     - иначе вернуть None (не менять подпись).
     Пустая строка → явная очистка подписи на стороне Telegram.
-    Примечание: пустая строка из payload.text без маркера clear_caption игнорируется и приводит к no-op.
+    Примечание: пустая строка из payload.text без маркера erase игнорируется и приводит к no-op.
     """
     cap = caption(payload)
     if cap is not None:
         return cap
-    if payload.clear_caption:
+    if payload.erase:
         return ""
     return None
 

--- a/application/dto/content.py
+++ b/application/dto/content.py
@@ -24,9 +24,9 @@ class Content:
     - Попытка изменить только эффект без изменения текста/медиа/markup логически приводит к NO_CHANGE.
 
     Очистка подписи:
-    - Если media и clear_caption=True и text в значении None/"" →
+    - Если media и erase=True и text в значении None/"" →
       в payload.text будет установлен "" и установлен маркер явной очистки.
-    - Если media и text == "" при clear_caption=False → выбрасывается ValueError.
+    - Если media и text == "" при erase=False → выбрасывается ValueError.
     """
     text: Optional[str] = None
     media: Optional[Media] = None
@@ -34,7 +34,7 @@ class Content:
     reply: Optional[Markup] = None
     preview: Optional[Preview] = None
     extra: Optional[Extra] = None
-    clear_caption: bool = False
+    erase: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/application/map/payload.py
+++ b/application/map/payload.py
@@ -63,17 +63,17 @@ def _to_group(items: Optional[List[Media]]) -> Optional[List[MediaItem]]:
 
 
 def to_payload(dto: Content) -> Payload:
-    # При media и clear_caption=True — выставляем text="" для явной очистки подписи.
+    # При media и erase=True — выставляем text="" для явной очистки подписи.
     text = dto.text
-    clear_caption = False
-    if dto.media and dto.clear_caption:
+    erase = False
+    if dto.media and dto.erase:
         if text is None or text == "":
             text = ""
-            clear_caption = True
+            erase = True
         else:
-            clear_caption = False
-    if dto.media and text == "" and not dto.clear_caption:
-        raise ValueError("empty_caption_without_clear_flag")
+            erase = False
+    if dto.media and text == "" and not dto.erase:
+        raise ValueError("empty_caption_without_erase_flag")
     return Payload(
         text=text,
         media=_to_media(dto.media),
@@ -81,7 +81,7 @@ def to_payload(dto: Content) -> Payload:
         reply=dto.reply,
         preview=dto.preview,
         extra=dto.extra,
-        clear_caption=clear_caption,
+        erase=erase,
     )
 
 

--- a/application/service/view/orchestrator.py
+++ b/application/service/view/orchestrator.py
@@ -91,7 +91,7 @@ class ViewOrchestrator:
         Нормализация meta:
         - Для media: восстанавливает media_type/file_id/caption при edit_*, когда Telegram вернул bool.
         - Для text: восстанавливает text при edit_*, когда Telegram вернул bool.
-        - Очистка подписи: payload.clear_caption -> caption == "".
+        - Очистка подписи: payload.erase -> caption == "".
         """
         m = dict(meta or {})
         kind = m.get("kind")
@@ -117,8 +117,8 @@ class ViewOrchestrator:
                     m["caption"] = new_cap
                 elif (getattr(payload, "media", None) and getattr(payload.media, "caption", None) == ""):
                     m["caption"] = ""  # очистка через media.caption=""
-                elif payload.clear_caption:
-                    m["caption"] = ""  # явная очистка через clear_caption
+                elif payload.erase:
+                    m["caption"] = ""  # явная очистка через erase
                 else:
                     m["caption"] = base_msg.media.caption
         elif kind == "text" and base_msg and (getattr(base_msg, "text", None) is not None):

--- a/domain/value/content.py
+++ b/domain/value/content.py
@@ -29,7 +29,7 @@ class Payload:
     reply: Markup | None = None
     preview: Preview | None = None
     extra: Extra | None = None
-    clear_caption: bool = False
+    erase: bool = False
 
     def morph(self, **kw: Any) -> Payload:
         return replace(self, **kw)
@@ -55,7 +55,7 @@ def normalize(payload: Payload) -> Payload:
         reply=payload.reply,
         preview=payload.preview,
         extra=payload.extra,
-        clear_caption=payload.clear_caption and not bool(group),
+        erase=payload.erase and not bool(group),
     )
 
 

--- a/tests/adapters/telegram/test_serializer.py
+++ b/tests/adapters/telegram/test_serializer.py
@@ -7,18 +7,18 @@ _DEF_MEDIA = MediaItem(type=MediaType.PHOTO, path="file-id")
 
 
 def test_caption_for_edit_returns_empty_when_marker_present():
-    payload = Payload(text="", media=_DEF_MEDIA, clear_caption=True)
+    payload = Payload(text="", media=_DEF_MEDIA, erase=True)
 
     assert caption_for_edit(payload) == ""
 
 
 def test_caption_for_edit_ignores_empty_text_without_marker():
-    payload = Payload(text="", media=_DEF_MEDIA, clear_caption=False)
+    payload = Payload(text="", media=_DEF_MEDIA, erase=False)
 
     assert caption_for_edit(payload) is None
 
 
 def test_caption_for_edit_prefers_caption_text():
-    payload = Payload(text="  actual  ", media=_DEF_MEDIA, clear_caption=False)
+    payload = Payload(text="  actual  ", media=_DEF_MEDIA, erase=False)
 
     assert caption_for_edit(payload) == "actual"

--- a/tests/application/map/test_payload.py
+++ b/tests/application/map/test_payload.py
@@ -4,26 +4,26 @@ from navigator.application.dto.content import Content, Media
 from navigator.application.map.payload import to_payload
 
 
-def test_to_payload_marks_clear_caption_for_media():
-    dto = Content(text=None, media=Media(path="photo.jpg"), clear_caption=True)
+def test_to_payload_marks_erase_for_media():
+    dto = Content(text=None, media=Media(path="photo.jpg"), erase=True)
 
     payload = to_payload(dto)
 
     assert payload.text == ""
-    assert payload.clear_caption is True
+    assert payload.erase is True
 
 
-def test_to_payload_keeps_clear_caption_with_explicit_empty_text():
-    dto = Content(text="", media=Media(path="photo.jpg"), clear_caption=True)
+def test_to_payload_keeps_erase_with_explicit_empty_text():
+    dto = Content(text="", media=Media(path="photo.jpg"), erase=True)
 
     payload = to_payload(dto)
 
     assert payload.text == ""
-    assert payload.clear_caption is True
+    assert payload.erase is True
 
 
 def test_to_payload_rejects_legacy_empty_caption_without_flag():
-    dto = Content(text="", media=Media(path="photo.jpg"), clear_caption=False)
+    dto = Content(text="", media=Media(path="photo.jpg"), erase=False)
 
-    with pytest.raises(ValueError, match="empty_caption_without_clear_flag"):
+    with pytest.raises(ValueError, match="empty_caption_without_erase_flag"):
         to_payload(dto)


### PR DESCRIPTION
## Summary
- rename the DTO and payload caption clearing flag to `erase`
- propagate the new name through serialization and orchestrator logic
- update supporting tests and error messages

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf24ddbb5883308e3775a3f3c479ac