### PR TITLE
Rename notify empty flow to alarm

### DIFF
--- a/adapters/telegram/gateway/__init__.py
+++ b/adapters/telegram/gateway/__init__.py
@@ -49,7 +49,7 @@ class TelegramGateway(MessageGateway):
         runner = BatchDeleteRunner(bot=self._bot, chunk_size=self._chunk_size)
         await runner.run(scope, ids)
 
-    async def notify_empty(self, scope: Scope) -> None:
+    async def alert(self, scope: Scope) -> None:
         if not scope.inline:
             await self._bot.send_message(scope.chat, lexeme("prev_not_found", scope.lang or "en"))
             jlog(

--- a/application/usecase/alarm.py
+++ b/application/usecase/alarm.py
@@ -13,11 +13,11 @@ class Alarm:
         self._gateway = gateway
 
     async def execute(self, scope: Scope) -> None:
-        await self._gateway.notify_empty(scope)
+        await self._gateway.alert(scope)
         jlog(
             logger,
             logging.INFO,
             LogCode.GATEWAY_NOTIFY_EMPTY,
-            op="notify_history_empty",
+            op="alarm",
             scope={"chat": scope.chat, "inline": bool(scope.inline)},
         )

--- a/application/usecase/set.py
+++ b/application/usecase/set.py
@@ -55,7 +55,7 @@ class Setter:
                 target_idx = i
                 break
         if target_idx is None:
-            await self._gateway.notify_empty(scope)
+            await self._gateway.alert(scope)
             jlog(
                 logger,
                 logging.INFO,

--- a/domain/port/message.py
+++ b/domain/port/message.py
@@ -41,7 +41,7 @@ class MessageGateway(Protocol):
     async def delete(self, scope: Scope, ids: List[int]) -> None:
         ...
 
-    async def notify_empty(self, scope: Scope) -> None:
+    async def alert(self, scope: Scope) -> None:
         ...
 
 

--- a/infrastructure/di/container.py
+++ b/infrastructure/di/container.py
@@ -16,7 +16,7 @@ from ...application.service.view.restorer import ViewRestorer
 from ...application.usecase.add import Appender
 from ...application.usecase.back import Rewinder
 from ...application.usecase.last import Tailer
-from ...application.usecase.notify_history_empty import Alarm
+from ...application.usecase.alarm import Alarm
 from ...application.usecase.pop import Trimmer
 from ...application.usecase.rebase import Shifter
 from ...application.usecase.replace import Swapper

--- a/presentation/navigator.py
+++ b/presentation/navigator.py
@@ -55,7 +55,7 @@ from ..application.map.payload import to_node_payload, to_payload
 from ..application.usecase.add import Appender
 from ..application.usecase.back import Rewinder
 from ..application.usecase.last import Tailer
-from ..application.usecase.notify_history_empty import Alarm
+from ..application.usecase.alarm import Alarm
 from ..application.usecase.pop import Trimmer
 from ..application.usecase.rebase import Shifter
 from ..application.usecase.replace import Swapper
@@ -196,7 +196,7 @@ class Navigator:
             await self._trimmer.execute(count)
 
     async def alert(self) -> None:
-        jlog(logger, logging.INFO, LogCode.NAVIGATOR_API, method="notify_empty", scope=profile(self._scope))
+        jlog(logger, logging.INFO, LogCode.NAVIGATOR_API, method="alert", scope=profile(self._scope))
         async with locks.guard(self._scope):
             await self._alarm.execute(self._scope)
 


### PR DESCRIPTION
## Summary
- rename the notify history module to `alarm`
- introduce the new `alert` gateway method name and update callers
- refresh the navigator logging for the renamed alarm use case

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf88462a8c8330b36acde88d2a3435