### PR TITLE
Support direct messages topic propagation in Telegram gateway

### DIFF
--- a/adapters/telegram/gateway/__init__.py
+++ b/adapters/telegram/gateway/__init__.py
@@ -8,6 +8,7 @@ from aiogram import Bot
 from .delete import BatchDeleteRunner
 from .edit import do_edit_text, do_edit_media, do_edit_caption, do_edit_markup
 from .send import do_send
+from .util import targets
 from ....domain.error import InlineUnsupported
 from ....domain.log.emit import jlog
 from ....domain.port.markup import MarkupCodec
@@ -51,7 +52,11 @@ class TelegramGateway(MessageGateway):
 
     async def alert(self, scope: Scope) -> None:
         if not scope.inline:
-            await self._bot.send_message(scope.chat, lexeme("prev_not_found", scope.lang or "en"))
+            kwargs = targets(scope)
+            await self._bot.send_message(
+                text=lexeme("prev_not_found", scope.lang or "en"),
+                **kwargs,
+            )
             jlog(
                 logger,
                 logging.INFO,

--- a/adapters/telegram/gateway/util.py
+++ b/adapters/telegram/gateway/util.py
@@ -14,6 +14,8 @@ def targets(scope: Scope, message_id: Optional[int] = None) -> Dict[str, Any]:
             data["message_id"] = message_id
     if scope.business:
         data["business_connection_id"] = scope.business
+    if scope.direct_topic_id is not None:
+        data["direct_messages_topic_id"] = scope.direct_topic_id
     return data
 
 

--- a/domain/service/scope.py
+++ b/domain/service/scope.py
@@ -5,7 +5,10 @@ from ..value.message import Scope
 
 
 def profile(s: Scope) -> Dict[str, Any]:
-    return {"chat": s.chat, "inline": bool(s.inline), "category": s.category}
+    data: Dict[str, Any] = {"chat": s.chat, "inline": bool(s.inline), "category": s.category}
+    if s.direct_topic_id is not None:
+        data["direct_topic_id"] = s.direct_topic_id
+    return data
 
 
 def scope_kv(s: Scope) -> Dict[str, Any]:

--- a/domain/value/message.py
+++ b/domain/value/message.py
@@ -13,6 +13,7 @@ class Scope:
     inline: str | None = None
     business: str | None = None
     category: str | None = None
+    direct_topic_id: int | None = None
 
     @property
     def user_id(self) -> int | None:

--- a/presentation/telegram/scope.py
+++ b/presentation/telegram/scope.py
@@ -17,6 +17,7 @@ def make_scope(event) -> Scope:
     user_id = getattr(getattr(event, "from_user", None), "id", None)
     mid = getattr(msg, "message_id", None)
     biz = getattr(msg, "business_connection_id", None)
+    direct_topic = getattr(getattr(msg, "direct_messages_topic", None), "topic_id", None)
     return Scope(
         chat=chat_id,
         lang=lang,
@@ -25,4 +26,5 @@ def make_scope(event) -> Scope:
         inline=None,
         business=biz,
         category=chat_kind,
+        direct_topic_id=direct_topic,
     )

--- a/tests/adapters/telegram/test_gateway.py
+++ b/tests/adapters/telegram/test_gateway.py
@@ -1,0 +1,41 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from navigator.adapters.telegram.gateway import TelegramGateway
+from navigator.adapters.telegram.gateway.util import targets
+from navigator.domain.value.message import Scope
+from navigator.presentation.telegram.lexicon import lexeme
+
+
+class DummyMarkupCodec:
+    def encode(self, markup):  # pragma: no cover - simple stub
+        return markup
+
+    def decode(self, stored):  # pragma: no cover - simple stub
+        return stored
+
+
+def test_targets_includes_direct_messages_topic_id() -> None:
+    scope = Scope(chat=42, direct_topic_id=777)
+
+    kwargs = targets(scope)
+
+    assert kwargs["chat_id"] == 42
+    assert kwargs["direct_messages_topic_id"] == 777
+
+
+def test_alert_forwards_direct_messages_topic_id() -> None:
+    send_message = AsyncMock()
+    bot = SimpleNamespace(send_message=send_message)
+    gateway = TelegramGateway(bot=bot, markup_codec=DummyMarkupCodec())
+    scope = Scope(chat=42, lang="en", direct_topic_id=777)
+
+    asyncio.run(gateway.alert(scope))
+
+    expected_text = lexeme("prev_not_found", "en")
+    send_message.assert_awaited_once_with(
+        text=expected_text,
+        chat_id=42,
+        direct_messages_topic_id=777,
+    )


### PR DESCRIPTION
## Summary
- add an optional `direct_topic_id` to message scopes and include it in the scope profile
- surface Telegram direct message topic identifiers when building scopes and target kwargs
- ensure alerts and gateway helpers propagate the topic id and add tests covering the behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf9261e5cc8330a97f3f19231b4f76