### PR TITLE
Rename service ops helpers

### DIFF
--- a/Renaming.md
+++ b/Renaming.md
@@ -1,0 +1,19 @@
+# Renaming Plan
+
+## Objectives
+- Replace snake_case identifiers with concise single-word alternatives while keeping intent clear.
+- Align module names with the one-word rule so imports remain readable and compliant.
+- Sequence the work to minimize breakage by starting with leaf utilities before updating shared interfaces.
+
+## Phases
+1. **Inventory** – Map every module and identifier that currently relies on underscores or glued words. Use automated search (e.g., `rg "_"`) to capture function, method, and attribute names in batches grouped by feature area (adapters, application, domain, presentation).
+2. **Vocabulary Selection** – For each batch, choose precise single-word replacements. Prefer verbs for functions, nouns for classes, and reuse consistent terminology across layers (e.g., repositories use `fetch`/`store`, policies use `allow`, renderers use `render`). Document chosen vocabulary to avoid collisions.
+3. **Module Migration** – Rename files and update import paths feature-by-feature. Begin with service helpers (already migrated to `store.preserve/persist/reindex`), then proceed to usecases, adapters, and finally shared domain types. After each module rename, adjust relative imports and run tests.
+4. **Interface Refactoring** – Once concrete modules are compliant, refactor ports and adapters so shared interfaces expose single-word APIs. Update adapters, services, and tests in lockstep to avoid dangling references. Stage renames to ensure asynchronous contracts (`fetch`, `store`, `delete`) stay semantically clear.
+5. **Validation** – After each phase, execute the full test suite and linting to confirm that renames preserve behavior. Review logs for dynamic attribute access or string-based lookups that may require synchronized updates.
+
+## Next Steps
+- Extend the single-word terminology to repository interfaces (`get_history` → `fetch`, `save_history` → `store`, etc.) and propagate changes through adapters and tests.
+- Normalize presentation-layer handlers (e.g., `back_handler`) by adopting concise verbs like `back` or `return` while verifying router registrations.
+- Audit domain value objects for accessor properties such as `inline_id` and prepare equivalent replacements (e.g., `inline` or `cursor`) alongside serialization adjustments.
+- Continue iterating until every identifier, including constants and configuration entries, adheres to the naming rules with no residual underscores apart from private or constant contexts.

--- a/application/service/store.py
+++ b/application/service/store.py
@@ -9,50 +9,50 @@ from ...domain.log.code import LogCode
 logger = logging.getLogger(__name__)
 
 
-def keep_preview_extra(p, e):
+def preserve(payload, entry):
     return replace(
-        p,
-        preview=p.preview if p.preview is not None else e.preview,
-        extra=p.extra if p.extra is not None else e.extra,
+        payload,
+        preview=payload.preview if payload.preview is not None else entry.preview,
+        extra=payload.extra if payload.extra is not None else entry.extra,
     )
 
 
-async def save_history_and_last(history_repo, last_repo, history_policy, history_limit, new_history, *, op: str):
-    trimmed = history_policy.prune(new_history, history_limit)
-    if len(trimmed) != len(new_history):
+async def persist(archive, ledger, policy, limit, history, *, op: str):
+    trimmed = policy.prune(history, limit)
+    if len(trimmed) != len(history):
         jlog(
             logger,
             logging.DEBUG,
             LogCode.HISTORY_TRIM,
             op=op,
-            history={"before": len(new_history), "after": len(trimmed)},
+            history={"before": len(history), "after": len(trimmed)},
         )
-    await history_repo.save_history(trimmed)
+    await archive.save_history(trimmed)
     jlog(logger, logging.DEBUG, LogCode.HISTORY_SAVE, op=op, history={"len": len(trimmed)})
     if trimmed and trimmed[-1].messages:
         mid = trimmed[-1].messages[0].id
-        await last_repo.set_last_id(mid)
+        await ledger.set_last_id(mid)
         jlog(logger, logging.INFO, LogCode.LAST_SET, op=op, message={"id": mid})
 
 
-def patch_entry_ids(entry: Entry, new_ids: List[int], new_extras: Optional[List[List[int]]] = None) -> Entry:
-    limit = min(len(entry.messages), len(new_ids))
-    patched_msgs = []
+def reindex(entry: Entry, ids: List[int], extras: Optional[List[List[int]]] = None) -> Entry:
+    limit = min(len(entry.messages), len(ids))
+    messages = []
     for i in range(limit):
-        patched_msgs.append(
+        messages.append(
             Msg(
-                id=int(new_ids[i]),
+                id=int(ids[i]),
                 text=entry.messages[i].text,
                 media=entry.messages[i].media,
                 group=entry.messages[i].group,
                 markup=entry.messages[i].markup,
                 preview=entry.messages[i].preview,
                 extra=entry.messages[i].extra,
-                extras=(new_extras[i] if new_extras and i < len(new_extras) else entry.messages[i].extras),
+                extras=(extras[i] if extras and i < len(extras) else entry.messages[i].extras),
                 inline_id=entry.messages[i].inline_id,
                 automated=entry.messages[i].automated,
                 ts=entry.messages[i].ts,
             )
         )
-    patched_msgs += entry.messages[limit:]
-    return Entry(state=entry.state, view=entry.view, messages=patched_msgs, root=entry.root)
+    messages += entry.messages[limit:]
+    return Entry(state=entry.state, view=entry.view, messages=messages, root=entry.root)

--- a/application/service/view/inline.py
+++ b/application/service/view/inline.py
@@ -2,7 +2,7 @@ import json
 import logging
 import re
 
-from ..ops import keep_preview_extra
+from ..store import preserve
 from ...internal.rules.inline import remap as _inline_remap
 from ....domain.entity.history import Entry
 from ....domain.entity.media import MediaType
@@ -81,7 +81,7 @@ class InlineStrategy:
             rendering_config: RenderingConfig,
     ):
         if inline:
-            p = keep_preview_extra(payload, last_message)
+            p = preserve(payload, last_message)
             if getattr(p, "group", None):
                 p = p.morph(media=p.group[0], group=None)
 

--- a/application/usecase/add.py
+++ b/application/usecase/add.py
@@ -72,7 +72,7 @@ class Appender:
         )
 
         new_history = [new_entry] if root else (history + [new_entry])
-        from ..service.ops import save_history_and_last
-        await save_history_and_last(
+        from ..service.store import persist
+        await persist(
             self._history_repo, self._last_repo, history_policy, self._history_limit, new_history, op="add"
         )

--- a/application/usecase/last.py
+++ b/application/usecase/last.py
@@ -170,11 +170,11 @@ class Tailer:
                         idx = i
                         break
                 if idx is not None:
-                    from ..service.ops import patch_entry_ids
+                    from ..service.store import reindex
                     old_msg = history[idx].messages[0]
                     need_patch = (result.id != old_msg.id)
                     new_extras = [result.extra] if need_patch else None
-                    patched = patch_entry_ids(history[idx], [result.id], new_extras)
+                    patched = reindex(history[idx], [result.id], new_extras)
                     history[idx] = patched
                     await self._history_repo.save_history(history)
                     jlog(logger, logging.DEBUG, LogCode.HISTORY_SAVE, op="last.edit", history={"len": len(history)})
@@ -203,8 +203,8 @@ class Tailer:
                         idx = i
                         break
                 if idx is not None:
-                    from ..service.ops import patch_entry_ids
-                    patched = patch_entry_ids(history[idx], [resend_result.id], [resend_result.extra])
+                    from ..service.store import reindex
+                    patched = reindex(history[idx], [resend_result.id], [resend_result.extra])
                     history[idx] = patched
                     await self._history_repo.save_history(history)
                     jlog(logger, logging.DEBUG, LogCode.HISTORY_SAVE, op="last.edit", history={"len": len(history)})

--- a/application/usecase/replace.py
+++ b/application/usecase/replace.py
@@ -61,7 +61,7 @@ class Swapper:
             updated = [new_entry]
         else:
             updated = history[:-1] + [new_entry]
-        from ..service.ops import save_history_and_last
-        await save_history_and_last(
+        from ..service.store import persist
+        await persist(
             self._history_repo, self._last_repo, history_policy, self._history_limit, updated, op="replace"
         )


### PR DESCRIPTION
## Summary
- document the repository-wide identifier renaming strategy in `Renaming.md`
- rename the service helper module to `store` and expose single-word helpers (`preserve`, `persist`, `reindex`)
- update inline rendering and usecases to call the renamed helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf9579bb3083309406a66d8ed917ce