### PR TITLE
Rename scope topic and inline metadata

### DIFF
--- a/Renaming.md
+++ b/Renaming.md
@@ -12,8 +12,14 @@
 4. **Interface Refactoring** – Once concrete modules are compliant, refactor ports and adapters so shared interfaces expose single-word APIs. Update adapters, services, and tests in lockstep to avoid dangling references. Stage renames to ensure asynchronous contracts (`fetch`, `store`, `delete`) stay semantically clear.
 5. **Validation** – After each phase, execute the full test suite and linting to confirm that renames preserve behavior. Review logs for dynamic attribute access or string-based lookups that may require synchronized updates.
 
+## Completed Updates
+- **Scope vocabulary** – `direct_topic_id` was collapsed into the single-word field `topic`, and deprecated aliases (`user_id`, `inline_id`, etc.) were removed to keep the dataclass clean.
+- **Message metadata** – `Msg.inline_id` and `Result.inline_id` now expose the single-word attribute `inline`; all adapters, services, and tests were synchronized to the new key. Storage serializers still read legacy payloads via fallback keys.
+- **Telegram scope assembly** – presentation helpers now build `Scope` using single-word locals (`language`, `topic`, `business`) to align naming across layers.
+
 ## Next Steps
 - Extend the single-word terminology to repository interfaces (`get_history` → `fetch`, `save_history` → `store`, etc.) and propagate changes through adapters and tests.
 - Normalize presentation-layer handlers (e.g., `back_handler`) by adopting concise verbs like `back` or `return` while verifying router registrations.
-- Audit domain value objects for accessor properties such as `inline_id` and prepare equivalent replacements (e.g., `inline` or `cursor`) alongside serialization adjustments.
+- Continue replacing snake_case message fields (`preview_url`, `reply_markup`, etc.) with precise single-word terms, prioritizing shared DTOs so adapters and use-cases stay in sync.
+- Audit remaining service helpers and map utilities for interim names such as `payload_kind` or `history_updated`, documenting replacements before batching the edits.
 - Continue iterating until every identifier, including constants and configuration entries, adheres to the naming rules with no residual underscores apart from private or constant contexts.

--- a/adapters/storage/historyrepo.py
+++ b/adapters/storage/historyrepo.py
@@ -165,7 +165,7 @@ class HistoryRepo:
                     "preview": self._encode_preview(m.preview),
                     "extra": m.extra,
                     "extras": list(m.extras),
-                    "inline_id": m.inline_id,
+                    "inline": m.inline,
                     "automated": m.automated,
                     "ts": self._encode_dt(m.ts),
                 }
@@ -206,7 +206,7 @@ class HistoryRepo:
                                 or []
                             )
                         ],
-                        inline_id=d.get("inline_id"),
+                        inline=d.get("inline", d.get("inline_id")),
                         automated=bool(
                             d.get(
                                 "automated",

--- a/adapters/telegram/gateway/send.py
+++ b/adapters/telegram/gateway/send.py
@@ -56,7 +56,7 @@ async def do_send(bot, codec: MarkupCodec, scope: Scope, payload, *, truncate: b
                 payload=_payload_kind(payload),
                 message={"id": sent_messages[0].message_id, "extra_len": len(sent_messages) - 1},
             )
-            meta = {"kind": "group", "group_items": items, "inline_id": scope.inline}
+            meta = {"kind": "group", "group_items": items, "inline": scope.inline}
             return Result(
                 id=sent_messages[0].message_id,
                 extra=[m.message_id for m in sent_messages[1:]],

--- a/application/map/entry.py
+++ b/application/map/entry.py
@@ -35,7 +35,7 @@ class EntryMapper:
                 raise ValueError("meta_missing_kind")
             if k not in ("text", "media", "group"):
                 raise ValueError(f"meta_unsupported_kind:{k}")
-            inline = meta.get("inline_id")
+            inline = meta.get("inline")
 
             previous = None
             if base and idx < len(getattr(base, "messages", []) or []):
@@ -91,7 +91,7 @@ class EntryMapper:
                     preview=payload.preview,
                     extra=extra,
                     extras=list(aux),
-                    inline_id=inline,
+                    inline=inline,
                     automated=True,
                     ts=now,
                 )

--- a/application/service/store.py
+++ b/application/service/store.py
@@ -49,7 +49,7 @@ def reindex(entry: Entry, ids: List[int], extras: Optional[List[List[int]]] = No
                 preview=entry.messages[i].preview,
                 extra=entry.messages[i].extra,
                 extras=(extras[i] if extras and i < len(extras) else entry.messages[i].extras),
-                inline_id=entry.messages[i].inline_id,
+                inline=entry.messages[i].inline,
                 automated=entry.messages[i].automated,
                 ts=entry.messages[i].ts,
             )

--- a/application/service/view/orchestrator.py
+++ b/application/service/view/orchestrator.py
@@ -157,7 +157,7 @@ class ViewOrchestrator:
                 "caption": getattr(r, "caption", None),
                 "text": getattr(r, "text", None),
                 "group_items": getattr(r, "group_items", None),
-                "inline_id": getattr(r, "inline_id", None),
+                "inline": getattr(r, "inline", None),
             }
             norm_meta = self._normalize_meta(raw_meta, base_msg, dec, payload)
             return RenderResult(id=r.id, extra=r.extra, meta=self._require_kind(norm_meta))
@@ -302,7 +302,7 @@ class ViewOrchestrator:
                     "group_items": [
                         {"media_type": it.type.value, "file_id": it.path, "caption": it.caption} for it in o.group
                     ],
-                    "inline_id": o.inline_id,
+                    "inline": o.inline,
                 }
             if o.media:
                 return {
@@ -310,9 +310,9 @@ class ViewOrchestrator:
                     "media_type": o.media.type.value,
                     "file_id": o.media.path,
                     "caption": o.media.caption,
-                    "inline_id": o.inline_id,
+                    "inline": o.inline,
                 }
-            return {"kind": "text", "text": o.text, "inline_id": o.inline_id}
+            return {"kind": "text", "text": o.text, "inline": o.inline}
 
         shield(scope, new[0] if new else Payload())
         old: List[Msg] = list(last_node.messages) if last_node else []
@@ -428,7 +428,7 @@ class ViewOrchestrator:
                 out_ids.append(ids[0])
                 out_extras.append(list(old[0].extras))
                 out_metas.append(
-                    self._require_kind({"kind": "group", "group_items": group_items, "inline_id": old[0].inline_id})
+                    self._require_kind({"kind": "group", "group_items": group_items, "inline": old[0].inline})
                 )
 
                 # продолжить обработку узла с индекса 1
@@ -496,7 +496,7 @@ class ViewOrchestrator:
                                 preview=o.preview,
                                 extra=o.extra,
                                 extras=getattr(o, "extras", []),
-                                inline_id=o.inline_id,
+                                inline=o.inline,
                                 automated=o.automated,
                                 ts=o.ts,
                             )
@@ -539,7 +539,7 @@ class ViewOrchestrator:
                         "caption": getattr(rr, "caption", None),
                         "text": getattr(rr, "text", None),
                         "group_items": getattr(rr, "group_items", None),
-                        "inline_id": getattr(rr, "inline_id", None),
+                        "inline": getattr(rr, "inline", None),
                     }
                     out_metas.append(self._require_kind(meta))
                     changed = True
@@ -554,7 +554,7 @@ class ViewOrchestrator:
                 "caption": getattr(r, "caption", None),
                 "text": getattr(r, "text", None),
                 "group_items": getattr(r, "group_items", None),
-                "inline_id": getattr(r, "inline_id", None),
+                "inline": getattr(r, "inline", None),
             }
             out_metas.append(self._require_kind(meta))
             changed = True
@@ -580,7 +580,7 @@ class ViewOrchestrator:
                         "caption": getattr(r, "caption", None),
                         "text": getattr(r, "text", None),
                         "group_items": getattr(r, "group_items", None),
-                        "inline_id": getattr(r, "inline_id", None),
+                        "inline": getattr(r, "inline", None),
                     }
                     out_metas.append(self._require_kind(meta))
                     changed = True

--- a/application/usecase/back.py
+++ b/application/usecase/back.py
@@ -110,7 +110,7 @@ class Rewinder:
                 preview=entry_to.messages[i].preview,
                 extra=entry_to.messages[i].extra,
                 extras=render_result.extras[i],
-                inline_id=entry_to.messages[i].inline_id,
+                inline=entry_to.messages[i].inline,
                 automated=entry_to.messages[i].automated,
                 ts=entry_to.messages[i].ts,
             )

--- a/application/usecase/rebase.py
+++ b/application/usecase/rebase.py
@@ -46,7 +46,7 @@ class Shifter:
             preview=first.preview,
             extra=first.extra,
             extras=first.extras,
-            inline_id=first.inline_id,
+            inline=first.inline,
             automated=first.automated,
             ts=first.ts,
         )

--- a/application/usecase/set.py
+++ b/application/usecase/set.py
@@ -127,7 +127,7 @@ class Setter:
                                      preview=tail.messages[i].preview,
                                      extra=tail.messages[i].extra,
                                      extras=render_result.extras[i],
-                                     inline_id=tail.messages[i].inline_id,
+                                     inline=tail.messages[i].inline,
                                      automated=tail.messages[i].automated,
                                      ts=tail.messages[i].ts,
                                  )

--- a/domain/entity/history.py
+++ b/domain/entity/history.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
@@ -22,29 +21,9 @@ class Msg:
     preview: "Preview" | None = None
     extra: dict[str, Any] | None = None
     extras: list[int] = field(default_factory=list)
-    inline_id: str | None = None  # inline_message_id, если есть
+    inline: str | None = None  # inline_message_id, если есть
     automated: bool = True
     ts: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
-
-    @property
-    def aux_ids(self) -> list[int]:
-        warnings.warn("Msg.aux_ids is deprecated; use Msg.extras", DeprecationWarning, stacklevel=2)
-        return self.extras
-
-    @aux_ids.setter
-    def aux_ids(self, value: list[int]) -> None:
-        warnings.warn("Msg.aux_ids is deprecated; use Msg.extras", DeprecationWarning, stacklevel=2)
-        self.extras = value
-
-    @property
-    def by_bot(self) -> bool:
-        warnings.warn("Msg.by_bot is deprecated; use Msg.automated", DeprecationWarning, stacklevel=2)
-        return self.automated
-
-    @by_bot.setter
-    def by_bot(self, value: bool) -> None:
-        warnings.warn("Msg.by_bot is deprecated; use Msg.automated", DeprecationWarning, stacklevel=2)
-        self.automated = value
 
 
 @dataclass(frozen=True, slots=True)

--- a/domain/port/message.py
+++ b/domain/port/message.py
@@ -18,7 +18,7 @@ class Result:
     caption: Optional[str] = None
     text: Optional[str] = None
     group_items: Optional[List[dict]] = None  # [{"media_type":..., "file_id":..., "caption": str|None}]
-    inline_id: Optional[str] = None
+    inline: Optional[str] = None
 
 
 @runtime_checkable

--- a/domain/service/scope.py
+++ b/domain/service/scope.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import Dict, Any
 
 from ..value.message import Scope
@@ -6,11 +5,6 @@ from ..value.message import Scope
 
 def profile(s: Scope) -> Dict[str, Any]:
     data: Dict[str, Any] = {"chat": s.chat, "inline": bool(s.inline), "category": s.category}
-    if s.direct_topic_id is not None:
-        data["direct_topic_id"] = s.direct_topic_id
+    if s.topic is not None:
+        data["topic"] = s.topic
     return data
-
-
-def scope_kv(s: Scope) -> Dict[str, Any]:
-    warnings.warn("scope_kv is deprecated; use profile", DeprecationWarning, stacklevel=2)
-    return profile(s)

--- a/domain/value/message.py
+++ b/domain/value/message.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from dataclasses import dataclass
 
 
@@ -13,44 +12,4 @@ class Scope:
     inline: str | None = None
     business: str | None = None
     category: str | None = None
-    direct_topic_id: int | None = None
-
-    @property
-    def user_id(self) -> int | None:
-        warnings.warn("Scope.user_id is deprecated; use Scope.user", DeprecationWarning, stacklevel=2)
-        return self.user
-
-    @user_id.setter
-    def user_id(self, value: int | None) -> None:
-        warnings.warn("Scope.user_id is deprecated; use Scope.user", DeprecationWarning, stacklevel=2)
-        self.user = value
-
-    @property
-    def inline_id(self) -> str | None:
-        warnings.warn("Scope.inline_id is deprecated; use Scope.inline", DeprecationWarning, stacklevel=2)
-        return self.inline
-
-    @inline_id.setter
-    def inline_id(self, value: str | None) -> None:
-        warnings.warn("Scope.inline_id is deprecated; use Scope.inline", DeprecationWarning, stacklevel=2)
-        self.inline = value
-
-    @property
-    def biz_id(self) -> str | None:
-        warnings.warn("Scope.biz_id is deprecated; use Scope.business", DeprecationWarning, stacklevel=2)
-        return self.business
-
-    @biz_id.setter
-    def biz_id(self, value: str | None) -> None:
-        warnings.warn("Scope.biz_id is deprecated; use Scope.business", DeprecationWarning, stacklevel=2)
-        self.business = value
-
-    @property
-    def chat_kind(self) -> str | None:
-        warnings.warn("Scope.chat_kind is deprecated; use Scope.category", DeprecationWarning, stacklevel=2)
-        return self.category
-
-    @chat_kind.setter
-    def chat_kind(self, value: str | None) -> None:
-        warnings.warn("Scope.chat_kind is deprecated; use Scope.category", DeprecationWarning, stacklevel=2)
-        self.category = value
+    topic: int | None = None

--- a/presentation/telegram/scope.py
+++ b/presentation/telegram/scope.py
@@ -2,29 +2,29 @@ from ...domain.value.message import Scope
 
 
 def make_scope(event) -> Scope:
-    lang_code = getattr(getattr(event, "from_user", None), "language_code", None)
-    lang = (lang_code or "en").split("-")[0].lower()
-    inline_id = getattr(event, "inline_message_id", None)
-    if inline_id:
-        user_id = getattr(getattr(event, "from_user", None), "id", None)
-        return Scope(chat=None, lang=lang, user=user_id, inline=inline_id, category=None)
-    msg = event.message if hasattr(event, "message") else event
-    chat_obj = getattr(msg, "chat", None)
-    chat_id = getattr(chat_obj, "id", None)
-    ctype_raw = getattr(chat_obj, "type", None)
-    chat_kind = "group" if ctype_raw == "supergroup" else (
-        ctype_raw if ctype_raw in {"private", "group", "channel"} else None)
-    user_id = getattr(getattr(event, "from_user", None), "id", None)
-    mid = getattr(msg, "message_id", None)
-    biz = getattr(msg, "business_connection_id", None)
-    direct_topic = getattr(getattr(msg, "direct_messages_topic", None), "topic_id", None)
+    language_source = getattr(getattr(event, "from_user", None), "language_code", None)
+    language = (language_source or "en").split("-")[0].lower()
+    inline = getattr(event, "inline_message_id", None)
+    if inline:
+        user = getattr(getattr(event, "from_user", None), "id", None)
+        return Scope(chat=None, lang=language, user=user, inline=inline, category=None)
+    message = event.message if hasattr(event, "message") else event
+    chat_data = getattr(message, "chat", None)
+    chat = getattr(chat_data, "id", None)
+    chat_type = getattr(chat_data, "type", None)
+    category = "group" if chat_type == "supergroup" else (
+        chat_type if chat_type in {"private", "group", "channel"} else None)
+    user = getattr(getattr(event, "from_user", None), "id", None)
+    message_id = getattr(message, "message_id", None)
+    business = getattr(message, "business_connection_id", None)
+    topic = getattr(getattr(message, "direct_messages_topic", None), "topic_id", None)
     return Scope(
-        chat=chat_id,
-        lang=lang,
-        user=user_id,
-        id=mid,
+        chat=chat,
+        lang=language,
+        user=user,
+        id=message_id,
         inline=None,
-        business=biz,
-        category=chat_kind,
-        direct_topic_id=direct_topic,
+        business=business,
+        category=category,
+        topic=topic,
     )

--- a/tests/adapters/storage/test_historyrepo.py
+++ b/tests/adapters/storage/test_historyrepo.py
@@ -33,7 +33,7 @@ def test_history_repo_persists_extra_without_mutation() -> None:
             preview=None,
             extra={"unexpected": "value"},
             extras=[],
-            inline_id=None,
+            inline=None,
             automated=True,
             ts=datetime.now(timezone.utc),
         )

--- a/tests/adapters/telegram/test_gateway.py
+++ b/tests/adapters/telegram/test_gateway.py
@@ -17,7 +17,7 @@ class DummyMarkupCodec:
 
 
 def test_targets_includes_direct_messages_topic_id() -> None:
-    scope = Scope(chat=42, direct_topic_id=777)
+    scope = Scope(chat=42, topic=777)
 
     kwargs = targets(scope)
 
@@ -29,7 +29,7 @@ def test_alert_forwards_direct_messages_topic_id() -> None:
     send_message = AsyncMock()
     bot = SimpleNamespace(send_message=send_message)
     gateway = TelegramGateway(bot=bot, markup_codec=DummyMarkupCodec())
-    scope = Scope(chat=42, lang="en", direct_topic_id=777)
+    scope = Scope(chat=42, lang="en", topic=777)
 
     asyncio.run(gateway.alert(scope))
 

--- a/tests/application/map/testentrymapper.py
+++ b/tests/application/map/testentrymapper.py
@@ -42,7 +42,7 @@ def testText() -> None:
     result = NodeResult(
         ids=[1],
         extras=[[]],
-        metas=[{"kind": "text", "text": "meta", "inline_id": "123"}],
+        metas=[{"kind": "text", "text": "meta", "inline": "123"}],
     )
 
     entry = mapper.convert(result, [payload], state="s", view="view", root=True)
@@ -51,7 +51,7 @@ def testText() -> None:
     assert entry.messages[0].text == "meta"
     assert entry.messages[0].media is None
     assert entry.messages[0].group is None
-    assert entry.messages[0].inline_id == "123"
+    assert entry.messages[0].inline == "123"
 
 
 def testMedia() -> None:
@@ -65,7 +65,7 @@ def testMedia() -> None:
             "media_type": "photo",
             "file_id": "file-id",
             "caption": "meta caption",
-            "inline_id": "inline",
+            "inline": "inline",
         }],
     )
 
@@ -78,7 +78,7 @@ def testMedia() -> None:
     assert msg.media.caption == "meta caption"
     assert msg.text is None
     assert msg.group is None
-    assert msg.inline_id == "inline"
+    assert msg.inline == "inline"
     assert msg.extras == [42]
 
 
@@ -99,7 +99,7 @@ def testGroup() -> None:
                 {"media_type": "photo", "file_id": "f1", "caption": "c1"},
                 {"media_type": "video", "file_id": "f2", "caption": ""},
             ],
-            "inline_id": None,
+            "inline": None,
         }],
     )
 


### PR DESCRIPTION
## Summary
- replace the deprecated `direct_topic_id` scope field with a single-word `topic` and update callers
- rename message `inline_id` metadata to `inline` across domain entities, adapters, services, and tests
- document the completed renaming wave and outline the next cleanups in `Renaming.md`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfd5efbc5c833086ec47a5b1647d38