### PR TITLE
Remove deprecated domain utility fallbacks

### DIFF
--- a/domain/constants.py
+++ b/domain/constants.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import Final
 
 __all__ = ["TextLimit", "CaptionLimit", "AlbumFloor", "AlbumCeiling", "AlbumBlend", "ThumbWatch"]
@@ -10,18 +9,3 @@ AlbumCeiling: Final = 10
 AlbumBlend: Final = {"photo", "video"}
 ThumbWatch: Final[bool] = False
 
-_DEPRECATED = {
-    "TEXT_MAX": TextLimit,
-    "CAPTION_MAX": CaptionLimit,
-    "ALBUM_MIN": AlbumFloor,
-    "ALBUM_MAX": AlbumCeiling,
-    "ALBUM_MIXED_ALLOWED": AlbumBlend,
-    "DETECT_THUMB_CHANGE": ThumbWatch,
-}
-
-
-def __getattr__(name: str):
-    if name in _DEPRECATED:
-        warnings.warn(f"{name} is deprecated; use the new single-word constant", DeprecationWarning, stacklevel=2)
-        return _DEPRECATED[name]
-    raise AttributeError(f"module 'domain.constants' has no attribute {name!r}")

--- a/domain/util/entities.py
+++ b/domain/util/entities.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import warnings
 from typing import Any, Dict, List
 
 from ..log.emit import jlog
@@ -64,8 +63,3 @@ def sanitize(entities: Any, text_len: int) -> List[Dict[str, Any]]:
     if entities and not out:
         jlog(logging.getLogger(__name__), logging.DEBUG, LogCode.EXTRA_UNKNOWN_DROPPED, note="entities_dropped_all")
     return out
-
-
-def validate_entities(entities: Any, text_len: int) -> List[Dict[str, Any]]:
-    warnings.warn("validate_entities is deprecated; use sanitize", DeprecationWarning, stacklevel=2)
-    return sanitize(entities, text_len)

--- a/domain/util/path.py
+++ b/domain/util/path.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import os
-import warnings
 from urllib.parse import urlparse
 
 
@@ -23,13 +22,3 @@ def local(s: str) -> bool:
     if "/" in s or "\\" in s:
         return True
     return False
-
-
-def is_http_url(s: str) -> bool:
-    warnings.warn("is_http_url is deprecated; use remote", DeprecationWarning, stacklevel=2)
-    return remote(s)
-
-
-def is_local_path(s: str) -> bool:
-    warnings.warn("is_local_path is deprecated; use local", DeprecationWarning, stacklevel=2)
-    return local(s)

--- a/domain/value/ids.py
+++ b/domain/value/ids.py
@@ -1,4 +1,3 @@
-import warnings
 from collections.abc import Iterable
 
 
@@ -17,13 +16,3 @@ def dedupe(ids: Iterable[int], sort: bool = False) -> list[int]:
 
 def order(ids: Iterable[int]) -> list[int]:
     return sorted({int(x) for x in ids or []})
-
-
-def unique_ids(ids: Iterable[int], sort: bool = False) -> list[int]:
-    warnings.warn("unique_ids is deprecated; use dedupe", DeprecationWarning, stacklevel=2)
-    return dedupe(ids, sort=sort)
-
-
-def unique_sorted(ids: Iterable[int]) -> list[int]:
-    warnings.warn("unique_sorted is deprecated; use order", DeprecationWarning, stacklevel=2)
-    return order(ids)


### PR DESCRIPTION
## Summary
- remove deprecated helper aliases from the domain value and util modules
- drop the dynamic constants fallback now that only the modern names remain

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfdfe27ca08330b181a1f5ac139095