### PR TITLE
Remove deprecated lock provider aliases

### DIFF
--- a/application/locks.py
+++ b/application/locks.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-from __future__ import annotations
-
 import asyncio
-import warnings
 from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 from weakref import WeakValueDictionary
@@ -121,34 +118,4 @@ __all__ = [
     "Guard",
     "guard",
     "appoint",
-]
-
-
-ScopeLike = ScopeForm
-LockProvider = Locksmith
-
-
-@dataclass
-class LockBox(Latch):
-    def __post_init__(self) -> None:
-        warnings.warn("LockBox is deprecated; use Latch", DeprecationWarning, stacklevel=2)
-
-
-class InMemoryLockProvider(MemoryLocksmith):
-    def __init__(self) -> None:
-        warnings.warn("InMemoryLockProvider is deprecated; use MemoryLocksmith", DeprecationWarning, stacklevel=2)
-        super().__init__()
-
-
-def reappoint(p: Locksmith) -> None:
-    warnings.warn("set_lock_provider is deprecated; use appoint", DeprecationWarning, stacklevel=2)
-    appoint(p)
-
-
-__all__ += [
-    "ScopeLike",
-    "LockProvider",
-    "LockBox",
-    "InMemoryLockProvider",
-    "reappoint",
 ]

--- a/infrastructure/locks.py
+++ b/infrastructure/locks.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import warnings
 import os
 from typing import TYPE_CHECKING, Any
 
@@ -89,11 +88,5 @@ def configure() -> None:
     appoint(RedisLocksmith(url, ttl, blocking))
 
 
-class RedisLockProvider(RedisLocksmith):
-    def __init__(self, url: str, ttl: float, blocking: float) -> None:
-        warnings.warn("RedisLockProvider is deprecated; use RedisLocksmith", DeprecationWarning, stacklevel=2)
-        super().__init__(url, ttl, blocking)
-
-
-__all__ = ["RedisLocksmith", "RedisLockProvider", "configure"]
+__all__ = ["RedisLocksmith", "configure"]
 


### PR DESCRIPTION
## Summary
- drop the deprecated lock aliases and adapter shims from `application.locks`
- remove the redis adapter alias and clean up exports in `infrastructure.locks`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cfe094f1bc8330a2e881f2ec92e623