### PR TITLE
Remove deprecated navigator compatibility APIs

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,4 +1,4 @@
-from .composition import assemble, create_navigator
+from .composition import assemble
 from .presentation.navigator import Navigator
 
-__all__ = ["Navigator", "assemble", "create_navigator"]
+__all__ = ["Navigator", "assemble"]

--- a/composition/__init__.py
+++ b/composition/__init__.py
@@ -1,5 +1,4 @@
 from typing import Optional, Any
-import warnings
 
 from ..adapters.factory.registry import default as reg_default
 from ..application.log.emit import set_redaction_mode
@@ -31,6 +30,3 @@ async def assemble(event: Any, state: Any, registry: Optional[Any] = None) -> Na
     )
 
 
-async def create_navigator(event: Any, state: Any, registry: Optional[Any] = None) -> Navigator:
-    warnings.warn("create_navigator is deprecated; use assemble", DeprecationWarning, stacklevel=2)
-    return await assemble(event, state, registry)

--- a/composition/migrate.py
+++ b/composition/migrate.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import warnings
 from typing import Any
 
 from ..adapters.factory.registry import default as _default_registry
@@ -45,6 +44,3 @@ async def cleanse(state: Any, registry=_default_registry) -> None:
     )
 
 
-async def purge_invalid_views(state: Any, registry=_default_registry) -> None:
-    warnings.warn("purge_invalid_views is deprecated; use cleanse", DeprecationWarning, stacklevel=2)
-    await cleanse(state, registry)

--- a/presentation/navigator.py
+++ b/presentation/navigator.py
@@ -45,7 +45,6 @@ Navigator API — ключевые контракты:
 from __future__ import annotations
 
 import logging
-import warnings
 from typing import Optional, Dict, Any, Union, SupportsInt
 
 from ..application import locks
@@ -200,10 +199,3 @@ class Navigator:
         async with locks.guard(self._scope):
             await self._alarm.execute(self._scope)
 
-    async def inform_history_is_empty(self) -> None:
-        warnings.warn(
-            "Navigator.inform_history_is_empty is deprecated; use Navigator.alert",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        await self.alert()


### PR DESCRIPTION
## Summary
- remove the deprecated `create_navigator`, `purge_invalid_views`, and `Navigator.inform_history_is_empty` helpers
- limit the package export surface to the supported `Navigator` and `assemble` APIs

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfe142dff48330a0bce41c0c536b12