### PR TITLE
Remove Scope id field

### DIFF
--- a/domain/value/message.py
+++ b/domain/value/message.py
@@ -8,7 +8,6 @@ class Scope:
     chat: int | None
     lang: str | None = None
     user: int | None = None
-    id: int | None = None
     inline: str | None = None
     business: str | None = None
     category: str | None = None

--- a/presentation/telegram/scope.py
+++ b/presentation/telegram/scope.py
@@ -15,14 +15,12 @@ def make_scope(event) -> Scope:
     category = "group" if chat_type == "supergroup" else (
         chat_type if chat_type in {"private", "group", "channel"} else None)
     user = getattr(getattr(event, "from_user", None), "id", None)
-    message_id = getattr(message, "message_id", None)
     business = getattr(message, "business_connection_id", None)
     topic = getattr(getattr(message, "direct_messages_topic", None), "topic_id", None)
     return Scope(
         chat=chat,
         lang=language,
         user=user,
-        id=message_id,
         inline=None,
         business=business,
         category=category,


### PR DESCRIPTION
## Summary
- remove the `id` attribute from the `Scope` value object
- stop populating `Scope` with the Telegram message identifier when building a scope

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfe588f53083309987b55fca63fe20