### PR TITLE
Remove deprecated ThumbWatch constant

### DIFF
--- a/domain/constants.py
+++ b/domain/constants.py
@@ -1,11 +1,10 @@
 from typing import Final
 
-__all__ = ["TextLimit", "CaptionLimit", "AlbumFloor", "AlbumCeiling", "AlbumBlend", "ThumbWatch"]
+__all__ = ["TextLimit", "CaptionLimit", "AlbumFloor", "AlbumCeiling", "AlbumBlend"]
 
 TextLimit: Final = 4096
 CaptionLimit: Final = 1024
 AlbumFloor: Final = 2
 AlbumCeiling: Final = 10
 AlbumBlend: Final = {"photo", "video"}
-ThumbWatch: Final[bool] = False
 


### PR DESCRIPTION
## Summary
- remove the ThumbWatch constant from domain constants and drop it from the public export list

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfe63fe818833085fd2b8764cbc3cb