### PR TITLE
Refine history repository serialization naming

### DIFF
--- a/tests/test_historyrepo_serialization.py
+++ b/tests/test_historyrepo_serialization.py
@@ -29,7 +29,7 @@ def test_to_dict_uses_canonical_keys():
     )
     entry = Entry(state="s", view="v", messages=[msg], root=True)
 
-    payload = repo._to_dict(entry)
+    payload = repo._dump(entry)
     assert payload["root"] is True
     assert payload["state"] == "s"
     assert payload["view"] == "v"
@@ -61,7 +61,7 @@ def test_from_dict_reads_canonical_keys():
         ],
     }
 
-    entry = repo._from_dict(data)
+    entry = repo._load(data)
     assert entry.state == "s"
     assert entry.view == "v"
     assert entry.root is True
@@ -92,7 +92,7 @@ def test_from_dict_rejects_legacy_keys():
     }
 
     with pytest.raises(ValueError):
-        repo._from_dict(data)
+        repo._load(data)
 
 
 def test_from_dict_requires_automated_flag():
@@ -109,4 +109,4 @@ def test_from_dict_requires_automated_flag():
     }
 
     with pytest.raises(ValueError):
-        repo._from_dict(data)
+        repo._load(data)


### PR DESCRIPTION
## Summary
- replace the history repository helper functions with codec classes that expose single-word method names
- rename the internal dump/load helpers to meet the naming constraints and update the serialization test suite

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfe8d412308330b3c2a8c2df0b9aaf