### PR TITLE
Adopt single-word album naming

### DIFF
--- a/Renames.md
+++ b/Renames.md
@@ -1,0 +1,26 @@
+# Renaming Plan
+
+## Completed updates
+
+The rendering album module has been switched to single-word identifiers:
+
+| Previous name | New name | Notes |
+| --- | --- | --- |
+| `validate_group` | `validate` | Entry point for album validation. |
+| `album_kind` | `nature` | Returns album media classification. |
+| `album_compatible` | `aligned` | Checks whether two albums can be edited in place. |
+| `_group_invalid_reasons` | `_audit` | Collects validation issues for albums. |
+| `invalid_size` | `limit` | Exception flag tracking size violations. |
+| `forbidden_types` | `forbidden` | Exception flag for disallowed media kinds. |
+| `audio_mixed` | `audio` | Exception flag for mixed audio albums. |
+| `document_mixed` | `document` | Exception flag for mixed document albums. |
+
+## Remaining work
+
+Additional modules still use snake_case identifiers. Future steps:
+
+1. Rendering decision helpers should be collapsed or renamed to single-word forms.
+2. Configuration objects (e.g., infrastructure settings) require one-word field names.
+3. Application service layers include numerous helper variables with underscores that need replacement or refactoring.
+
+This staged approach keeps the codebase functional while progressively moving every identifier to the one-word convention.

--- a/adapters/telegram/media.py
+++ b/adapters/telegram/media.py
@@ -21,7 +21,7 @@ from ...domain.constants import CaptionLimit
 from ...domain.entity.media import MediaItem, MediaType
 from ...domain.error import MessageEditForbidden, NavigatorError, CaptionTooLong
 from ...domain.log.emit import jlog
-from ...domain.service.rendering.album import validate_group, MediaGroupInvalid
+from ...domain.service.rendering.album import MediaGroupInvalid, validate
 from ...domain.util.path import local, remote
 from ...domain.log.code import LogCode
 
@@ -127,7 +127,7 @@ def group_to_input(items: List[MediaItem], extra: Dict[str, Any] | None = None, 
                    truncate: bool = False) -> List[InputMedia]:
     kinds = [getattr(i.type, "value", None) for i in (items or [])]
     try:
-        validate_group(items)
+        validate(items)
     except NavigatorError as e:
         if isinstance(e, MediaGroupInvalid):
             jlog(
@@ -137,10 +137,10 @@ def group_to_input(items: List[MediaItem], extra: Dict[str, Any] | None = None, 
                 kind="group_invalid",
                 flags={
                     "empty": e.empty,
-                    "size": e.invalid_size,
-                    "forbidden_types": e.forbidden_types,
-                    "audio_mixed": e.audio_mixed,
-                    "document_mixed": e.document_mixed,
+                    "limit": e.limit,
+                    "forbidden": e.forbidden,
+                    "audio": e.audio,
+                    "document": e.document,
                 },
                 types=kinds,
             )

--- a/application/service/view/orchestrator.py
+++ b/application/service/view/orchestrator.py
@@ -16,7 +16,7 @@ from ....domain.error import MessageNotChanged, MessageEditForbidden, EmptyPaylo
 from ....domain.port.message import MessageGateway, Result
 from ....domain.service.rendering import decision
 from ....domain.service.rendering.config import RenderingConfig
-from ....domain.service.rendering.album import album_compatible
+from ....domain.service.rendering.album import aligned
 from ....domain.service.rendering.helpers import classify, match
 from ....domain.util.path import remote, local
 from ....domain.value.content import Payload
@@ -329,7 +329,7 @@ class ViewOrchestrator:
         if (not inline) and old and new and getattr(old[0], "group", None) and getattr(new[0], "group", None):
             old_group = old[0].group or []
             new_group = new[0].group or []
-            if album_compatible(old_group, new_group):
+            if aligned(old_group, new_group):
                 ids = self._album_ids(old[0])
 
                 # --- extra (глобально для группы) ---

--- a/domain/service/rendering/album.py
+++ b/domain/service/rendering/album.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Set, Literal
+from typing import List, Literal, Optional, Set
 
 from ...constants import AlbumBlend, AlbumCeiling, AlbumFloor
 from ...entity.media import MediaItem, MediaType
@@ -10,63 +10,63 @@ class MediaGroupInvalid(NavigatorError):
             self,
             *,
             empty: bool,
-            invalid_size: bool,
-            forbidden_types: bool,
-            audio_mixed: bool,
-            document_mixed: bool,
+            limit: bool,
+            forbidden: bool,
+            audio: bool,
+            document: bool,
     ):
         self.empty = empty
-        self.invalid_size = invalid_size
-        self.forbidden_types = forbidden_types
-        self.audio_mixed = audio_mixed
-        self.document_mixed = document_mixed
+        self.limit = limit
+        self.forbidden = forbidden
+        self.audio = audio
+        self.document = document
         super().__init__("group_invalid")
 
 
-def _group_invalid_reasons(items: Optional[List[MediaItem]]) -> List[str]:
-    reasons = []
+def _audit(items: Optional[List[MediaItem]]) -> List[str]:
+    issues: List[str] = []
     if not items:
-        reasons.append("empty")
-        return reasons
+        issues.append("empty")
+        return issues
     if len(items) < AlbumFloor or len(items) > AlbumCeiling:
-        reasons.append("size")
-    types: Set[MediaType] = {i.type for i in items}
-    if types & {MediaType.ANIMATION, MediaType.VOICE, MediaType.VIDEO_NOTE}:
-        reasons.append("forbidden_types")
-    if MediaType.AUDIO in types and types != {MediaType.AUDIO}:
-        reasons.append("audio_mixed")
-    if MediaType.DOCUMENT in types and types != {MediaType.DOCUMENT}:
-        reasons.append("document_mixed")
-    return reasons
+        issues.append("limit")
+    kinds: Set[MediaType] = {item.type for item in items}
+    if kinds & {MediaType.ANIMATION, MediaType.VOICE, MediaType.VIDEO_NOTE}:
+        issues.append("forbidden")
+    if MediaType.AUDIO in kinds and kinds != {MediaType.AUDIO}:
+        issues.append("audio")
+    if MediaType.DOCUMENT in kinds and kinds != {MediaType.DOCUMENT}:
+        issues.append("document")
+    return issues
 
 
-def validate_group(items: List[MediaItem]) -> None:
-    reasons = _group_invalid_reasons(items)
-    if reasons:
+def validate(items: List[MediaItem]) -> None:
+    issues = _audit(items)
+    if issues:
         raise MediaGroupInvalid(
-            empty="empty" in reasons,
-            invalid_size="size" in reasons,
-            forbidden_types="forbidden_types" in reasons,
-            audio_mixed="audio_mixed" in reasons,
-            document_mixed="document_mixed" in reasons,
+            empty="empty" in issues,
+            limit="limit" in issues,
+            forbidden="forbidden" in issues,
+            audio="audio" in issues,
+            document="document" in issues,
         )
 
 
-def album_kind(items: List[MediaItem]) -> Literal["audio", "document", "mixed"]:
-    types = {i.type for i in items or []}
-    if types == {MediaType.AUDIO}:
+def nature(items: List[MediaItem]) -> Literal["audio", "document", "mixed"]:
+    kinds = {item.type for item in items or []}
+    if kinds == {MediaType.AUDIO}:
         return "audio"
-    if types == {MediaType.DOCUMENT}:
+    if kinds == {MediaType.DOCUMENT}:
         return "document"
     return "mixed"
 
 
-def album_compatible(old: List[MediaItem], new: List[MediaItem]) -> bool:
+def aligned(old: List[MediaItem], new: List[MediaItem]) -> bool:
     if len(old) != len(new):
         return False
-    k = album_kind(old)
-    if k == "audio":
-        return all(i.type == MediaType.AUDIO for i in new)
-    if k == "document":
-        return all(i.type == MediaType.DOCUMENT for i in new)
-    return all(i.type.value in AlbumBlend for i in new)
+    mood = nature(old)
+    if mood == "audio":
+        return all(item.type == MediaType.AUDIO for item in new)
+    if mood == "document":
+        return all(item.type == MediaType.DOCUMENT for item in new)
+    return all(item.type.value in AlbumBlend for item in new)


### PR DESCRIPTION
## Summary
- rename album validation helpers to single-word forms and adjust exception flags
- update album consumers to reference the new names and flags
- document the current renaming plan and outline remaining work

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfef1890808330b34ebd7d385a51c4