### PR TITLE
Remove inline media id heuristic log code

### DIFF
--- a/domain/log/code.py
+++ b/domain/log/code.py
@@ -15,7 +15,6 @@ class LogCode(Enum):
     INLINE_DELETE_SEND_FORBIDDEN = "inline_delete_send_forbidden"
     INLINE_TAIL_DELETE_IDS = "inline_tail_delete_ids"
     INLINE_REMAP_DELETE_SEND = "inline_remap_delete_send"
-    INLINE_MEDIA_ID_HEURISTIC = "inline_media_id_heuristic"  # используется в варианте 1.3B
 
     # Albums
     ALBUM_PARTIAL_OK = "album_partial_ok"


### PR DESCRIPTION
## Summary
- remove the unused `INLINE_MEDIA_ID_HEURISTIC` entry from the logging enum

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cffbc892908330971613d33d644014