### PR TITLE
Stop dropping degraded message text during restoration

### DIFF
--- a/application/service/view/restorer.py
+++ b/application/service/view/restorer.py
@@ -69,8 +69,7 @@ class ViewRestorer:
 
     @staticmethod
     def _static_restore_msg(m) -> Payload:
-        drop_text = bool((getattr(m, "extra", {}) or {}).get("degraded"))
-        text = None if drop_text else getattr(m, "text", None)
+        text = getattr(m, "text", None)
 
         if text is None and getattr(m, "media", None):
             cap = getattr(m.media, "caption", None)


### PR DESCRIPTION
## Summary
- always reuse stored message text during static restoration instead of consulting the degraded flag
- keep the caption escape fallback for media entries so caption-only messages still render

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cffe88d278833093a254645fdd2fc8