### PR TITLE
Simplify Telegram error patterns and add tests

### DIFF
--- a/adapters/telegram/gateway/patterns.py
+++ b/adapters/telegram/gateway/patterns.py
@@ -1,50 +1,43 @@
-NOT_MODIFIED = [
-    "message is not modified",
-    "сообщение не изменено",
-    "сообщение не изменилось",
-    "mensaje no modificado",
-    "le message n'a pas été modifié",
-    "nachricht wurde nicht geändert",
-    "messaggio non modificato",
-    "mensagem não modificada",
-    "mesaj değiştirilmedi",
-    "wiadomość nie została zmieniona",
-]
+"""Canonical Bot API error message fragments used by the Telegram gateway.
 
-EDIT_FORBIDDEN = [
+The official cloud Bot API (v9.2) responds with English descriptions only, and
+aiogram 3.22.0 surfaces these descriptions verbatim. We therefore keep a small
+set of English fragments that are known to precede the explanatory part of the
+errors. See https://core.telegram.org/bots/api#making-requests and
+https://docs.aiogram.dev/en/v3.22.0/api/exceptions/ for details.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ErrorPatterns:
+    """Container with normalized message fragments for a Bot API error."""
+
+    patterns: tuple[str, ...]
+
+    @classmethod
+    def from_phrases(cls, *phrases: str) -> ErrorPatterns:
+        normalized = tuple(phrase.lower() for phrase in phrases)
+        return cls(patterns=normalized)
+
+    def matches(self, message: str) -> bool:
+        """Return ``True`` if *message* contains one of the stored fragments."""
+
+        lowered = message.lower()
+        return any(fragment in lowered for fragment in self.patterns)
+
+
+NOT_MODIFIED = ErrorPatterns.from_phrases("message is not modified")
+
+EDIT_FORBIDDEN = ErrorPatterns.from_phrases(
     "message can't be edited",
     "bot can't edit message",
     "message is not editable",
-    "can be edited only within 48 hours",
-    "not modified by the bot",
+    "message can be edited only within 48 hours",
+)
 
-    "нельзя редактировать сообщение",
-    "сообщение нельзя редактировать",
-    "сообщение не редактируется",
-    "можно редактировать только в течение 48 часов",
 
-    "no se puede editar el mensaje",
-    "el mensaje no se puede editar",
-    "solo se puede editar durante 48 horas",
-
-    "le message ne peut pas être modifié",
-    "peut être modifié uniquement pendant 48 heures",
-
-    "nachricht kann nicht bearbeitet werden",
-    "kann nur innerhalb von 48 stunden bearbeitet werden",
-
-    "il messaggio non può essere modificato",
-    "può essere modificato solo entro 48 ore",
-
-    "a mensagem não pode ser editada",
-    "pode ser editada apenas dentro de 48 horas",
-
-    "mesaj düzenlenemez",
-    "yalnızca 48 saat içinde düzenlenebilir",
-
-    "wiadomości nie można edytować",
-    "można edytować tylko w ciągu 48 godzin",
-
-    "повідомлення не можна редагувати",
-    "можна редагувати лише протягом 48 годин",
-]
+__all__ = ["ErrorPatterns", "NOT_MODIFIED", "EDIT_FORBIDDEN"]

--- a/domain/log/code.py
+++ b/domain/log/code.py
@@ -53,6 +53,7 @@ class LogCode(Enum):
     GATEWAY_DELETE_FAIL = "gateway_delete_fail"
     GATEWAY_NOTIFY_EMPTY = "gateway_notify_empty"
     TELEGRAM_RETRY = "telegram_retry"
+    TELEGRAM_UNHANDLED_ERROR = "telegram_unhandled_error"
 
     # Extras / Serializer
     EXTRA_FILTERED_OUT = "extra_filtered_out"

--- a/tests/adapters/telegram/gateway/test_retry.py
+++ b/tests/adapters/telegram/gateway/test_retry.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import sys
+from collections.abc import Awaitable
+from pathlib import Path
+from typing import TypeVar
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[5]))
+
+from navigator.adapters.telegram.gateway.retry import invoke
+from navigator.domain.error import MessageEditForbidden, MessageNotChanged
+from navigator.domain.log.code import LogCode
+
+
+class DummyTelegramError(Exception):
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.message = message
+
+
+FakeAiogramError = type(
+    "FakeAiogramError",
+    (DummyTelegramError,),
+    {"__module__": "aiogram.testing"},
+)
+
+T = TypeVar("T")
+
+
+def run(coro: Awaitable[T]) -> T:  # noqa: UP047 - Python 3.11 runtime does not support PEP 695 syntax.
+    return asyncio.run(coro)
+
+
+def test_invoke_translates_not_modified() -> None:
+    async def action() -> None:
+        raise DummyTelegramError(
+            "Bad Request: message is not modified: nothing to change",
+        )
+
+    with pytest.raises(MessageNotChanged):
+        run(invoke(action))
+
+
+def test_invoke_translates_edit_forbidden() -> None:
+    async def action() -> None:
+        raise DummyTelegramError(
+            "Bad Request: message can be edited only within 48 hours",
+        )
+
+    with pytest.raises(MessageEditForbidden):
+        run(invoke(action))
+
+
+def test_invoke_logs_unhandled_aiogram_error(caplog: pytest.LogCaptureFixture) -> None:
+    async def action() -> None:
+        raise FakeAiogramError("Bad Request: some brand new message")
+
+    caplog.set_level(logging.WARNING)
+
+    with pytest.raises(FakeAiogramError):
+        run(invoke(action))
+
+    payloads = [json.loads(record.getMessage()) for record in caplog.records]
+    assert any(
+        payload.get("code") == LogCode.TELEGRAM_UNHANDLED_ERROR.value
+        for payload in payloads
+    )


### PR DESCRIPTION
## Summary
- document the reliance on canonical English Bot API messages and wrap them in a small helper
- update retry handling to use the helper and emit a warning when a Telegram error is not recognized
- add coverage for the gateway retry helper, including the new logging path

## Testing
- ruff check adapters/telegram/gateway/patterns.py adapters/telegram/gateway/retry.py tests/adapters/telegram/gateway/test_retry.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d0017881c88330b552e447f9e4cdd1