### PR TITLE
Refine logging nomenclature

### DIFF
--- a/application/log/emit.py
+++ b/application/log/emit.py
@@ -1,6 +1,6 @@
 import logging
 
-from ...domain.log.emit import jlog, set_redaction_mode
+from ...domain.log.emit import calibrate, jlog
 
 
 def debug(logger, code, **fields):
@@ -19,4 +19,4 @@ def error(logger, code, **fields):
     jlog(logger, logging.ERROR, code, **fields)
 
 
-__all__ = ["jlog", "debug", "info", "warning", "error", "set_redaction_mode"]
+__all__ = ["jlog", "debug", "info", "warning", "error", "calibrate"]

--- a/composition/__init__.py
+++ b/composition/__init__.py
@@ -1,20 +1,20 @@
 from typing import Optional, Any
 
-from ..adapters.factory.registry import default as reg_default
-from ..application.log.emit import set_redaction_mode
+from ..adapters.factory.registry import default as fallback
+from ..application.log.emit import calibrate
 from ..infrastructure.config import SETTINGS
 from ..infrastructure.di.container import AppContainer
 from ..infrastructure.locks import configure
 from ..presentation.navigator import Navigator
-from ..presentation.telegram.scope import make_scope
+from ..presentation.telegram.scope import make_scope as forge
 
 
 async def assemble(event: Any, state: Any, registry: Optional[Any] = None) -> Navigator:
-    set_redaction_mode(SETTINGS.log_redaction_mode)
+    calibrate(SETTINGS.log_redaction_mode)
     configure()
-    reg = registry if registry is not None else reg_default
+    reg = registry if registry is not None else fallback
     container = AppContainer(event=event, state=state, registry=reg)
-    scope = make_scope(event)
+    scope = forge(event)
     return Navigator(
         appender=container.appender(),
         swapper=container.swapper(),

--- a/domain/log/emit.py
+++ b/domain/log/emit.py
@@ -8,49 +8,49 @@ from typing import Any, Dict
 from .code import LogCode
 
 REDACT_KEYS = {"path", "inline", "business", "url", "caption", "thumb"}
-_DEFAULT_REDACTION_MODE = "safe"
-_redaction_mode = _DEFAULT_REDACTION_MODE
+DEFAULT_MODE = "safe"
+_mode = DEFAULT_MODE
 
 
-def set_redaction_mode(mode: str) -> None:
+def calibrate(mode: str) -> None:
     """Configure log redaction mode."""
 
-    global _redaction_mode
-    normalized = (mode or _DEFAULT_REDACTION_MODE).lower()
-    if normalized not in {"debug", "safe", "paranoid"}:
-        normalized = _DEFAULT_REDACTION_MODE
-    _redaction_mode = normalized
+    global _mode
+    normal = (mode or DEFAULT_MODE).lower()
+    if normal not in {"debug", "safe", "paranoid"}:
+        normal = DEFAULT_MODE
+    _mode = normal
 
 
-def _keys_to_redact() -> set[str]:
+def _targets() -> set[str]:
     base = set(REDACT_KEYS)
-    if _redaction_mode == "paranoid":
+    if _mode == "paranoid":
         base.update({"text", "entities"})
     return base
 
 
-def _redact(v: Any) -> Any:
+def _filter(v: Any) -> Any:
     if v is None:
         return None
     if isinstance(v, dict):
-        keys = _keys_to_redact()
+        keys = _targets()
         return {
-            k: ("***" if k in keys and _redaction_mode != "debug" else _redact(vv))
+            k: ("***" if k in keys and _mode != "debug" else _filter(vv))
             for k, vv in v.items()
         }
     if isinstance(v, (list, tuple)):
-        return [_redact(x) for x in v]
+        return [_filter(x) for x in v]
     return v
 
 
 def jlog(logger: logging.Logger, level: int, code: LogCode, **fields: Any) -> None:
     if not logger.isEnabledFor(level):
         return
-    redacted_fields = _redact(dict(fields))
-    exc_info = bool(redacted_fields.pop("exc_info", False))
+    scrubbed = _filter(dict(fields))
+    trace = bool(scrubbed.pop("exc_info", False))
     payload: Dict[str, Any] = {
         "ts": datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z"),
         "code": code.value,
-        **redacted_fields,
+        **scrubbed,
     }
-    logger.log(level, json.dumps(payload, ensure_ascii=False, default=str), exc_info=exc_info)
+    logger.log(level, json.dumps(payload, ensure_ascii=False, default=str), exc_info=trace)


### PR DESCRIPTION
## Summary
- rename the redaction configuration API in the logging layer to the single-word name `calibrate`
- propagate the new naming through the composition bootstrap and application logging facade
- tighten helper terminology in the redaction filter to avoid underscored identifiers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d008c4880c8330895c373723ffe3f3