### PR TITLE
Rename payload mapping and policy identifiers

### DIFF
--- a/application/map/entry.py
+++ b/application/map/entry.py
@@ -14,7 +14,7 @@ class EntryMapper:
 
     def convert(
             self,
-            result: "NodeResult",
+            outcome: "Outcome",
             payloads: List[Payload],
             state: Optional[str],
             view: Optional[str],
@@ -28,8 +28,8 @@ class EntryMapper:
         msgs: List[Msg] = []
         now = datetime.now(timezone.utc)
         for idx, payload in enumerate(payloads):
-            mid = result.ids[idx]
-            meta = result.metas[idx] if idx < len(result.metas) else {}
+            mid = outcome.ids[idx]
+            meta = outcome.metas[idx] if idx < len(outcome.metas) else {}
             k = meta.get("kind")
             if not isinstance(k, str):
                 raise ValueError("meta_missing_kind")
@@ -80,7 +80,7 @@ class EntryMapper:
                 length = 0
 
             extra = cleanse(source, length=length)
-            aux = result.extras[idx] if idx < len(result.extras) else []
+            aux = outcome.extras[idx] if idx < len(outcome.extras) else []
             msgs.append(
                 Msg(
                     id=mid,
@@ -100,11 +100,11 @@ class EntryMapper:
         return Entry(state=state, view=vk, messages=msgs, root=bool(root))
 
 
-class NodeResult:
+class Outcome:
     def __init__(self, ids: List[int], extras: List[List[int]], metas: List[dict]):
         self.ids = list(ids)
         self.extras = [list(x) for x in (extras or [])]
         self.metas = [dict(m or {}) for m in (metas or [])]
 
 
-__all__ = ["EntryMapper", "NodeResult"]
+__all__ = ["EntryMapper", "Outcome"]

--- a/application/service/view/orchestrator.py
+++ b/application/service/view/orchestrator.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Optional, List, Any
 
 from ..view.inline import InlineStrategy
-from .policy import payload_with_allowed_reply
+from .policy import adapt
 from ...internal import policy as _pol
 from ...internal.policy import shield
 from ...log.decorators import log_io
@@ -138,7 +138,7 @@ class ViewOrchestrator:
             dec: decision.Decision,
     ) -> Optional[RenderResult]:
         shield(scope, payload)
-        payload = payload_with_allowed_reply(scope, payload)
+        payload = adapt(scope, payload)
 
         def _head_msg(e):
             return self._head_msg(e)
@@ -268,7 +268,7 @@ class ViewOrchestrator:
             last_node: Optional[Entry],
             inline: bool,
     ) -> Optional[RenderResultNode]:
-        new = [payload_with_allowed_reply(scope, p) for p in payloads]
+        new = [adapt(scope, p) for p in payloads]
         if inline:
             original_len = len(new)
             if original_len > 1:

--- a/application/service/view/policy.py
+++ b/application/service/view/policy.py
@@ -9,7 +9,7 @@ from ....domain.value.message import Scope
 _INLINE_KEYBOARD_KIND = "InlineKeyboardMarkup"
 
 
-def allowed_reply(scope: Scope, reply: Optional[Markup]) -> Optional[Markup]:
+def permit(scope: Scope, reply: Optional[Markup]) -> Optional[Markup]:
     """Return reply markup allowed for the given scope.
 
     Scope-specific restrictions limit business chats and non-private/group chats to
@@ -28,11 +28,11 @@ def allowed_reply(scope: Scope, reply: Optional[Markup]) -> Optional[Markup]:
     return reply if reply.kind == _INLINE_KEYBOARD_KIND else None
 
 
-def payload_with_allowed_reply(scope: Scope, payload: Payload) -> Payload:
-    allowed = allowed_reply(scope, payload.reply)
+def adapt(scope: Scope, payload: Payload) -> Payload:
+    allowed = permit(scope, payload.reply)
     if allowed is payload.reply:
         return payload
     return payload.morph(reply=allowed)
 
 
-__all__ = ["allowed_reply", "payload_with_allowed_reply"]
+__all__ = ["permit", "adapt"]

--- a/application/usecase/back.py
+++ b/application/usecase/back.py
@@ -35,7 +35,7 @@ class Rewinder:
         self._last_repo = last_repo
 
     @log_io(None, None, None)
-    async def execute(self, scope: Scope, handler_data: Dict[str, Any]) -> None:
+    async def execute(self, scope: Scope, context: Dict[str, Any]) -> None:
         history = await self._history_repo.get_history()
         jlog(
             logger,
@@ -50,9 +50,9 @@ class Rewinder:
         entry_from = history[-1]
         entry_to = history[-2]
         is_inline = bool(scope.inline)
-        fsm_data: Dict[str, Any] = await self._state_repo.get_data()
-        merged_handler_data = {**fsm_data, **handler_data}
-        restored_payloads = await self._restorer.restore_node(entry_to, merged_handler_data, inline=is_inline)
+        memory: Dict[str, Any] = await self._state_repo.get_data()
+        merged = {**memory, **context}
+        restored_payloads = await self._restorer.restore_node(entry_to, merged, inline=is_inline)
         resolved_payloads = [normalize(p) for p in restored_payloads]
         if not is_inline:
             render_result = await self._orchestrator.render_node(

--- a/application/usecase/replace.py
+++ b/application/usecase/replace.py
@@ -3,13 +3,13 @@ from typing import List
 
 from ..log.decorators import log_io
 from ..log.emit import jlog
-from ..map.entry import EntryMapper, NodeResult
+from ..map.entry import EntryMapper, Outcome
 from ..service.view.orchestrator import ViewOrchestrator
-from ..service.view.policy import payload_with_allowed_reply
+from ..service.view.policy import adapt
 from ...domain.port.history import HistoryRepository
 from ...domain.port.last import LastMessageRepository
 from ...domain.port.state import StateRepository
-from ...domain.service.history import policy as history_policy
+from ...domain.service.history import policy as chronicle
 from ...domain.value.content import Payload, normalize
 from ...domain.value.message import Scope
 from ...domain.log.code import LogCode
@@ -20,48 +20,48 @@ logger = logging.getLogger(__name__)
 class Swapper:
     def __init__(
             self,
-            history_repo: HistoryRepository,
-            state_repo: StateRepository,
-            last_repo: LastMessageRepository,
+            archive: HistoryRepository,
+            state: StateRepository,
+            tail: LastMessageRepository,
             orchestrator: ViewOrchestrator,
             mapper: EntryMapper,
-            history_limit: int,
+            limit: int,
     ):
-        self._history_repo = history_repo
-        self._state_repo = state_repo
-        self._last_repo = last_repo
+        self._archive = archive
+        self._state = state
+        self._tail = tail
         self._orchestrator = orchestrator
         self._mapper = mapper
-        self._history_limit = history_limit
+        self._limit = limit
 
     @log_io(None, None, None)
-    async def execute(self, scope: Scope, payloads: List[Payload]) -> None:
-        resolved = [payload_with_allowed_reply(scope, normalize(p)) for p in payloads]
-        history = await self._history_repo.get_history()
-        jlog(logger, logging.DEBUG, LogCode.HISTORY_LOAD, op="replace", history={"len": len(history)})
-        last_entry = history[-1] if history else None
-        rr = await self._orchestrator.render_node(
-            "replace", scope, resolved, last_entry, inline=bool(scope.inline)
+    async def execute(self, scope: Scope, bundle: List[Payload]) -> None:
+        adjusted = [adapt(scope, normalize(p)) for p in bundle]
+        records = await self._archive.get_history()
+        jlog(logger, logging.DEBUG, LogCode.HISTORY_LOAD, op="replace", history={"len": len(records)})
+        trail = records[-1] if records else None
+        render = await self._orchestrator.render_node(
+            "replace", scope, adjusted, trail, inline=bool(scope.inline)
         )
-        if not rr or not rr.ids or not rr.changed:
+        if not render or not render.ids or not render.changed:
             jlog(logger, logging.INFO, LogCode.RENDER_SKIP, op="replace")
             return
-        current_state = await self._state_repo.get_state()
+        status = await self._state.get_state()
 
-        effective_payloads = resolved[:len(rr.ids)]
-        new_entry = self._mapper.convert(
-            NodeResult(rr.ids, rr.extras, rr.metas),
-            effective_payloads,
-            current_state,
-            last_entry.view if last_entry else None,
-            root=bool(last_entry.root) if last_entry else False,
-            base=last_entry,
+        usable = adjusted[:len(render.ids)]
+        entry = self._mapper.convert(
+            Outcome(render.ids, render.extras, render.metas),
+            usable,
+            status,
+            trail.view if trail else None,
+            root=bool(trail.root) if trail else False,
+            base=trail,
         )
-        if not history:
-            updated = [new_entry]
+        if not records:
+            timeline = [entry]
         else:
-            updated = history[:-1] + [new_entry]
+            timeline = records[:-1] + [entry]
         from ..service.store import persist
         await persist(
-            self._history_repo, self._last_repo, history_policy, self._history_limit, updated, op="replace"
+            self._archive, self._tail, chronicle, self._limit, timeline, op="replace"
         )

--- a/application/usecase/set.py
+++ b/application/usecase/set.py
@@ -38,7 +38,7 @@ class Setter:
             self,
             scope: Scope,
             target_state: str,
-            handler_data: Dict[str, Any],
+            context: Dict[str, Any],
     ) -> None:
         history = await self._history_repo.get_history()
         jlog(
@@ -72,9 +72,9 @@ class Setter:
         jlog(logger, logging.DEBUG, LogCode.HISTORY_SAVE, op="set", history={"len": len(new_history)})
         await self._state_repo.set_state(target_entry.state)
         jlog(logger, logging.INFO, LogCode.STATE_SET, op="set", state={"target": target_entry.state})
-        fsm_data = await self._state_repo.get_data()
-        merged_handler_data = {**fsm_data, **handler_data}
-        restored_payloads = await self._restorer.restore_node(target_entry, merged_handler_data, inline=is_inline)
+        memory = await self._state_repo.get_data()
+        merged = {**memory, **context}
+        restored_payloads = await self._restorer.restore_node(target_entry, merged, inline=is_inline)
         resolved_payloads = [normalize(p) for p in restored_payloads]
         if not is_inline:
             render_result = await self._orchestrator.render_node(

--- a/presentation/telegram/router.py
+++ b/presentation/telegram/router.py
@@ -30,8 +30,8 @@ async def back_handler(cb: CallbackQuery, navigator: Navigator, **data: Dict[str
     try:
         jlog(logger, logging.INFO, LogCode.ROUTER_BACK_ENTER, kind="callback",
              scope={"chat": cb.message.chat.id if cb.message else 0, "inline": bool(cb.inline_message_id)})
-        handler_data = {**data, "event": cb}
-        await navigator.back(handler_data=handler_data)
+        context = {**data, "event": cb}
+        await navigator.back(context=context)
         jlog(logger, logging.INFO, LogCode.ROUTER_BACK_DONE, kind="callback",
              scope={"chat": cb.message.chat.id if cb.message else 0, "inline": bool(cb.inline_message_id)})
         await cb.answer()
@@ -54,8 +54,8 @@ async def back_text_handler(msg: Message, navigator: Navigator, **data: Dict[str
     try:
         jlog(logger, logging.INFO, LogCode.ROUTER_BACK_ENTER, kind="text",
              scope={"chat": msg.chat.id, "inline": False})
-        handler_data = {**data, "event": msg}
-        await navigator.back(handler_data=handler_data)
+        context = {**data, "event": msg}
+        await navigator.back(context=context)
         jlog(logger, logging.INFO, LogCode.ROUTER_BACK_DONE, kind="text",
              scope={"chat": msg.chat.id, "inline": False})
     except HistoryEmpty:


### PR DESCRIPTION
## Summary
- rename the payload mapping helpers to single-word names such as `convert` and `collect`, updating callers accordingly
- rename the reply policy helpers to `permit` and `adapt` and apply the new terminology through the orchestrator and use cases
- propagate context terminology through navigator back/set flows and adopt the new `Outcome` mapper container

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d00b9242a4833087f4ac0e900e042b