### PR TITLE
Refine naming plan and update config terms

### DIFF
--- a/Renaming.md
+++ b/Renaming.md
@@ -1,0 +1,36 @@
+# Renaming Strategy
+
+## Objectives
+- Converge every identifier on a single clear word (classes may use two) without internal underscores.
+- Keep the code semantics intact by selecting concise synonyms that still convey intent.
+- Tackle the refactor in batches ordered by dependency depth to reduce churn.
+
+## Completed Adjustments
+- `sitecustomize.py`: renamed the package pointer variable to `_package` to eliminate the internal underscore.
+- `infrastructure.config.Settings`: renamed fields to one-word synonyms (`retention`, `thumbguard`, `redaction`) and updated the container, rendering config, and composition bootstrap to use them.
+- Rendering configuration objects now expose the boolean guard as `thumbguard` so downstream checks use a compliant identifier.
+
+## Upcoming Phases
+1. **Infrastructure layer sweep**
+   - Rename locking utilities: e.g., `_LatchLike` methods such as `acquire`, `release`, `untether` stay, but helpers like `_key`, `_current`, `_LatchAdapter` need concise words (`_pivot`, `_active`, `_Latch`, etc.).
+   - Revisit dependency injection providers so every exposed factory/property (`history_repo`, `state_repo`, `temp_repo`) becomes a one-word noun (`archive`, `registry`, `stash`).
+2. **Application services**
+   - Replace underscored helpers in view orchestration (`_media_editable_inline`, `_reply_changed`) with short verbs (`_allowedit`, `_replydiff`).
+   - Align use case dependencies (`history_repo`, `last_repo`, `state_repo`) with the provider renames from phase 1.
+   - Simplify logging hooks (`log_io`) and payload mappers (`collect`, `convert`) to single-word verbs where necessary.
+3. **Adapters**
+   - Telegram gateway modules contain snake_case helpers (`retry_request`, `make_payload`); map each to crisp verbs (`retry`, `compose`).
+   - Storage adapters use `*_repo`/`*_keys` suffixes; collapse to standalone nouns (`ledger`, `vault`, `cursor`).
+4. **Domain model**
+   - Error hierarchy currently uses multiword class names (`MessageEditForbidden`); shorten to one- or two-word nouns (`EditBan`, `EditVoid`).
+   - Value objects expose attributes like `message_effect_id`; introduce alias layers so external API keys remain untouched while internal attributes become compliant (`effect`, `effectid` wrapper properties).
+   - Rendering helpers (`_text_extra_equal`, `_has_any_media`) should be renamed to minimal verbs (`_textequal`, `_hasmedia`).
+5. **Presentation layer and tests**
+   - Navigator API uses methods such as `get_id`; switch to `getid` via wrapper objects or redesign call sites to respect rule 3 by choosing substitute verbs (`fetch`, `mark`).
+   - Update test modules currently named `test_retry.py` to a one-word form like `retrycase.py` while keeping pytest discovery (`test` prefix) via module-level `pytestmark`.
+
+## Execution Notes
+- Progress through the dependency graph from lowest-level utilities upward, renaming call sites after each layer to maintain runnable builds.
+- Provide compatibility shims (temporary properties or wrappers) during transition phases when external APIs demand snake_case names.
+- After each batch, run the full test suite (`pytest`) and static analyzers (`ruff`, `mypy`) to ensure behavior parity.
+- Update documentation and developer guides to explain the new vocabulary once the renaming is complete.

--- a/application/service/view/orchestrator.py
+++ b/application/service/view/orchestrator.py
@@ -354,7 +354,7 @@ class ViewOrchestrator:
 
                 media_extra_changed = _media_affects_changed(old_e, new_e)
 
-                if self._rendering_config.thumb_watch:
+                if self._rendering_config.thumbguard:
                     if bool(old_e.get("has_thumb")) != bool(new_e.get("thumb") is not None):
                         media_extra_changed = True
 

--- a/composition/__init__.py
+++ b/composition/__init__.py
@@ -10,7 +10,7 @@ from ..presentation.telegram.scope import make_scope as forge
 
 
 async def assemble(event: Any, state: Any, ledger: Optional[Any] = None) -> Navigator:
-    calibrate(SETTINGS.log_redaction_mode)
+    calibrate(SETTINGS.redaction)
     configure()
     stock = ledger if ledger is not None else fallback
     container = AppContainer(event=event, state=state, ledger=stock)

--- a/domain/service/rendering/config.py
+++ b/domain/service/rendering/config.py
@@ -3,5 +3,5 @@ from dataclasses import dataclass
 
 @dataclass(frozen=True, slots=True)
 class RenderingConfig:
-    thumb_watch: bool = False
+    thumbguard: bool = False
 

--- a/domain/service/rendering/decision.py
+++ b/domain/service/rendering/decision.py
@@ -103,7 +103,7 @@ def _media_opts_split(e, config: RenderingConfig) -> tuple[_MediaCaptionOpts, _M
     edt = _MediaEditOpts(
         spoiler=bool(x.get("spoiler")),
         start=st,
-        thumb_present=(present if config.thumb_watch else False),
+        thumb_present=(present if config.thumbguard else False),
     )
     return cap, edt
 

--- a/infrastructure/config.py
+++ b/infrastructure/config.py
@@ -4,19 +4,19 @@ from pydantic import BaseModel, Field
 
 
 class Settings(BaseModel):
-    history_limit: int = Field(18, ge=1, le=200)
+    retention: int = Field(18, ge=1, le=200)
     chunk: int = Field(100, ge=1, le=100)
     truncate: bool = Field(False)
     strict_inline_media_path: bool = Field(True)
-    thumb_watch: bool = Field(False)
-    log_redaction_mode: str = Field("safe")
+    thumbguard: bool = Field(False)
+    redaction: str = Field("safe")
 
 
 SETTINGS = Settings(
-    history_limit=int(os.getenv("NAV_HISTORY_LIMIT", "18")),
+    retention=int(os.getenv("NAV_HISTORY_LIMIT", "18")),
     chunk=int(os.getenv("NAV_CHUNK", "100")),
     truncate=os.getenv("NAV_TRUNCATE", "0").lower() in {"1", "true", "yes"},
     strict_inline_media_path=os.getenv("NAV_STRICT_INLINE_MEDIA_PATH", "1").lower() in {"1", "true", "yes"},
-    thumb_watch=os.getenv("NAV_DETECT_THUMB_CHANGE", "0").lower() in {"1", "true", "yes"},
-    log_redaction_mode=os.getenv("NAV_LOG_REDACTION", "safe").lower(),
+    thumbguard=os.getenv("NAV_DETECT_THUMB_CHANGE", "0").lower() in {"1", "true", "yes"},
+    redaction=os.getenv("NAV_LOG_REDACTION", "safe").lower(),
 )

--- a/infrastructure/di/container.py
+++ b/infrastructure/di/container.py
@@ -31,7 +31,7 @@ class AppContainer(containers.DeclarativeContainer):
     state = providers.Dependency(instance_of=FSMContext)
     ledger = providers.Dependency(instance_of=ViewLedger)
 
-    history_limit = providers.Object(SETTINGS.history_limit)
+    retention = providers.Object(SETTINGS.retention)
     chunk = providers.Object(SETTINGS.chunk)
 
     markup_codec = providers.Singleton(AiogramMarkupCodec)
@@ -55,7 +55,7 @@ class AppContainer(containers.DeclarativeContainer):
         is_url_input_file=is_url_input_file,
         strict_inline_media_path=providers.Object(SETTINGS.strict_inline_media_path),
     )
-    rendering_config = providers.Object(RenderingConfig(thumb_watch=SETTINGS.thumb_watch))
+    rendering_config = providers.Object(RenderingConfig(thumbguard=SETTINGS.thumbguard))
     view_orchestrator = providers.Factory(
         ViewOrchestrator,
         gateway=gateway,
@@ -70,13 +70,13 @@ class AppContainer(containers.DeclarativeContainer):
         Appender,
         history_repo=history_repo, state_repo=state_repo, last_repo=last_repo,
         orchestrator=view_orchestrator,
-        mapper=entry_mapper, history_limit=history_limit,
+        mapper=entry_mapper, limit=retention,
     )
     swapper = providers.Factory(
         Swapper,
         history_repo=history_repo, state_repo=state_repo, last_repo=last_repo,
         orchestrator=view_orchestrator,
-        mapper=entry_mapper, history_limit=history_limit,
+        mapper=entry_mapper, limit=retention,
     )
     rewinder = providers.Factory(
         Rewinder,

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,8 +1,8 @@
 import sys
 from pathlib import Path
 
-_pkg_dir = Path(__file__).resolve().parent
-_parent = _pkg_dir.parent
+_package = Path(__file__).resolve().parent
+_parent = _package.parent
 
 if str(_parent) not in sys.path:
     sys.path.insert(0, str(_parent))


### PR DESCRIPTION
## Summary
- document a staged strategy for converting identifiers to single-word names
- rename configuration fields to single-word alternatives and update container wiring
- align rendering config and navigator orchestration checks with the new terminology

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d011a021ac8330be0622c56bee5248