### PR TITLE
Rename Telegram gateway helper identifiers

### DIFF
--- a/Renaming.md
+++ b/Renaming.md
@@ -16,6 +16,23 @@
 - Audit adapter-layer gateway helpers (e.g., `do_edit_text`, `reply_for_send`) and select concise replacements that respect the single-word rule.
 - Review protocol definitions so that method names like `get_state`, `set_state`, and `save_history` become single-word verbs without losing intent (e.g., `state`, `store`).
 
+## Gateway Renaming Plan
+
+| Scope | Legacy Identifier | Replacement |
+|-------|-------------------|-------------|
+| Telegram gateway helpers | `do_send` | `dispatch` |
+| Telegram gateway helpers | `do_edit_text` | `rewrite` |
+| Telegram gateway helpers | `do_edit_media` | `recast` |
+| Telegram gateway helpers | `do_edit_caption` | `retitle` |
+| Telegram gateway helpers | `do_edit_markup` | `remap` |
+| Telegram reply helpers | `reply_for_send`/`reply_for_edit` | `markup(codec, reply, *, edit)` |
+| Gateway logging helpers | Inline replacements for `log_edit_fail`/`log_edit_ok` | Inline `jlog` calls |
+
+## Upcoming Protocol Updates
+
+- Promote `MessageGateway` verbs such as `edit_text`, `edit_media`, `edit_caption`, and `edit_markup` to single-word alternatives once downstream call sites have adopted the helper renames listed above.
+- Consolidate result metadata fields (`media_type`, `file_id`, `group_items`) under single-word terms after aligning storage and rendering pipelines.
+
 ## Guidelines for Future Renames
 - When multiple contexts share similar operations, choose consistent vocabulary (e.g., prefer `store`/`load` across repositories).
 - Use existing domain terminology (history, tail, scope, ledger) to inform replacement words instead of inventing artificial compounds.

--- a/adapters/telegram/gateway/__init__.py
+++ b/adapters/telegram/gateway/__init__.py
@@ -6,8 +6,8 @@ from typing import List
 from aiogram import Bot
 
 from .delete import BatchDeleteRunner
-from .edit import do_edit_text, do_edit_media, do_edit_caption, do_edit_markup
-from .send import do_send
+from .edit import rewrite, recast, retitle, remap
+from .send import dispatch
 from .util import targets
 from ....domain.error import InlineUnsupported
 from ....domain.log.emit import jlog
@@ -32,19 +32,19 @@ class TelegramGateway(MessageGateway):
     async def send(self, scope: Scope, payload: Payload) -> Result:
         if scope.inline:
             raise InlineUnsupported("inline_send_not_supported")
-        return await do_send(self._bot, self._codec, scope, payload, truncate=self._truncate)
+        return await dispatch(self._bot, self._codec, scope, payload, truncate=self._truncate)
 
     async def edit_text(self, scope: Scope, message_id: int, payload: Payload) -> Result:
-        return await do_edit_text(self._bot, self._codec, scope, message_id, payload, truncate=self._truncate)
+        return await rewrite(self._bot, self._codec, scope, message_id, payload, truncate=self._truncate)
 
     async def edit_media(self, scope: Scope, message_id: int, payload: Payload) -> Result:
-        return await do_edit_media(self._bot, self._codec, scope, message_id, payload, truncate=self._truncate)
+        return await recast(self._bot, self._codec, scope, message_id, payload, truncate=self._truncate)
 
     async def edit_caption(self, scope: Scope, message_id: int, payload: Payload) -> Result:
-        return await do_edit_caption(self._bot, self._codec, scope, message_id, payload, truncate=self._truncate)
+        return await retitle(self._bot, self._codec, scope, message_id, payload, truncate=self._truncate)
 
     async def edit_markup(self, scope: Scope, message_id: int, payload: Payload) -> Result:
-        return await do_edit_markup(self._bot, self._codec, scope, message_id, payload)
+        return await remap(self._bot, self._codec, scope, message_id, payload)
 
     async def delete(self, scope: Scope, ids: List[int]) -> None:
         runner = BatchDeleteRunner(bot=self._bot, chunk=self._chunk)

--- a/adapters/telegram/gateway/send.py
+++ b/adapters/telegram/gateway/send.py
@@ -2,7 +2,7 @@ import logging
 from inspect import signature
 from typing import Any, Dict
 
-from .common import reply_for_send
+from .common import markup
 from .retry import invoke
 from .util import extract_meta
 from .util import targets as _targets
@@ -22,7 +22,7 @@ from ....domain.log.code import LogCode
 logger = logging.getLogger(__name__)
 
 
-async def do_send(bot, codec: MarkupCodec, scope: Scope, payload, *, truncate: bool = False) -> Result:
+async def dispatch(bot, codec: MarkupCodec, scope: Scope, payload, *, truncate: bool = False) -> Result:
     context = _targets(scope)
     inline = bool(scope.inline)
     allow_local = not inline
@@ -136,7 +136,7 @@ async def do_send(bot, codec: MarkupCodec, scope: Scope, payload, *, truncate: b
             call_kwargs: Dict[str, Any] = {
                 **context,
                 **{payload.media.type.value: tg_media},
-                "reply_markup": reply_for_send(codec, payload.reply),
+                "reply_markup": markup(codec, payload.reply, edit=False),
                 **caption_kwargs,
                 **media_kwargs,
             }
@@ -162,7 +162,7 @@ async def do_send(bot, codec: MarkupCodec, scope: Scope, payload, *, truncate: b
                 bot.send_message,
                 **context,
                 text=raw,
-                reply_markup=reply_for_send(codec, payload.reply),
+                reply_markup=markup(codec, payload.reply, edit=False),
                 link_preview_options=serializer.map_preview(payload.preview),
                 **text_kwargs,
             )


### PR DESCRIPTION
## Summary
- add a gateway renaming plan to Renaming.md to track single-word replacements
- rename Telegram gateway helper functions to single-word verbs and introduce a shared markup helper
- update the gateway entry point to invoke the renamed helpers and inline edit logging

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d01754e1c083309eed9bd1d2877429