### PR TITLE
Adopt single-word repository verbs

### DIFF
--- a/Renaming.md
+++ b/Renaming.md
@@ -9,12 +9,14 @@
 - Telegram router handlers now expose the callback handler as `retreat` and the text handler as `recall`, with `_tongue` providing locale detection.
 - Telegram scope builder renamed to `outline`, imported through the composition root as `forge`.
 - Navigator tail helper now relies on `_tailer` and uses `identifier`/`status` for clarity when referencing message identifiers and state values.
+- Domain storage contracts now use single-word verbs: history repositories `recall`/`archive`, state repositories `status`/`assign`/`diagram`/`capture`/`payload`, last message repositories `peek`/`mark`, and temporary repositories `collect`/`stash`.
+- Application service decorator `log_io` shortened to `trace`, with `augment` replacing the `extra_fn` callback for additional log context.
 
 ## Next Steps
-- Migrate remaining domain and application layer functions (for example `get_history`, `save_history`, `log_io`) to single-word equivalents while keeping semantic clarity.
+- Migrate remaining domain and application layer helpers (e.g., mapper converters, orchestrator builders) that still rely on snake_case naming to single-word equivalents while keeping semantic clarity.
 - Replace abbreviations such as `uc`, `msg`, `cfg`, and similar throughout the repository with full words.
 - Audit adapter-layer gateway helpers (e.g., `do_edit_text`, `reply_for_send`) and select concise replacements that respect the single-word rule.
-- Review protocol definitions so that method names like `get_state`, `set_state`, and `save_history` become single-word verbs without losing intent (e.g., `state`, `store`).
+- Review gateway and presenter protocols to retire legacy snake_case verbs that remain (e.g., `edit_text`, `send_media`) once downstream helpers adopt their single-word counterparts.
 
 ## Gateway Renaming Plan
 

--- a/adapters/storage/historyrepo.py
+++ b/adapters/storage/historyrepo.py
@@ -141,13 +141,13 @@ class HistoryRepo:
     def __init__(self, state: FSMContext):
         self._state = state
 
-    async def get_history(self) -> List[Entry]:
+    async def recall(self) -> List[Entry]:
         data = await self._state.get_data()
         raw = data.get(FSM_HISTORY_KEY, [])
         jlog(logger, logging.DEBUG, LogCode.HISTORY_LOAD, history={"len": len(raw)})
         return [self._load(d) for d in raw]
 
-    async def save_history(self, history: List[Entry]) -> None:
+    async def archive(self, history: List[Entry]) -> None:
         payload = [self._dump(entry) for entry in history]
         await self._state.update_data({FSM_HISTORY_KEY: payload})
         jlog(logger, logging.DEBUG, LogCode.HISTORY_SAVE, history={"len": len(payload)})

--- a/adapters/storage/lastrepo.py
+++ b/adapters/storage/lastrepo.py
@@ -15,13 +15,13 @@ class LastRepo(LastMessageRepository):
     def __init__(self, state: FSMContext):
         self._state = state
 
-    async def get_last_id(self) -> Optional[int]:
+    async def peek(self) -> Optional[int]:
         data = await self._state.get_data()
         mid = data.get(FSM_LAST_ID_KEY)
         jlog(logger, logging.DEBUG, LogCode.LAST_GET, message={"id": mid})
         return mid
 
-    async def set_last_id(self, id: Optional[int]) -> None:
+    async def mark(self, id: Optional[int]) -> None:
         await self._state.update_data({FSM_LAST_ID_KEY: id})
         code = LogCode.LAST_DELETE if id is None else LogCode.LAST_SET
         jlog(logger, logging.DEBUG, code, message={"id": id})

--- a/adapters/storage/staterepo.py
+++ b/adapters/storage/staterepo.py
@@ -16,16 +16,16 @@ class StateRepo(StateRepository):
     def __init__(self, state: FSMContext):
         self._state = state
 
-    async def get_state(self) -> Optional[str]:
+    async def status(self) -> Optional[str]:
         s = await self._state.get_state()
         jlog(logger, logging.DEBUG, LogCode.STATE_GET, state={"current": s})
         return s
 
-    async def set_state(self, state: Optional[str]) -> None:
+    async def assign(self, state: Optional[str]) -> None:
         await self._state.set_state(state)
         jlog(logger, logging.DEBUG, LogCode.STATE_SET, state={"target": state})
 
-    async def get_graph(self) -> Graph:
+    async def diagram(self) -> Graph:
         data = await self._state.get_data()
         nodes = data.get(FSM_GRAPH_NODES_KEY, [])
         edges = data.get(FSM_GRAPH_EDGES_KEY, {})
@@ -35,7 +35,7 @@ class StateRepo(StateRepository):
             edges=edges,
         )
 
-    async def save_graph(self, graph: Graph) -> None:
+    async def capture(self, graph: Graph) -> None:
         await self._state.update_data({
             FSM_GRAPH_NODES_KEY: graph.nodes,
             FSM_GRAPH_EDGES_KEY: graph.edges,
@@ -43,7 +43,7 @@ class StateRepo(StateRepository):
         jlog(logger, logging.DEBUG, LogCode.GRAPH_SAVE,
              graph={"nodes_len": len(graph.nodes), "edges_keys": len(graph.edges)})
 
-    async def get_data(self) -> Dict[str, Any]:
+    async def payload(self) -> Dict[str, Any]:
         d = await self._state.get_data()
         filtered = {k: v for k, v in d.items() if not str(k).startswith("nav")}
         keys_len = len(filtered)

--- a/adapters/storage/temprepo.py
+++ b/adapters/storage/temprepo.py
@@ -15,7 +15,7 @@ class TempRepo(TemporaryRepository):
     def __init__(self, state: FSMContext):
         self._state = state
 
-    async def get_temp_ids(self) -> List[int]:
+    async def collect(self) -> List[int]:
         data = await self._state.get_data()
         raw = data.get(FSM_TEMP_KEY, [])
         try:
@@ -25,7 +25,7 @@ class TempRepo(TemporaryRepository):
         jlog(logger, logging.DEBUG, LogCode.TEMP_LOAD, temp={"len": len(ids)})
         return ids
 
-    async def save_temp_ids(self, ids: List[int]) -> None:
+    async def stash(self, ids: List[int]) -> None:
         payload = [int(x) for x in (ids or [])]
         await self._state.update_data({FSM_TEMP_KEY: payload})
         jlog(logger, logging.DEBUG, LogCode.TEMP_SAVE, temp={"len": len(payload)})

--- a/application/log/decorators.py
+++ b/application/log/decorators.py
@@ -34,7 +34,7 @@ def _message_summary(result: Any) -> Optional[dict]:
     return {"id": mid, "extra_len": len(extra) if isinstance(extra, list) else 0}
 
 
-def log_io(code_start, code_ok, code_skip, extra_fn: Optional[Callable[[Any], dict]] = None):
+def trace(code_start, code_ok, code_skip, augment: Optional[Callable[[Any], dict]] = None):
     def deco(fn: Callable[..., Any]):
         @wraps(fn)
         async def wrapper(*args: Any, **kwargs: Any):
@@ -65,9 +65,9 @@ def log_io(code_start, code_ok, code_skip, extra_fn: Optional[Callable[[Any], di
                         msg = _message_summary(result)
                         if msg is not None:
                             fields["message"] = msg
-                        if extra_fn is not None:
+                        if augment is not None:
                             try:
-                                extra = extra_fn(result)
+                                extra = augment(result)
                                 if isinstance(extra, dict):
                                     fields.update(extra)
                             except (TypeError, ValueError):

--- a/application/service/store.py
+++ b/application/service/store.py
@@ -27,11 +27,11 @@ async def persist(archive, ledger, policy, limit, history, *, op: str):
             op=op,
             history={"before": len(history), "after": len(trimmed)},
         )
-    await archive.save_history(trimmed)
+    await archive.archive(trimmed)
     jlog(logger, logging.DEBUG, LogCode.HISTORY_SAVE, op=op, history={"len": len(trimmed)})
     if trimmed and trimmed[-1].messages:
         mid = trimmed[-1].messages[0].id
-        await ledger.set_last_id(mid)
+        await ledger.mark(mid)
         jlog(logger, logging.INFO, LogCode.LAST_SET, op=op, message={"id": mid})
 
 

--- a/application/service/view/orchestrator.py
+++ b/application/service/view/orchestrator.py
@@ -7,7 +7,7 @@ from ..view.inline import InlineStrategy
 from .policy import adapt
 from ...internal import policy as _pol
 from ...internal.policy import shield
-from ...log.decorators import log_io
+from ...log.decorators import trace
 from ...log.emit import jlog
 from ....domain.entity.history import Entry, Msg
 from ....domain.entity.media import MediaItem
@@ -129,7 +129,7 @@ class ViewOrchestrator:
             raise ValueError(f"render_meta_unsupported_kind:{kind}")
         return meta
 
-    @log_io(LogCode.RENDER_START, LogCode.RENDER_OK, LogCode.RENDER_SKIP)
+    @trace(LogCode.RENDER_START, LogCode.RENDER_OK, LogCode.RENDER_SKIP)
     async def swap(
             self,
             scope: Scope,

--- a/application/usecase/add.py
+++ b/application/usecase/add.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional, List
 
-from ..log.decorators import log_io
+from ..log.decorators import trace
 from ..log.emit import jlog
 from ..map.entry import EntryMapper, Outcome
 from ..service.view.orchestrator import ViewOrchestrator
@@ -35,7 +35,7 @@ class Appender:
         self._mapper = mapper
         self._limit = limit
 
-    @log_io(None, None, None)
+    @trace(None, None, None)
     async def execute(
             self,
             scope: Scope,
@@ -44,7 +44,7 @@ class Appender:
             root: bool = False,
     ) -> None:
         adjusted = [adapt(scope, normalize(p)) for p in bundle]
-        records = await self._archive.get_history()
+        records = await self._archive.recall()
         jlog(
             logger,
             logging.DEBUG,
@@ -58,7 +58,7 @@ class Appender:
         if not render or not render.ids or not render.changed:
             jlog(logger, logging.INFO, LogCode.RENDER_SKIP, op="add")
             return
-        status = await self._state.get_state()
+        status = await self._state.status()
         jlog(logger, logging.INFO, LogCode.STATE_GET, op="add", state={"current": status})
 
         usable = adjusted[:len(render.ids)]

--- a/application/usecase/replace.py
+++ b/application/usecase/replace.py
@@ -1,7 +1,7 @@
 import logging
 from typing import List
 
-from ..log.decorators import log_io
+from ..log.decorators import trace
 from ..log.emit import jlog
 from ..map.entry import EntryMapper, Outcome
 from ..service.view.orchestrator import ViewOrchestrator
@@ -34,10 +34,10 @@ class Swapper:
         self._mapper = mapper
         self._limit = limit
 
-    @log_io(None, None, None)
+    @trace(None, None, None)
     async def execute(self, scope: Scope, bundle: List[Payload]) -> None:
         adjusted = [adapt(scope, normalize(p)) for p in bundle]
-        records = await self._archive.get_history()
+        records = await self._archive.recall()
         jlog(logger, logging.DEBUG, LogCode.HISTORY_LOAD, op="replace", history={"len": len(records)})
         trail = records[-1] if records else None
         render = await self._orchestrator.render_node(
@@ -46,7 +46,7 @@ class Swapper:
         if not render or not render.ids or not render.changed:
             jlog(logger, logging.INFO, LogCode.RENDER_SKIP, op="replace")
             return
-        status = await self._state.get_state()
+        status = await self._state.status()
 
         usable = adjusted[:len(render.ids)]
         entry = self._mapper.convert(

--- a/domain/port/history.py
+++ b/domain/port/history.py
@@ -9,10 +9,10 @@ from ..entity.history import Entry
 class HistoryRepository(Protocol):
     """Storage for navigation history."""
 
-    async def get_history(self) -> List[Entry]:
+    async def recall(self) -> List[Entry]:
         """Return full history ordered from first to last."""
 
-    async def save_history(self, history: List[Entry]) -> None:
+    async def archive(self, history: List[Entry]) -> None:
         """Persist full history snapshot."""
 
 

--- a/domain/port/last.py
+++ b/domain/port/last.py
@@ -7,10 +7,10 @@ from typing import Protocol, Optional, runtime_checkable
 class LastMessageRepository(Protocol):
     """Storage for last sent message identifier."""
 
-    async def get_last_id(self) -> Optional[int]:
+    async def peek(self) -> Optional[int]:
         """Return last message id or None."""
 
-    async def set_last_id(self, id: Optional[int]) -> None:
+    async def mark(self, id: Optional[int]) -> None:
         """Set or clear last message id."""
 
 

--- a/domain/port/state.py
+++ b/domain/port/state.py
@@ -9,19 +9,19 @@ from ..entity.stategraph import Graph
 class StateRepository(Protocol):
     """FSM state and graph storage."""
 
-    async def get_state(self) -> Optional[str]:
+    async def status(self) -> Optional[str]:
         """Return current state or None."""
 
-    async def set_state(self, state: Optional[str]) -> None:
+    async def assign(self, state: Optional[str]) -> None:
         """Set current state."""
 
-    async def get_graph(self) -> Graph:
+    async def diagram(self) -> Graph:
         """Return state graph."""
 
-    async def save_graph(self, graph: Graph) -> None:
+    async def capture(self, graph: Graph) -> None:
         """Persist state graph."""
 
-    async def get_data(self) -> Dict[str, Any]:
+    async def payload(self) -> Dict[str, Any]:
         """Return FSM data payload."""
 
 

--- a/domain/port/temp.py
+++ b/domain/port/temp.py
@@ -7,10 +7,10 @@ from typing import Protocol, List, runtime_checkable
 class TemporaryRepository(Protocol):
     """Storage for temporary message ids."""
 
-    async def get_temp_ids(self) -> List[int]:
+    async def collect(self) -> List[int]:
         """Return list of ids."""
 
-    async def save_temp_ids(self, ids: List[int]) -> None:
+    async def stash(self, ids: List[int]) -> None:
         """Persist list of ids."""
 
 


### PR DESCRIPTION
## Summary
- extend the renaming plan with the new single-word vocabulary for storage verbs and logging decorator updates
- rename history, state, last, and temporary repository protocols to recall/archive, status/assign/diagram/capture/payload, peek/mark, and collect/stash
- update adapters, services, and use cases to call the new repository verbs and use the `trace` logging decorator

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d0197ffee8833084a2f89bc6a8530d