### PR TITLE
Rename Telegram gateway identifiers to single words

### DIFF
--- a/Renaming.md
+++ b/Renaming.md
@@ -11,12 +11,15 @@
 - Navigator tail helper now relies on `_tailer` and uses `identifier`/`status` for clarity when referencing message identifiers and state values.
 - Domain storage contracts now use single-word verbs: history repositories `recall`/`archive`, state repositories `status`/`assign`/`diagram`/`capture`/`payload`, last message repositories `peek`/`mark`, and temporary repositories `collect`/`stash`.
 - Application service decorator `log_io` shortened to `trace`, with `augment` replacing the `extra_fn` callback for additional log context.
+- Telegram serialization helpers now expose `decode`/`preview`/`caption`/`restate`, with `cleanse`/`divide`/`scrub` guarded by extra `audit`/`screen` checks.
+- Telegram media helpers adopt `weblink`/`adapt`/`convert`/`compose`/`assemble`, with inline strategy injection renamed to `probe`/`strictpath` and Settings following suit.
+- Message gateway protocol promotes edit verbs to `rewrite`/`recast`/`retitle`/`remap`, with orchestrator dispatch updated to the new names.
 
 ## Next Steps
 - Migrate remaining domain and application layer helpers (e.g., mapper converters, orchestrator builders) that still rely on snake_case naming to single-word equivalents while keeping semantic clarity.
 - Replace abbreviations such as `uc`, `msg`, `cfg`, and similar throughout the repository with full words.
 - Audit adapter-layer gateway helpers (e.g., `do_edit_text`, `reply_for_send`) and select concise replacements that respect the single-word rule.
-- Review gateway and presenter protocols to retire legacy snake_case verbs that remain (e.g., `edit_text`, `send_media`) once downstream helpers adopt their single-word counterparts.
+- Extend presenter-facing protocols (e.g., `send_media`) to the new single-word vocabulary established for the gateway.
 
 ## Gateway Renaming Plan
 

--- a/adapters/telegram/extra.py
+++ b/adapters/telegram/extra.py
@@ -14,7 +14,7 @@ ALLOWED_MEDIA_EXTRA = {
 }
 
 
-def validate_extra(extra: Dict[str, Any] | None, allowed: Set[str]) -> None:
+def audit(extra: Dict[str, Any] | None, allowed: Set[str]) -> None:
     if not extra:
         return
     keys = set(extra.keys())

--- a/adapters/telegram/gateway/__init__.py
+++ b/adapters/telegram/gateway/__init__.py
@@ -34,16 +34,16 @@ class TelegramGateway(MessageGateway):
             raise InlineUnsupported("inline_send_not_supported")
         return await dispatch(self._bot, self._codec, scope, payload, truncate=self._truncate)
 
-    async def edit_text(self, scope: Scope, message_id: int, payload: Payload) -> Result:
+    async def rewrite(self, scope: Scope, message_id: int, payload: Payload) -> Result:
         return await rewrite(self._bot, self._codec, scope, message_id, payload, truncate=self._truncate)
 
-    async def edit_media(self, scope: Scope, message_id: int, payload: Payload) -> Result:
+    async def recast(self, scope: Scope, message_id: int, payload: Payload) -> Result:
         return await recast(self._bot, self._codec, scope, message_id, payload, truncate=self._truncate)
 
-    async def edit_caption(self, scope: Scope, message_id: int, payload: Payload) -> Result:
+    async def retitle(self, scope: Scope, message_id: int, payload: Payload) -> Result:
         return await retitle(self._bot, self._codec, scope, message_id, payload, truncate=self._truncate)
 
-    async def edit_markup(self, scope: Scope, message_id: int, payload: Payload) -> Result:
+    async def remap(self, scope: Scope, message_id: int, payload: Payload) -> Result:
         return await remap(self._bot, self._codec, scope, message_id, payload)
 
     async def delete(self, scope: Scope, ids: List[int]) -> None:

--- a/adapters/telegram/gateway/common.py
+++ b/adapters/telegram/gateway/common.py
@@ -2,7 +2,7 @@ import logging
 
 from aiogram.types import InlineKeyboardMarkup
 
-from .util import extract_meta
+from .util import extract
 from .. import serializer
 from ....domain.log.emit import jlog
 from ....domain.port.message import Result
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 
 def markup(codec, reply, *, edit: bool):
-    obj = serializer.decode_reply(codec, reply)
+    obj = serializer.decode(codec, reply)
     if not edit:
         return obj
     return obj if isinstance(obj, InlineKeyboardMarkup) else None
@@ -26,7 +26,7 @@ def finalize(scope, payload, identifier, result):
     else:
         fallback = getattr(result, "message_id", None)
         mid = fallback if fallback is not None else identifier
-    meta = extract_meta(result, payload, scope)
+    meta = extract(result, payload, scope)
     jlog(
         logger,
         logging.INFO,

--- a/adapters/telegram/gateway/util.py
+++ b/adapters/telegram/gateway/util.py
@@ -19,7 +19,7 @@ def targets(scope: Scope, message_id: Optional[int] = None) -> Dict[str, Any]:
     return data
 
 
-def _msg_to_meta(msg: Message) -> dict:
+def _digest(msg: Message) -> dict:
     if getattr(msg, "media_group_id", None):
         pass
     if getattr(msg, "text", None) is not None and not getattr(msg, "photo", None) \
@@ -50,7 +50,7 @@ def _msg_to_meta(msg: Message) -> dict:
     return {"kind": "text", "text": getattr(msg, "text", None), "inline": None}
 
 
-def extract_meta(result_msg_or_bool: Any, payload: Any, scope: Scope) -> dict:
+def extract(result_msg_or_bool: Any, payload: Any, scope: Scope) -> dict:
     """
     Возвращает dict: kind, media_type, file_id, caption, text, group_items, inline.
     Для inline всегда проставлять inline из scope.
@@ -58,7 +58,7 @@ def extract_meta(result_msg_or_bool: Any, payload: Any, scope: Scope) -> dict:
     """
     token = getattr(scope, "inline", None)
     if hasattr(result_msg_or_bool, "message_id"):
-        m = _msg_to_meta(result_msg_or_bool)
+        m = _digest(result_msg_or_bool)
         m["inline"] = token
         return m
     if getattr(payload, "group", None):

--- a/adapters/telegram/keyfilter.py
+++ b/adapters/telegram/keyfilter.py
@@ -9,7 +9,7 @@ _seen: set[tuple[str, FrozenSet[str]]] = set()
 _logger = logging.getLogger(__name__)
 
 
-def _sig_params(target: Any) -> set:
+def _signature(target: Any) -> set:
     obj = target.__init__ if inspect.isclass(target) else target
     try:
         sig = inspect.signature(obj)
@@ -20,10 +20,10 @@ def _sig_params(target: Any) -> set:
         return {"__ANY__"}
 
 
-def accept_for(target: Any, extra: Dict[str, Any] | None) -> Dict[str, Any]:
+def screen(target: Any, extra: Dict[str, Any] | None) -> Dict[str, Any]:
     if not extra:
         return {}
-    allowed = _sig_params(target)
+    allowed = _signature(target)
     if "__ANY__" in allowed:
         tgt = getattr(target, "__name__", str(target))
         keys = frozenset(extra.keys())

--- a/application/service/view/inline.py
+++ b/application/service/view/inline.py
@@ -25,11 +25,11 @@ def _looks_like_file_id(s: str) -> bool:
 
 
 class InlineStrategy:
-    def __init__(self, gateway, is_url_input_file, strict_inline_media_path):
+    def __init__(self, gateway, probe, strictpath):
         self._gateway = gateway
-        self._is_url_input_file = is_url_input_file
+        self._probe = probe
         self._logger = logging.getLogger(__name__)
-        self._strict_inline_media_path = strict_inline_media_path
+        self._strictpath = strictpath
 
     def _media_editable_inline(self, p) -> bool:
         """
@@ -45,13 +45,13 @@ class InlineStrategy:
         if getattr(m, "type", None) in (MediaType.VOICE, MediaType.VIDEO_NOTE):
             return False
         path = getattr(m, "path", None)
-        if self._is_url_input_file(path):
+        if self._probe(path):
             return True
         if isinstance(path, str):
             if remote(path):
                 return True
             if not local(path):
-                return _looks_like_file_id(path) if self._strict_inline_media_path else True
+                return _looks_like_file_id(path) if self._strictpath else True
         return False
 
     def _reply_changed(self, base_msg, p) -> bool:

--- a/application/service/view/orchestrator.py
+++ b/application/service/view/orchestrator.py
@@ -184,36 +184,36 @@ class ViewOrchestrator:
             async def _resend() -> Result:
                 return await self._gateway.send(scope, payload)
 
-            async def _edit_text() -> Optional[Result]:
+            async def _rewrite() -> Optional[Result]:
                 m = _head_msg(last)
                 if not m:
                     return None
-                return await self._gateway.edit_text(scope, m.id, payload)
+                return await self._gateway.rewrite(scope, m.id, payload)
 
-            async def _edit_media() -> Optional[Result]:
+            async def _recast() -> Optional[Result]:
                 m = _head_msg(last)
                 if not m:
                     return None
-                return await self._gateway.edit_media(scope, m.id, payload)
+                return await self._gateway.recast(scope, m.id, payload)
 
-            async def _edit_caption() -> Optional[Result]:
+            async def _retitle() -> Optional[Result]:
                 m = _head_msg(last)
                 if not m:
                     return None
-                return await self._gateway.edit_caption(scope, m.id, payload)
+                return await self._gateway.retitle(scope, m.id, payload)
 
-            async def _edit_markup() -> Optional[Result]:
+            async def _remap() -> Optional[Result]:
                 m = _head_msg(last)
                 if not m:
                     return None
-                return await self._gateway.edit_markup(scope, m.id, payload)
+                return await self._gateway.remap(scope, m.id, payload)
 
             dispatch = {
                 decision.Decision.RESEND: _resend,
-                decision.Decision.EDIT_TEXT: _edit_text,
-                decision.Decision.EDIT_MEDIA: _edit_media,
-                decision.Decision.EDIT_MEDIA_CAPTION: _edit_caption,
-                decision.Decision.EDIT_MARKUP: _edit_markup,
+                decision.Decision.EDIT_TEXT: _rewrite,
+                decision.Decision.EDIT_MEDIA: _recast,
+                decision.Decision.EDIT_MEDIA_CAPTION: _retitle,
+                decision.Decision.EDIT_MARKUP: _remap,
             }
             fn = dispatch.get(dec)
             if not fn:
@@ -362,10 +362,10 @@ class ViewOrchestrator:
                 if caption_changed:
                     cap = (new_group[0].caption or "")
                     p_for_cap = new[0].morph(media=new_group[0], group=None, text=("" if cap == "" else None))
-                    await self._gateway.edit_caption(scope, ids[0], p_for_cap)
+                    await self._gateway.retitle(scope, ids[0], p_for_cap)
                     changed = True
                 if reply_changed:
-                    await self._gateway.edit_markup(scope, ids[0], new[0])
+                    await self._gateway.remap(scope, ids[0], new[0])
                     changed = True
 
                 def _same_file(a: MediaItem, b: MediaItem) -> bool:
@@ -381,7 +381,7 @@ class ViewOrchestrator:
                     need_file_switch = self._needs_edit_media(oi, ni)
                     need_extra_switch = (not need_file_switch) and media_extra_changed and _same_file(oi, ni)
                     if need_file_switch or need_extra_switch:
-                        await self._gateway.edit_media(scope, target_id, new[0].morph(media=ni, group=None))
+                        await self._gateway.recast(scope, target_id, new[0].morph(media=ni, group=None))
                         changed = True
 
                 def _pick_file_id(i):

--- a/domain/port/message.py
+++ b/domain/port/message.py
@@ -25,16 +25,16 @@ class MessageGateway(Protocol):
     async def send(self, scope: Scope, payload: Payload) -> Result:
         ...
 
-    async def edit_text(self, scope: Scope, message_id: int, payload: Payload) -> Result:
+    async def rewrite(self, scope: Scope, message_id: int, payload: Payload) -> Result:
         ...
 
-    async def edit_media(self, scope: Scope, message_id: int, payload: Payload) -> Result:
+    async def recast(self, scope: Scope, message_id: int, payload: Payload) -> Result:
         ...
 
-    async def edit_caption(self, scope: Scope, message_id: int, payload: Payload) -> Result:
+    async def retitle(self, scope: Scope, message_id: int, payload: Payload) -> Result:
         ...
 
-    async def edit_markup(self, scope: Scope, message_id: int, payload: Payload) -> Result:
+    async def remap(self, scope: Scope, message_id: int, payload: Payload) -> Result:
         ...
 
     async def delete(self, scope: Scope, ids: List[int]) -> None:

--- a/infrastructure/config.py
+++ b/infrastructure/config.py
@@ -7,7 +7,7 @@ class Settings(BaseModel):
     retention: int = Field(18, ge=1, le=200)
     chunk: int = Field(100, ge=1, le=100)
     truncate: bool = Field(False)
-    strict_inline_media_path: bool = Field(True)
+    strictpath: bool = Field(True)
     thumbguard: bool = Field(False)
     redaction: str = Field("safe")
 
@@ -16,7 +16,7 @@ SETTINGS = Settings(
     retention=int(os.getenv("NAV_HISTORY_LIMIT", "18")),
     chunk=int(os.getenv("NAV_CHUNK", "100")),
     truncate=os.getenv("NAV_TRUNCATE", "0").lower() in {"1", "true", "yes"},
-    strict_inline_media_path=os.getenv("NAV_STRICT_INLINE_MEDIA_PATH", "1").lower() in {"1", "true", "yes"},
+    strictpath=os.getenv("NAV_STRICT_INLINE_MEDIA_PATH", "1").lower() in {"1", "true", "yes"},
     thumbguard=os.getenv("NAV_DETECT_THUMB_CHANGE", "0").lower() in {"1", "true", "yes"},
     redaction=os.getenv("NAV_LOG_REDACTION", "safe").lower(),
 )

--- a/infrastructure/di/container.py
+++ b/infrastructure/di/container.py
@@ -8,7 +8,7 @@ from ...adapters.storage.temprepo import TempRepo
 from ...adapters.storage.transitionrecorder import TransitionRecorder
 from ...adapters.telegram.gateway import TelegramGateway
 from ...adapters.telegram.markupcodec import AiogramMarkupCodec
-from ...adapters.telegram.media import is_url_input_file
+from ...adapters.telegram.media import weblink
 from ...application.map.entry import EntryMapper
 from ...application.service.view.inline import InlineStrategy
 from ...application.service.view.orchestrator import ViewOrchestrator
@@ -52,8 +52,8 @@ class AppContainer(containers.DeclarativeContainer):
     inline_strategy = providers.Factory(
         InlineStrategy,
         gateway=gateway,
-        is_url_input_file=is_url_input_file,
-        strict_inline_media_path=providers.Object(SETTINGS.strict_inline_media_path),
+        probe=weblink,
+        strictpath=providers.Object(SETTINGS.strictpath),
     )
     rendering_config = providers.Object(RenderingConfig(thumbguard=SETTINGS.thumbguard))
     view_orchestrator = providers.Factory(


### PR DESCRIPTION
## Summary
- rename Telegram serializer, media, keyfilter and utility helpers to single-word identifiers
- promote `MessageGateway` verbs and orchestrator dispatch to the new rewrite/recast/retitle/remap names
- align inline strategy configuration and container wiring with the new `probe`/`strictpath` naming

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d01c9cff208330a6f4f8439f652cee