### PR TITLE
Adopt single-word gateway naming

### DIFF
--- a/Renaming.md
+++ b/Renaming.md
@@ -14,12 +14,14 @@
 - Telegram serialization helpers now expose `decode`/`preview`/`caption`/`restate`, with `cleanse`/`divide`/`scrub` guarded by extra `audit`/`screen` checks.
 - Telegram media helpers adopt `weblink`/`adapt`/`convert`/`compose`/`assemble`, with inline strategy injection renamed to `probe`/`strictpath` and Settings following suit.
 - Message gateway protocol promotes edit verbs to `rewrite`/`recast`/`retitle`/`remap`, with orchestrator dispatch updated to the new names.
+- Telegram gateway internals now use single-word identifiers throughout dispatch/edit/delete flows, including the extras bundle handling, `DeleteBatch` runner, and the shared `targets`/`extract` helpers with `sanitize` alignment.
 
 ## Next Steps
 - Migrate remaining domain and application layer helpers (e.g., mapper converters, orchestrator builders) that still rely on snake_case naming to single-word equivalents while keeping semantic clarity.
 - Replace abbreviations such as `uc`, `msg`, `cfg`, and similar throughout the repository with full words.
 - Audit adapter-layer gateway helpers (e.g., `do_edit_text`, `reply_for_send`) and select concise replacements that respect the single-word rule.
 - Extend presenter-facing protocols (e.g., `send_media`) to the new single-word vocabulary established for the gateway.
+- Continue migrating dependency-injection providers and application use-case locals (e.g., `history_repo`, `to_delete`) away from snake_case once core gateway flows stabilise.
 
 ## Gateway Renaming Plan
 
@@ -32,6 +34,7 @@
 | Telegram gateway helpers | `do_edit_markup` | `remap` |
 | Telegram reply helpers | `reply_for_send`/`reply_for_edit` | `markup(codec, reply, *, edit)` |
 | Gateway logging helpers | Inline replacements for `log_edit_fail`/`log_edit_ok` | Inline `jlog` calls |
+| Telegram batch delete runner | `BatchDeleteRunner` | `DeleteBatch` |
 
 ## Upcoming Protocol Updates
 

--- a/adapters/telegram/gateway/__init__.py
+++ b/adapters/telegram/gateway/__init__.py
@@ -5,7 +5,7 @@ from typing import List
 
 from aiogram import Bot
 
-from .delete import BatchDeleteRunner
+from .delete import DeleteBatch
 from .edit import rewrite, recast, retitle, remap
 from .send import dispatch
 from .util import targets
@@ -23,9 +23,9 @@ logger = logging.getLogger(__name__)
 
 
 class TelegramGateway(MessageGateway):
-    def __init__(self, bot: Bot, markup_codec: MarkupCodec, chunk: int = 100, truncate: bool = False):
+    def __init__(self, bot: Bot, codec: MarkupCodec, chunk: int = 100, truncate: bool = False):
         self._bot = bot
-        self._codec = markup_codec
+        self._codec = codec
         self._chunk = int(chunk)
         self._truncate = bool(truncate)
 
@@ -34,21 +34,21 @@ class TelegramGateway(MessageGateway):
             raise InlineUnsupported("inline_send_not_supported")
         return await dispatch(self._bot, self._codec, scope, payload, truncate=self._truncate)
 
-    async def rewrite(self, scope: Scope, message_id: int, payload: Payload) -> Result:
-        return await rewrite(self._bot, self._codec, scope, message_id, payload, truncate=self._truncate)
+    async def rewrite(self, scope: Scope, message: int, payload: Payload) -> Result:
+        return await rewrite(self._bot, self._codec, scope, message, payload, truncate=self._truncate)
 
-    async def recast(self, scope: Scope, message_id: int, payload: Payload) -> Result:
-        return await recast(self._bot, self._codec, scope, message_id, payload, truncate=self._truncate)
+    async def recast(self, scope: Scope, message: int, payload: Payload) -> Result:
+        return await recast(self._bot, self._codec, scope, message, payload, truncate=self._truncate)
 
-    async def retitle(self, scope: Scope, message_id: int, payload: Payload) -> Result:
-        return await retitle(self._bot, self._codec, scope, message_id, payload, truncate=self._truncate)
+    async def retitle(self, scope: Scope, message: int, payload: Payload) -> Result:
+        return await retitle(self._bot, self._codec, scope, message, payload, truncate=self._truncate)
 
-    async def remap(self, scope: Scope, message_id: int, payload: Payload) -> Result:
-        return await remap(self._bot, self._codec, scope, message_id, payload)
+    async def remap(self, scope: Scope, message: int, payload: Payload) -> Result:
+        return await remap(self._bot, self._codec, scope, message, payload)
 
-    async def delete(self, scope: Scope, ids: List[int]) -> None:
-        runner = BatchDeleteRunner(bot=self._bot, chunk=self._chunk)
-        await runner.run(scope, ids)
+    async def delete(self, scope: Scope, identifiers: List[int]) -> None:
+        runner = DeleteBatch(bot=self._bot, chunk=self._chunk)
+        await runner.run(scope, identifiers)
 
     async def alert(self, scope: Scope) -> None:
         if not scope.inline:

--- a/adapters/telegram/gateway/common.py
+++ b/adapters/telegram/gateway/common.py
@@ -22,10 +22,10 @@ def markup(codec, reply, *, edit: bool):
 
 def finalize(scope, payload, identifier, result):
     if scope.inline:
-        mid = identifier
+        marker = identifier
     else:
         fallback = getattr(result, "message_id", None)
-        mid = fallback if fallback is not None else identifier
+        marker = fallback if fallback is not None else identifier
     meta = extract(result, payload, scope)
     jlog(
         logger,
@@ -33,6 +33,6 @@ def finalize(scope, payload, identifier, result):
         LogCode.GATEWAY_EDIT_OK,
         scope=profile(scope),
         payload=classify(payload),
-        message={"id": mid, "extra_len": 0},
+        message={"id": marker, "extra_len": 0},
     )
-    return Result(id=mid, extra=[], **meta)
+    return Result(id=marker, extra=[], **meta)

--- a/adapters/telegram/gateway/delete.py
+++ b/adapters/telegram/gateway/delete.py
@@ -17,12 +17,12 @@ logger = logging.getLogger(__name__)
 _DELAY_SEC = max(0.0, float(int(os.getenv("NAV_DELETE_DELAY_MS", "50"))) / 1000.0)
 
 
-class BatchDeleteRunner:
+class DeleteBatch:
     def __init__(self, bot, chunk: int):
         self._bot = bot
         self._chunk = min(int(chunk), 100)
 
-    async def run(self, scope: Scope, ids: List[int]) -> None:
+    async def run(self, scope: Scope, identifiers: List[int]) -> None:
         if scope.inline and not scope.business:
             jlog(
                 logger,
@@ -30,12 +30,12 @@ class BatchDeleteRunner:
                 LogCode.RENDER_SKIP,
                 scope=profile(scope),
                 note="inline_without_business_delete_skip",
-                count=len(ids or []),
+                count=len(identifiers or []),
             )
             return
-        if not ids:
+        if not identifiers:
             return
-        unique = _order(ids)
+        unique = _order(identifiers)
         if not unique:
             return
         groups = [

--- a/adapters/telegram/media.py
+++ b/adapters/telegram/media.py
@@ -78,49 +78,49 @@ def compose(
         if item.type in (MediaType.VOICE, MediaType.VIDEO_NOTE):
             raise MessageEditForbidden("edit_media_type_forbidden")
         raise ValueError(f"Unsupported media type for InputMedia: {item.type}")
-    cap_extra, media_extra = divide(extra)
-    _screen(media_extra)
-    cap = caption if caption is not None else item.caption
-    txt_len = len(cap or "")
-    kv = cleanse(cap_extra, is_caption=True, target=input_class, text_len=txt_len)
-    opts = media_extra or {}
+    bundle = divide(extra)
+    _screen(bundle["media"])
+    caption = caption if caption is not None else item.caption
+    length = len(caption or "")
+    mapping = cleanse(bundle["caption"], captioning=True, target=input_class, length=length)
+    settings = bundle["media"] or {}
     if item.type in (MediaType.PHOTO, MediaType.VIDEO, MediaType.ANIMATION):
-        if opts.get("spoiler") is not None:
-            kv["has_spoiler"] = bool(opts.get("spoiler"))
-        if opts.get("show_caption_above_media") is not None:
-            kv["show_caption_above_media"] = bool(opts.get("show_caption_above_media"))
+        if settings.get("spoiler") is not None:
+            mapping["has_spoiler"] = bool(settings.get("spoiler"))
+        if settings.get("show_caption_above_media") is not None:
+            mapping["show_caption_above_media"] = bool(settings.get("show_caption_above_media"))
     if item.type == MediaType.VIDEO:
-        if opts.get("start") is not None:
-            kv["start_timestamp"] = opts.get("start")
+        if settings.get("start") is not None:
+            mapping["start_timestamp"] = settings.get("start")
     if item.type in (MediaType.VIDEO, MediaType.ANIMATION, MediaType.AUDIO, MediaType.DOCUMENT):
-        if opts.get("thumb") is not None:
-            kv["thumbnail"] = adapt(opts.get("thumb"), allow_local=allow_local)
+        if settings.get("thumb") is not None:
+            mapping["thumbnail"] = adapt(settings.get("thumb"), allow_local=allow_local)
     if item.type == MediaType.AUDIO:
-        if opts.get("title") is not None:
-            kv["title"] = str(opts.get("title"))
-        if opts.get("performer") is not None:
-            kv["performer"] = str(opts.get("performer"))
-        if opts.get("duration") is not None:
-            kv["duration"] = int(opts.get("duration"))
+        if settings.get("title") is not None:
+            mapping["title"] = str(settings.get("title"))
+        if settings.get("performer") is not None:
+            mapping["performer"] = str(settings.get("performer"))
+        if settings.get("duration") is not None:
+            mapping["duration"] = int(settings.get("duration"))
     if item.type in (MediaType.VIDEO, MediaType.ANIMATION):
-        if opts.get("width") is not None:
-            kv["width"] = int(opts.get("width"))
-        if opts.get("height") is not None:
-            kv["height"] = int(opts.get("height"))
-        if opts.get("duration") is not None:
-            kv["duration"] = int(opts.get("duration"))
+        if settings.get("width") is not None:
+            mapping["width"] = int(settings.get("width"))
+        if settings.get("height") is not None:
+            mapping["height"] = int(settings.get("height"))
+        if settings.get("duration") is not None:
+            mapping["duration"] = int(settings.get("duration"))
 
-    if cap is not None and len(str(cap)) > CaptionLimit:
+    if caption is not None and len(str(caption)) > CaptionLimit:
         if truncate:
-            cap = str(cap)[:CaptionLimit]
+            caption = str(caption)[:CaptionLimit]
         else:
             raise CaptionTooLong()
 
-    kv = screen(input_class, kv)
-    kwargs = {"media": convert(item, allow_local=allow_local), **kv}
-    if cap is not None:
-        kwargs["caption"] = cap
-    return input_class(**kwargs)
+    mapping = screen(input_class, mapping)
+    arguments = {"media": convert(item, allow_local=allow_local), **mapping}
+    if caption is not None:
+        arguments["caption"] = caption
+    return input_class(**arguments)
 
 
 def assemble(items: List[MediaItem], extra: Dict[str, Any] | None = None, *, allow_local: bool = True,
@@ -147,8 +147,8 @@ def assemble(items: List[MediaItem], extra: Dict[str, Any] | None = None, *, all
         else:
             jlog(logger, logging.WARNING, LogCode.MEDIA_UNSUPPORTED, kind="group_invalid", types=kinds)
         raise
-    out: List[InputMedia] = []
-    for idx, item in enumerate(items):
-        cap = item.caption if idx == 0 else ""
-        out.append(compose(item, caption=cap, extra=extra, allow_local=allow_local, truncate=truncate))
-    return out
+    result: List[InputMedia] = []
+    for index, item in enumerate(items):
+        caption = item.caption if index == 0 else ""
+        result.append(compose(item, caption=caption, extra=extra, allow_local=allow_local, truncate=truncate))
+    return result

--- a/application/service/view/restorer.py
+++ b/application/service/view/restorer.py
@@ -14,8 +14,8 @@ logger = logging.getLogger(__name__)
 
 
 class ViewRestorer:
-    def __init__(self, markup_codec: MarkupCodec, ledger: ViewLedger):
-        self._markup_codec = markup_codec
+    def __init__(self, codec: MarkupCodec, ledger: ViewLedger):
+        self._codec = codec
         self._ledger = ledger
 
     async def restore_node(self, entry: Entry, context: Dict[str, Any], *, inline: bool) -> List[Payload]:

--- a/domain/port/message.py
+++ b/domain/port/message.py
@@ -25,19 +25,19 @@ class MessageGateway(Protocol):
     async def send(self, scope: Scope, payload: Payload) -> Result:
         ...
 
-    async def rewrite(self, scope: Scope, message_id: int, payload: Payload) -> Result:
+    async def rewrite(self, scope: Scope, message: int, payload: Payload) -> Result:
         ...
 
-    async def recast(self, scope: Scope, message_id: int, payload: Payload) -> Result:
+    async def recast(self, scope: Scope, message: int, payload: Payload) -> Result:
         ...
 
-    async def retitle(self, scope: Scope, message_id: int, payload: Payload) -> Result:
+    async def retitle(self, scope: Scope, message: int, payload: Payload) -> Result:
         ...
 
-    async def remap(self, scope: Scope, message_id: int, payload: Payload) -> Result:
+    async def remap(self, scope: Scope, message: int, payload: Payload) -> Result:
         ...
 
-    async def delete(self, scope: Scope, ids: List[int]) -> None:
+    async def delete(self, scope: Scope, identifiers: List[int]) -> None:
         ...
 
     async def alert(self, scope: Scope) -> None:

--- a/domain/util/entities.py
+++ b/domain/util/entities.py
@@ -29,37 +29,37 @@ _ALLOWED_ENTITY_TYPES = {
 }
 
 
-def sanitize(entities: Any, text_len: int) -> List[Dict[str, Any]]:
-    out: List[Dict[str, Any]] = []
+def sanitize(entities: Any, length: int) -> List[Dict[str, Any]]:
+    result: List[Dict[str, Any]] = []
     if not isinstance(entities, list):
-        return out
-    for e in entities:
-        if not isinstance(e, dict):
+        return result
+    for entity in entities:
+        if not isinstance(entity, dict):
             continue
-        t = e.get("type")
-        off = e.get("offset")
-        ln = e.get("length")
-        if t not in _ALLOWED_ENTITY_TYPES:
+        kind = entity.get("type")
+        offset = entity.get("offset")
+        span = entity.get("length")
+        if kind not in _ALLOWED_ENTITY_TYPES:
             continue
         try:
-            off_i = int(off)
-            ln_i = int(ln)
+            offset_value = int(offset)
+            span_value = int(span)
         except Exception:
             continue
-        if off_i < 0 or ln_i < 1:
+        if offset_value < 0 or span_value < 1:
             continue
-        if (off_i + ln_i) > max(0, int(text_len)):
+        if (offset_value + span_value) > max(0, int(length)):
             continue
-        cleaned = {"type": t, "offset": off_i, "length": ln_i}
-        if t == "text_link" and isinstance(e.get("url"), str):
-            cleaned["url"] = e["url"]
-        if t == "text_mention" and e.get("user") is not None:
-            cleaned["user"] = e["user"]
-        if t == "pre" and isinstance(e.get("language"), str):
-            cleaned["language"] = e["language"]
-        if t == "custom_emoji" and isinstance(e.get("custom_emoji_id"), str):
-            cleaned["custom_emoji_id"] = e["custom_emoji_id"]
-        out.append(cleaned)
-    if entities and not out:
+        entry = {"type": kind, "offset": offset_value, "length": span_value}
+        if kind == "text_link" and isinstance(entity.get("url"), str):
+            entry["url"] = entity["url"]
+        if kind == "text_mention" and entity.get("user") is not None:
+            entry["user"] = entity["user"]
+        if kind == "pre" and isinstance(entity.get("language"), str):
+            entry["language"] = entity["language"]
+        if kind == "custom_emoji" and isinstance(entity.get("custom_emoji_id"), str):
+            entry["custom_emoji_id"] = entity["custom_emoji_id"]
+        result.append(entry)
+    if entities and not result:
         jlog(logging.getLogger(__name__), logging.DEBUG, LogCode.EXTRA_UNKNOWN_DROPPED, note="entities_dropped_all")
-    return out
+    return result

--- a/infrastructure/di/container.py
+++ b/infrastructure/di/container.py
@@ -38,7 +38,7 @@ class AppContainer(containers.DeclarativeContainer):
     gateway = providers.Singleton(
         TelegramGateway,
         bot=event.provided.bot,
-        markup_codec=markup_codec,
+        codec=markup_codec,
         chunk=chunk,
         truncate=providers.Object(SETTINGS.truncate),
     )
@@ -63,7 +63,7 @@ class AppContainer(containers.DeclarativeContainer):
         rendering_config=rendering_config,
     )
     view_restorer = providers.Factory(
-        ViewRestorer, markup_codec=markup_codec, ledger=ledger
+        ViewRestorer, codec=markup_codec, ledger=ledger
     )
 
     appender = providers.Factory(


### PR DESCRIPTION
## Summary
- Align Telegram gateway dispatch and edit flows with single-word identifiers and refreshed serializer/media utilities.
- Rename the batch delete runner and gateway protocol signatures while wiring the DI container and restorer to the new codec name.
- Update the renaming roadmap to capture the completed gateway cleanup and remaining snake_case migration work.

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d01ff35c388330b6b5ad7e0b3e9e27