### PR TITLE
Rename inline strategy API to single-word names

### DIFF
--- a/Renaming.md
+++ b/Renaming.md
@@ -15,6 +15,7 @@
 - Telegram media helpers adopt `weblink`/`adapt`/`convert`/`compose`/`assemble`, with inline strategy injection renamed to `probe`/`strictpath` and Settings following suit.
 - Message gateway protocol promotes edit verbs to `rewrite`/`recast`/`retitle`/`remap`, with orchestrator dispatch updated to the new names.
 - Telegram gateway internals now use single-word identifiers throughout dispatch/edit/delete flows, including the extras bundle handling, `DeleteBatch` runner, and the shared `targets`/`extract` helpers with `sanitize` alignment.
+- Inline editing helpers remove the `handle_element`/`_media_editable_inline`/`_reply_changed` names in favour of `handle`, `_inlineable`, and `_replydelta`, dropping the auxiliary `_inline_remap` alias for a streamlined `_inline` import.
 
 ## Next Steps
 - Migrate remaining domain and application layer helpers (e.g., mapper converters, orchestrator builders) that still rely on snake_case naming to single-word equivalents while keeping semantic clarity.
@@ -22,6 +23,7 @@
 - Audit adapter-layer gateway helpers (e.g., `do_edit_text`, `reply_for_send`) and select concise replacements that respect the single-word rule.
 - Extend presenter-facing protocols (e.g., `send_media`) to the new single-word vocabulary established for the gateway.
 - Continue migrating dependency-injection providers and application use-case locals (e.g., `history_repo`, `to_delete`) away from snake_case once core gateway flows stabilise.
+- Align tail orchestration helpers with the inline vocabulary by renaming locals such as `base_msg`/`ids_to_del`/`last_entry` to concise single-word alternatives after the new inline strategy API settles.
 
 ## Gateway Renaming Plan
 

--- a/application/service/view/orchestrator.py
+++ b/application/service/view/orchestrator.py
@@ -442,13 +442,13 @@ class ViewOrchestrator:
                     decision.Decision.EDIT_MARKUP,
             ):
                 if inline:
-                    rr = await self._inline.handle_element(
+                    rr = await self._inline.handle(
                         scope=scope,
                         payload=p,
-                        last_message=o,
+                        tail=o,
                         inline=True,
                         swap=self.swap,
-                        rendering_config=self._rendering_config,
+                        config=self._rendering_config,
                     )
                     out_ids.append(rr.id if rr else o.id)
                     out_extras.append(list(rr.extra if rr else getattr(o, "extras", []) or []))
@@ -487,13 +487,13 @@ class ViewOrchestrator:
                 continue
             if dec == decision.Decision.DELETE_SEND:
                 if inline:
-                    rr = await self._inline.handle_element(
+                    rr = await self._inline.handle(
                         scope=scope,
                         payload=p,
-                        last_message=o,
+                        tail=o,
                         inline=True,
                         swap=self.swap,
-                        rendering_config=self._rendering_config,
+                        config=self._rendering_config,
                     )
                     out_ids.append(rr.id if rr else o.id)
                     out_extras.append(list(rr.extra if rr else getattr(o, "extras", []) or []))

--- a/application/usecase/last.py
+++ b/application/usecase/last.py
@@ -2,7 +2,7 @@ import logging
 from typing import Optional, List
 
 from ..internal.policy import TailPrune, prime
-from ..internal.rules.inline import remap as _inline_remap
+from ..internal.rules.inline import remap as _inline
 from ..log.emit import jlog
 from ..service.view.orchestrator import ViewOrchestrator
 from ...domain.port.history import HistoryRepository
@@ -118,7 +118,7 @@ class Tailer:
         if scope.inline and dec == decision.Decision.DELETE_SEND:
             base_msg = base.messages[0] if (base and base.messages) else None
             if base_msg:
-                remapped = _inline_remap(base_msg, p, inline=True)
+                remapped = _inline(base_msg, p, inline=True)
                 jlog(logger, logging.INFO, LogCode.INLINE_REMAP_DELETE_SEND, from_="DELETE_SEND", to_=remapped.name)
                 if remapped == decision.Decision.EDIT_MARKUP:
                     result = await self._orchestrator.swap(scope, p.morph(media=base_msg.media, group=None), base,
@@ -147,13 +147,13 @@ class Tailer:
                 decision.Decision.EDIT_MARKUP,
         ):
             lm = base.messages[0] if base and base.messages else None
-            result = await self._orchestrator._inline.handle_element(
+            result = await self._orchestrator._inline.handle(
                 scope=scope,
                 payload=p,
-                last_message=lm,
+                tail=lm,
                 inline=True,
                 swap=self._orchestrator.swap,
-                rendering_config=self._orchestrator.rendering_config,
+                config=self._orchestrator.rendering_config,
             )
         else:
             result = await self._orchestrator.swap(scope, p, base, dec)

--- a/presentation/navigator.py
+++ b/presentation/navigator.py
@@ -33,7 +33,7 @@ Navigator API — ключевые контракты:
 8) Inline: ремап DELETE_SEND:
    - В inline DELETE_SEND ремапится в EDIT_MEDIA; в EDIT_TEXT — только когда база и новый — текст.
    - Если медиа не редактируется, но меняется только клавиатура — допускается EDIT_MARKUP.
-    - Точки ремапа: InlineStrategy.handle_element и Tailer.edit.
+    - Точки ремапа: InlineStrategy.handle и Tailer.edit.
    - Лог-маркер: INLINE_REMAP_DELETE_SEND.
 
 9) Inline: last.delete без business — удаляет только из истории при TailPrune=True.


### PR DESCRIPTION
## Summary
- rename the inline strategy entry point to `handle` and adjust its helpers to the new single-word vocabulary
- drop the private `_looks_like_file_id` shim in favour of direct pattern checks and update orchestrator/tailer callers
- document the inline rename in the repository-wide naming plan and refresh navigator guidance

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d02545eabc83309d32b4af79269580