### PR TITLE
Rename view restorer API to single-word terms

### DIFF
--- a/Renaming.md
+++ b/Renaming.md
@@ -43,6 +43,15 @@
 - Promote `MessageGateway` verbs such as `edit_text`, `edit_media`, `edit_caption`, and `edit_markup` to single-word alternatives once downstream call sites have adopted the helper renames listed above.
 - Consolidate result metadata fields (`media_type`, `file_id`, `group_items`) under single-word terms after aligning storage and rendering pipelines.
 
+## View Restoration Plan
+
+| Scope | Legacy Identifier | Replacement |
+|-------|-------------------|-------------|
+| View restorer service | `restore_node` | `revive` |
+| View restorer service | `_try_dynamic_restore` | `_dynamic` |
+| View restorer service | `_static_restore_msg` | `_static` |
+| View restorer logging | `factory_key` keyword | `forge` |
+
 ## Guidelines for Future Renames
 - When multiple contexts share similar operations, choose consistent vocabulary (e.g., prefer `store`/`load` across repositories).
 - Use existing domain terminology (history, tail, scope, ledger) to inform replacement words instead of inventing artificial compounds.

--- a/application/usecase/back.py
+++ b/application/usecase/back.py
@@ -52,7 +52,7 @@ class Rewinder:
         is_inline = bool(scope.inline)
         memory: Dict[str, Any] = await self._state_repo.payload()
         merged = {**memory, **context}
-        restored_payloads = await self._restorer.restore_node(entry_to, merged, inline=is_inline)
+        restored_payloads = await self._restorer.revive(entry_to, merged, inline=is_inline)
         resolved_payloads = [normalize(p) for p in restored_payloads]
         if not is_inline:
             render_result = await self._orchestrator.render_node(

--- a/application/usecase/set.py
+++ b/application/usecase/set.py
@@ -74,7 +74,7 @@ class Setter:
         jlog(logger, logging.INFO, LogCode.STATE_SET, op="set", state={"target": target_entry.state})
         memory = await self._state_repo.payload()
         merged = {**memory, **context}
-        restored_payloads = await self._restorer.restore_node(target_entry, merged, inline=is_inline)
+        restored_payloads = await self._restorer.revive(target_entry, merged, inline=is_inline)
         resolved_payloads = [normalize(p) for p in restored_payloads]
         if not is_inline:
             render_result = await self._orchestrator.render_node(


### PR DESCRIPTION
## Summary
- rename the view restorer entry point to the single-word method `revive`
- align dynamic and static helpers with `_dynamic` and `_static` names and adjust logging keyword usage
- document the new renaming plan updates covering the view restorer vocabulary

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d034f259f083309325d68e3b1e5c76