### PR TITLE
Align tail use-case naming

### DIFF
--- a/Renaming.md
+++ b/Renaming.md
@@ -16,6 +16,8 @@
 - Message gateway protocol promotes edit verbs to `rewrite`/`recast`/`retitle`/`remap`, with orchestrator dispatch updated to the new names.
 - Telegram gateway internals now use single-word identifiers throughout dispatch/edit/delete flows, including the extras bundle handling, `DeleteBatch` runner, and the shared `targets`/`extract` helpers with `sanitize` alignment.
 - Inline editing helpers remove the `handle_element`/`_media_editable_inline`/`_reply_changed` names in favour of `handle`, `_inlineable`, and `_replydelta`, dropping the auxiliary `_inline_remap` alias for a streamlined `_inline` import.
+- Rebase flow shifter dependencies shorten to `ledger`/`buffer`/`latest`, with the pivot message handled through `marker`/`patched`/`trailer`/`rebuilt` terminology.
+- Tail use-case adopts `latest`/`ledger` storage naming, exposes the public `peek` verb, and keeps inline decisions readable through `normal`/`choice`/`mapped`/`targets`/`resend` markers.
 
 ## Next Steps
 - Migrate remaining domain and application layer helpers (e.g., mapper converters, orchestrator builders) that still rely on snake_case naming to single-word equivalents while keeping semantic clarity.
@@ -37,6 +39,38 @@
 | Telegram reply helpers | `reply_for_send`/`reply_for_edit` | `markup(codec, reply, *, edit)` |
 | Gateway logging helpers | Inline replacements for `log_edit_fail`/`log_edit_ok` | Inline `jlog` calls |
 | Telegram batch delete runner | `BatchDeleteRunner` | `DeleteBatch` |
+
+## Tail Use-Case Renaming Plan
+
+| Scope | Legacy Identifier | Replacement |
+|-------|-------------------|-------------|
+| Last message flow | `last_repo` | `latest` |
+| Last message flow | `_last_repo` | `_latest` |
+| Last message flow | `history_repo` | `ledger` |
+| Last message flow | `_history_repo` | `_ledger` |
+| Last message flow | `get_id` | `peek` |
+| Last message flow | `new_history` | `trimmed` |
+| Last message flow | `new_last_id` | `marker` |
+| Last message flow | `last_node` | `tail` |
+| Last message flow | `last_entry` | `anchor` |
+| Last message flow | `base_msg` | `stem` |
+| Last message flow | `ids_to_del` | `targets` |
+| Last message flow | `resend_result` | `resend` |
+
+## Rebase Use-Case Renaming Plan
+
+| Scope | Legacy Identifier | Replacement |
+|-------|-------------------|-------------|
+| Rebase flow | `history_repo` | `ledger` |
+| Rebase flow | `_history_repo` | `_ledger` |
+| Rebase flow | `temp_repo` | `buffer` |
+| Rebase flow | `_temp_repo` | `_buffer` |
+| Rebase flow | `last_repo` | `latest` |
+| Rebase flow | `_last_repo` | `_latest` |
+| Rebase flow | `new_id` | `marker` |
+| Rebase flow | `patched_first` | `patched` |
+| Rebase flow | `rebased_last` | `trailer` |
+| Rebase flow | `rebased` | `rebuilt` |
 
 ## Upcoming Protocol Updates
 

--- a/application/service/view/inline.py
+++ b/application/service/view/inline.py
@@ -100,8 +100,8 @@ class InlineStrategy:
                 verdict = _d.decide(anchor, entry, config)
                 if verdict is _d.Decision.DELETE_SEND:
                     remap = _inline(base, entry, inline=True)
-                    jlog(self._logger, logging.INFO, LogCode.INLINE_REMAP_DELETE_SEND, from_="DELETE_SEND",
-                         to_=remap.name)
+                    jlog(self._logger, logging.INFO, LogCode.INLINE_REMAP_DELETE_SEND, origin="DELETE_SEND",
+                         target=remap.name)
                     if remap is _d.Decision.EDIT_MARKUP:
                         return await swap(
                             scope,

--- a/application/usecase/last.py
+++ b/application/usecase/last.py
@@ -19,41 +19,41 @@ logger = logging.getLogger(__name__)
 class Tailer:
     def __init__(
             self,
-            last_repo: LastMessageRepository,
-            history_repo: HistoryRepository,
+            latest: LastMessageRepository,
+            ledger: HistoryRepository,
             gateway: MessageGateway,
             orchestrator: ViewOrchestrator,
     ):
-        self._last_repo = last_repo
-        self._history_repo = history_repo
+        self._latest = latest
+        self._ledger = ledger
         self._gateway = gateway
         self._orchestrator = orchestrator
 
-    async def get_id(self) -> Optional[int]:
-        mid = await self._last_repo.peek()
-        jlog(logger, logging.INFO, LogCode.LAST_GET, message={"id": mid})
-        return mid
+    async def peek(self) -> Optional[int]:
+        marker = await self._latest.peek()
+        jlog(logger, logging.INFO, LogCode.LAST_GET, message={"id": marker})
+        return marker
 
     async def delete(self, scope: Scope) -> None:
-        history = await self._history_repo.recall()
+        history = await self._ledger.recall()
         if not history:
             jlog(logger, logging.INFO, LogCode.RENDER_SKIP, op="last.delete", note="no_history")
             return
         if scope.inline and not scope.business:
             if TailPrune:
-                new_history = history[:-1]
-                await self._history_repo.archive(new_history)
-                jlog(logger, logging.DEBUG, LogCode.HISTORY_SAVE, op="last.delete", history={"len": len(new_history)})
-                new_last_id = None
-                if new_history and new_history[-1].messages:
-                    new_last_id = int(new_history[-1].messages[0].id)
-                await self._last_repo.mark(new_last_id)
+                trimmed = history[:-1]
+                await self._ledger.archive(trimmed)
+                jlog(logger, logging.DEBUG, LogCode.HISTORY_SAVE, op="last.delete", history={"len": len(trimmed)})
+                marker = None
+                if trimmed and trimmed[-1].messages:
+                    marker = int(trimmed[-1].messages[0].id)
+                await self._latest.mark(marker)
                 jlog(
                     logger,
                     logging.INFO,
-                    LogCode.LAST_SET if new_last_id is not None else LogCode.LAST_DELETE,
+                    LogCode.LAST_SET if marker is not None else LogCode.LAST_DELETE,
                     op="last.delete",
-                    message={"id": new_last_id},
+                    message={"id": marker},
                 )
             else:
                 jlog(
@@ -65,16 +65,16 @@ class Tailer:
                     note="inline_noop",
                 )
             return
-        last_node = history[-1]
+        tail = history[-1]
         ids: List[int] = []
-        for m in last_node.messages:
-            ids.append(m.id)
-            ids.extend(list(getattr(m, "extras", []) or []))
+        for message in tail.messages:
+            ids.append(message.id)
+            ids.extend(list(getattr(message, "extras", []) or []))
         if ids:
             await self._gateway.delete(scope, ids)
-        await self._history_repo.archive(history[:-1])
+        await self._ledger.archive(history[:-1])
         jlog(logger, logging.DEBUG, LogCode.HISTORY_SAVE, op="last.delete", history={"len": len(history) - 1})
-        await self._last_repo.mark(None)
+        await self._latest.mark(None)
         jlog(
             logger,
             logging.INFO,
@@ -84,55 +84,59 @@ class Tailer:
         )
 
     async def edit(self, scope: Scope, payload: Payload) -> Optional[int]:
-        last_id = await self._last_repo.peek()
-        if not last_id:
+        marker = await self._latest.peek()
+        if not marker:
             jlog(logger, logging.INFO, LogCode.RENDER_SKIP, op="last.edit", note="no_last_id")
             return None
 
-        p = normalize(payload)
-        if scope.inline and getattr(p, "group", None):
-            first = p.group[0]
-            p = p.morph(media=first, group=None)
+        normal = normalize(payload)
+        if scope.inline and getattr(normal, "group", None):
+            first = normal.group[0]
+            normal = normal.morph(media=first, group=None)
 
-        history = await self._history_repo.recall()
-        last_entry = None
-        for e in reversed(history):
-            if e.messages and e.messages[0].id == last_id:
-                last_entry = e
+        history = await self._ledger.recall()
+        anchor = None
+        for entry in reversed(history):
+            if entry.messages and entry.messages[0].id == marker:
+                anchor = entry
                 break
 
-        if last_entry is not None:
-            dec = decision.decide(last_entry, p, self._orchestrator.rendering_config)
+        if anchor is not None:
+            choice = decision.decide(anchor, normal, self._orchestrator.rendering_config)
         else:
-            if p.media:
-                dec = decision.Decision.EDIT_MEDIA
-            elif p.text is not None:
-                dec = decision.Decision.EDIT_TEXT
-            elif p.reply is not None:
-                dec = decision.Decision.EDIT_MARKUP
+            if normal.media:
+                choice = decision.Decision.EDIT_MEDIA
+            elif normal.text is not None:
+                choice = decision.Decision.EDIT_TEXT
+            elif normal.reply is not None:
+                choice = decision.Decision.EDIT_MARKUP
             else:
                 return None
 
-        base = last_entry if last_entry is not None else prime(last_id, p)
+        base = anchor if anchor is not None else prime(marker, normal)
 
-        if scope.inline and dec == decision.Decision.DELETE_SEND:
-            base_msg = base.messages[0] if (base and base.messages) else None
-            if base_msg:
-                remapped = _inline(base_msg, p, inline=True)
-                jlog(logger, logging.INFO, LogCode.INLINE_REMAP_DELETE_SEND, from_="DELETE_SEND", to_=remapped.name)
-                if remapped == decision.Decision.EDIT_MARKUP:
-                    result = await self._orchestrator.swap(scope, p.morph(media=base_msg.media, group=None), base,
-                                                           remapped)
+        if scope.inline and choice == decision.Decision.DELETE_SEND:
+            stem = base.messages[0] if (base and base.messages) else None
+            if stem:
+                mapped = _inline(stem, normal, inline=True)
+                jlog(logger, logging.INFO, LogCode.INLINE_REMAP_DELETE_SEND, origin="DELETE_SEND", target=mapped.name)
+                if mapped == decision.Decision.EDIT_MARKUP:
+                    result = await self._orchestrator.swap(
+                        scope,
+                        normal.morph(media=stem.media, group=None),
+                        base,
+                        mapped,
+                    )
                     if result:
-                        await self._last_repo.mark(result.id)
+                        await self._latest.mark(result.id)
                         jlog(logger, logging.INFO, LogCode.LAST_SET, op="last.edit", message={"id": result.id})
                         return result.id
                     jlog(logger, logging.INFO, LogCode.RENDER_SKIP, op="last.edit", note="inline_remap_markup_noop")
                     return None
-                if remapped in (decision.Decision.EDIT_TEXT, decision.Decision.EDIT_MEDIA):
-                    result = await self._orchestrator.swap(scope, p, base, remapped)
+                if mapped in (decision.Decision.EDIT_TEXT, decision.Decision.EDIT_MEDIA):
+                    result = await self._orchestrator.swap(scope, normal, base, mapped)
                     if result:
-                        await self._last_repo.mark(result.id)
+                        await self._latest.mark(result.id)
                         jlog(logger, logging.INFO, LogCode.LAST_SET, op="last.edit", message={"id": result.id})
                         return result.id
                     jlog(logger, logging.INFO, LogCode.RENDER_SKIP, op="last.edit", note="inline_remap_noop")
@@ -140,74 +144,74 @@ class Tailer:
             jlog(logger, logging.INFO, LogCode.RENDER_SKIP, op="last.edit", note="inline_no_content_type_switch")
             return None
 
-        if scope.inline and dec in (
+        if scope.inline and choice in (
                 decision.Decision.EDIT_TEXT,
                 decision.Decision.EDIT_MEDIA,
                 decision.Decision.EDIT_MEDIA_CAPTION,
                 decision.Decision.EDIT_MARKUP,
         ):
-            lm = base.messages[0] if base and base.messages else None
+            head = base.messages[0] if base and base.messages else None
             result = await self._orchestrator._inline.handle(
                 scope=scope,
-                payload=p,
-                tail=lm,
+                payload=normal,
+                tail=head,
                 inline=True,
                 swap=self._orchestrator.swap,
                 config=self._orchestrator.rendering_config,
             )
         else:
-            result = await self._orchestrator.swap(scope, p, base, dec)
+            result = await self._orchestrator.swap(scope, normal, base, choice)
 
         if result:
-            await self._last_repo.mark(result.id)
+            await self._latest.mark(result.id)
             jlog(logger, logging.INFO, LogCode.LAST_SET, op="last.edit", message={"id": result.id})
 
-            if last_entry is not None:
-                idx = None
-                for i in range(len(history) - 1, -1, -1):
-                    if history[i].messages and history[i].messages[0].id == last_id:
-                        idx = i
+            if anchor is not None:
+                cursor = None
+                for index in range(len(history) - 1, -1, -1):
+                    if history[index].messages and history[index].messages[0].id == marker:
+                        cursor = index
                         break
-                if idx is not None:
+                if cursor is not None:
                     from ..service.store import reindex
-                    old_msg = history[idx].messages[0]
-                    need_patch = (result.id != old_msg.id)
-                    new_extras = [result.extra] if need_patch else None
-                    patched = reindex(history[idx], [result.id], new_extras)
-                    history[idx] = patched
-                    await self._history_repo.archive(history)
+                    former = history[cursor].messages[0]
+                    mismatch = (result.id != former.id)
+                    bundle = [result.extra] if mismatch else None
+                    patched = reindex(history[cursor], [result.id], bundle)
+                    history[cursor] = patched
+                    await self._ledger.archive(history)
                     jlog(logger, logging.DEBUG, LogCode.HISTORY_SAVE, op="last.edit", history={"len": len(history)})
             return result.id
 
-        if dec is decision.Decision.EDIT_TEXT and not (p.text and str(p.text).strip()):
+        if choice is decision.Decision.EDIT_TEXT and not (normal.text and str(normal.text).strip()):
             return None
-        if dec in (decision.Decision.EDIT_MEDIA, decision.Decision.EDIT_MEDIA_CAPTION) and not (p.media or p.group):
+        if choice in (decision.Decision.EDIT_MEDIA, decision.Decision.EDIT_MEDIA_CAPTION) and not (normal.media or normal.group):
             return None
 
-        if (not scope.inline) and dec in (
+        if (not scope.inline) and choice in (
                 decision.Decision.EDIT_TEXT,
                 decision.Decision.EDIT_MEDIA,
                 decision.Decision.EDIT_MEDIA_CAPTION,
                 decision.Decision.DELETE_SEND,
         ):
-            ids_to_del = [last_id]
-            if last_entry and last_entry.messages:
-                ids_to_del += list(last_entry.messages[0].extras or [])
-            await self._gateway.delete(scope, ids_to_del)
-            resend_result = await self._orchestrator.swap(scope, p, None, decision.Decision.RESEND)
-            if resend_result:
-                idx = None
-                for i in range(len(history) - 1, -1, -1):
-                    if history[i].messages and history[i].messages[0].id == last_id:
-                        idx = i
+            targets = [marker]
+            if anchor and anchor.messages:
+                targets += list(anchor.messages[0].extras or [])
+            await self._gateway.delete(scope, targets)
+            resend = await self._orchestrator.swap(scope, normal, None, decision.Decision.RESEND)
+            if resend:
+                cursor = None
+                for index in range(len(history) - 1, -1, -1):
+                    if history[index].messages and history[index].messages[0].id == marker:
+                        cursor = index
                         break
-                if idx is not None:
+                if cursor is not None:
                     from ..service.store import reindex
-                    patched = reindex(history[idx], [resend_result.id], [resend_result.extra])
-                    history[idx] = patched
-                    await self._history_repo.archive(history)
+                    patched = reindex(history[cursor], [resend.id], [resend.extra])
+                    history[cursor] = patched
+                    await self._ledger.archive(history)
                     jlog(logger, logging.DEBUG, LogCode.HISTORY_SAVE, op="last.edit", history={"len": len(history)})
-                await self._last_repo.mark(resend_result.id)
-                jlog(logger, logging.INFO, LogCode.LAST_SET, op="last.edit", message={"id": resend_result.id})
-                return resend_result.id
+                await self._latest.mark(resend.id)
+                jlog(logger, logging.INFO, LogCode.LAST_SET, op="last.edit", message={"id": resend.id})
+                return resend.id
         return None

--- a/infrastructure/di/container.py
+++ b/infrastructure/di/container.py
@@ -91,9 +91,9 @@ class AppContainer(containers.DeclarativeContainer):
         orchestrator=view_orchestrator, last_repo=last_repo,
     )
     trimmer = providers.Factory(Trimmer, history_repo=history_repo, last_repo=last_repo)
-    shifter = providers.Factory(Shifter, history_repo=history_repo, temp_repo=temp_repo, last_repo=last_repo)
+    shifter = providers.Factory(Shifter, ledger=history_repo, buffer=temp_repo, latest=last_repo)
     tailer = providers.Factory(
-        Tailer, last_repo=last_repo, history_repo=history_repo, gateway=gateway,
+        Tailer, latest=last_repo, ledger=history_repo, gateway=gateway,
         orchestrator=view_orchestrator,
     )
     alarm = providers.Factory(

--- a/presentation/navigator.py
+++ b/presentation/navigator.py
@@ -75,7 +75,7 @@ class _Tail:
     async def get(self) -> Optional[Dict[str, Any]]:
         jlog(logger, logging.INFO, LogCode.NAVIGATOR_API, method="last.get", scope=profile(self._scope))
         async with locks.guard(self._scope):
-            identifier = await self._tailer.get_id()
+            identifier = await self._tailer.peek()
         if identifier is None:
             return None
         return {


### PR DESCRIPTION
## Summary
- Documented single-word targets for the tail and rebase use-cases in `Renaming.md` and aligned the execution vocabulary around `peek`, `marker`, and new storage aliases.
- Updated the rebase shifter and tailer flows to use the new names throughout their logic, including dependency wiring, inline decision logging, and presenter integration.

## Testing
- python -m compileall application/usecase/rebase.py application/usecase/last.py presentation/navigator.py infrastructure/di/container.py application/service/view/inline.py

------
https://chatgpt.com/codex/tasks/task_e_68d036353edc83309fb0ce39228446be