### PR TITLE
Align logging helpers with single-word naming

### DIFF
--- a/Renaming.md
+++ b/Renaming.md
@@ -18,6 +18,8 @@
 - Inline editing helpers remove the `handle_element`/`_media_editable_inline`/`_reply_changed` names in favour of `handle`, `_inlineable`, and `_replydelta`, dropping the auxiliary `_inline_remap` alias for a streamlined `_inline` import.
 - Rebase flow shifter dependencies shorten to `ledger`/`buffer`/`latest`, with the pivot message handled through `marker`/`patched`/`trailer`/`rebuilt` terminology.
 - Tail use-case adopts `latest`/`ledger` storage naming, exposes the public `peek` verb, and keeps inline decisions readable through `normal`/`choice`/`mapped`/`targets`/`resend` markers.
+- Logging decorator utilities now rely on `_capture` and `_snapshot`, with the `trace` decorator exposing the public `begin`/`success`/`skip` argument trio for clarity.
+- Gateway error pattern builders collapse to the classmethod `collect`, removing the final `from_phrases` snake-case entry point.
 
 ## Next Steps
 - Migrate remaining domain and application layer helpers (e.g., mapper converters, orchestrator builders) that still rely on snake_case naming to single-word equivalents while keeping semantic clarity.

--- a/adapters/telegram/gateway/patterns.py
+++ b/adapters/telegram/gateway/patterns.py
@@ -19,7 +19,7 @@ class ErrorPatterns:
     patterns: tuple[str, ...]
 
     @classmethod
-    def from_phrases(cls, *phrases: str) -> ErrorPatterns:
+    def collect(cls, *phrases: str) -> ErrorPatterns:
         normalized = tuple(phrase.lower() for phrase in phrases)
         return cls(patterns=normalized)
 
@@ -30,9 +30,9 @@ class ErrorPatterns:
         return any(fragment in lowered for fragment in self.patterns)
 
 
-NOT_MODIFIED = ErrorPatterns.from_phrases("message is not modified")
+NOT_MODIFIED = ErrorPatterns.collect("message is not modified")
 
-EDIT_FORBIDDEN = ErrorPatterns.from_phrases(
+EDIT_FORBIDDEN = ErrorPatterns.collect(
     "message can't be edited",
     "bot can't edit message",
     "message is not editable",


### PR DESCRIPTION
## Summary
- rename the logging decorator helpers to the new `_capture`/`_snapshot` names and expose the `trace` arguments as `begin`/`success`/`skip`
- rename the Telegram error pattern constructor to the single-word classmethod `collect`
- document the naming updates in the renaming plan

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d038cb9a948330905d6a02694f5664