### PR TITLE
Refine use case naming vocabulary

### DIFF
--- a/adapters/storage/transitionrecorder.py
+++ b/adapters/storage/transitionrecorder.py
@@ -9,54 +9,53 @@ from ...domain.log.code import LogCode
 
 
 class TransitionRecorder(TransitionObserver):
-    def __init__(self, state_repo: StateRepository):
-        self._state_repo = state_repo
+    def __init__(self, status: StateRepository):
+        self._status = status
         self._logger = logging.getLogger(__name__)
 
-    async def on_transition(self, from_state: Optional[str], to_state: str) -> None:
-        graph = await self._state_repo.diagram()
-        nodes_before = list(graph.nodes)
-        before_edges_raw: Dict[str, List[str]] = dict(graph.edges)
-        if from_state is None:
-            nodes: Set[str] = set(graph.nodes)
-            nodes.add(to_state)
-            new_graph = Graph(
+    async def on_transition(self, origin: Optional[str], target: str) -> None:
+        chart = await self._status.diagram()
+        baseline = list(chart.nodes)
+        prior: Dict[str, Set[str]] = {name: set(paths) for name, paths in chart.edges.items()}
+        if origin is None:
+            nodes: Set[str] = set(chart.nodes)
+            nodes.add(target)
+            fresh = Graph(
                 nodes=sorted(list(nodes)),
-                edges={k: list(v) for k, v in graph.edges.items()},
+                edges={name: list(paths) for name, paths in chart.edges.items()},
             )
-            await self._state_repo.capture(new_graph)
+            await self._status.capture(fresh)
             jlog(
                 self._logger,
                 logging.DEBUG,
                 LogCode.TRANSITION,
-                state={"from": None, "to": to_state},
-                nodes_before=len(nodes_before),
-                nodes_after=len(new_graph.nodes),
+                state={"from": None, "to": target},
+                nodes_before=len(baseline),
+                nodes_after=len(fresh.nodes),
                 edges_added=[],
             )
             return
-        if from_state == to_state:
+        if origin == target:
             return
-        nodes: Set[str] = set(graph.nodes)
-        nodes.update({from_state, to_state})
-        edges_sets: Dict[str, Set[str]] = {st: set(neigh) for st, neigh in graph.edges.items()}
-        edges_sets.setdefault(from_state, set()).add(to_state)
-        edges_sets.setdefault(to_state, set()).add(from_state)
-        updated_edges: Dict[str, List[str]] = {st: sorted(list(neigh)) for st, neigh in edges_sets.items()}
-        new_graph = Graph(nodes=sorted(list(nodes)), edges=updated_edges)
-        await self._state_repo.capture(new_graph)
-        before_edges: Dict[str, Set[str]] = {st: set(neigh) for st, neigh in before_edges_raw.items()}
-        after_edges: Dict[str, Set[str]] = {st: set(neigh) for st, neigh in new_graph.edges.items()}
-        added_from = sorted(list(after_edges.get(from_state, set()) - before_edges.get(from_state, set())))
-        added_to = sorted(list(after_edges.get(to_state, set()) - before_edges.get(to_state, set())))
+        nodes: Set[str] = set(chart.nodes)
+        nodes.update({origin, target})
+        bundles: Dict[str, Set[str]] = {name: set(paths) for name, paths in chart.edges.items()}
+        bundles.setdefault(origin, set()).add(target)
+        bundles.setdefault(target, set()).add(origin)
+        edges: Dict[str, List[str]] = {name: sorted(list(paths)) for name, paths in bundles.items()}
+        fresh = Graph(nodes=sorted(list(nodes)), edges=edges)
+        await self._status.capture(fresh)
+        after: Dict[str, Set[str]] = {name: set(paths) for name, paths in fresh.edges.items()}
+        origin_added = sorted(list(after.get(origin, set()) - prior.get(origin, set())))
+        target_added = sorted(list(after.get(target, set()) - prior.get(target, set())))
         jlog(
             self._logger,
             logging.DEBUG,
             LogCode.TRANSITION,
-            state={"from": from_state, "to": to_state},
-            nodes_before=len(nodes_before),
-            nodes_after=len(new_graph.nodes),
-            edges_added={"from": added_from, "to": added_to},
+            state={"from": origin, "to": target},
+            nodes_before=len(baseline),
+            nodes_after=len(fresh.nodes),
+            edges_added={"from": origin_added, "to": target_added},
         )
 
 


### PR DESCRIPTION
## Summary
- align navigator back/set/pop flows with the single-word naming scheme (ledger/status/latest, targets, trim markers)
- streamline the transition recorder API to use single-word parameters while keeping logging intact
- update the dependency injection container to provide the renamed collaborators with single-word provider names

## Testing
- python -m compileall application/usecase/back.py application/usecase/set.py application/usecase/pop.py adapters/storage/transitionrecorder.py infrastructure/di/container.py

------
https://chatgpt.com/codex/tasks/task_e_68d03a55d364833080a0cf4fade51bf1