### PR TITLE
Refine gateway metadata naming

### DIFF
--- a/Renaming.md
+++ b/Renaming.md
@@ -20,6 +20,7 @@
 - Tail use-case adopts `latest`/`ledger` storage naming, exposes the public `peek` verb, and keeps inline decisions readable through `normal`/`choice`/`mapped`/`targets`/`resend` markers.
 - Logging decorator utilities now rely on `_capture` and `_snapshot`, with the `trace` decorator exposing the public `begin`/`success`/`skip` argument trio for clarity.
 - Gateway error pattern builders collapse to the classmethod `collect`, removing the final `from_phrases` snake-case entry point.
+- Gateway result metadata now settles on single-word keys `medium`/`file`/`clusters`, with the view orchestrator mirroring the terminology through its `rendering` profile accessor.
 
 ## Next Steps
 - Migrate remaining domain and application layer helpers (e.g., mapper converters, orchestrator builders) that still rely on snake_case naming to single-word equivalents while keeping semantic clarity.
@@ -77,7 +78,7 @@
 ## Upcoming Protocol Updates
 
 - Promote `MessageGateway` verbs such as `edit_text`, `edit_media`, `edit_caption`, and `edit_markup` to single-word alternatives once downstream call sites have adopted the helper renames listed above.
-- Consolidate result metadata fields (`media_type`, `file_id`, `group_items`) under single-word terms after aligning storage and rendering pipelines.
+- Audit downstream consumers for the new `medium`/`file`/`clusters` metadata vocabulary to ensure compatibility across storage and presentation layers.
 
 ## View Restoration Plan
 

--- a/adapters/storage/historyrepo.py
+++ b/adapters/storage/historyrepo.py
@@ -29,7 +29,7 @@ class MediaCodec:
             return None
         return {
             "type": item.type.value,
-            "file_id": item.path,
+            "file": item.path,
             "caption": item.caption,
         }
 
@@ -38,7 +38,7 @@ class MediaCodec:
         if not isinstance(data, Dict):
             return None
         kind = data.get("type")
-        file_id = data.get("file_id")
+        file_id = data.get("file")
         if not (isinstance(kind, str) and isinstance(file_id, str) and file_id):
             return None
         return MediaItem(type=MediaType(kind), path=file_id, caption=data.get("caption"))

--- a/adapters/telegram/gateway/send.py
+++ b/adapters/telegram/gateway/send.py
@@ -37,15 +37,15 @@ async def dispatch(bot, codec: MarkupCodec, scope: Scope, payload, *, truncate: 
             items = []
             for message in messages:
                 if message.photo:
-                    items.append({"media_type": "photo", "file_id": message.photo[-1].file_id, "caption": message.caption})
+                    items.append({"medium": "photo", "file": message.photo[-1].file_id, "caption": message.caption})
                 elif message.video:
-                    items.append({"media_type": "video", "file_id": message.video.file_id, "caption": message.caption})
+                    items.append({"medium": "video", "file": message.video.file_id, "caption": message.caption})
                 elif message.animation:
-                    items.append({"media_type": "animation", "file_id": message.animation.file_id, "caption": message.caption})
+                    items.append({"medium": "animation", "file": message.animation.file_id, "caption": message.caption})
                 elif message.document:
-                    items.append({"media_type": "document", "file_id": message.document.file_id, "caption": message.caption})
+                    items.append({"medium": "document", "file": message.document.file_id, "caption": message.caption})
                 elif message.audio:
-                    items.append({"media_type": "audio", "file_id": message.audio.file_id, "caption": message.caption})
+                    items.append({"medium": "audio", "file": message.audio.file_id, "caption": message.caption})
             jlog(
                 logger,
                 logging.INFO,
@@ -54,7 +54,7 @@ async def dispatch(bot, codec: MarkupCodec, scope: Scope, payload, *, truncate: 
                 payload=_classify(payload),
                 message={"id": messages[0].message_id, "extra_len": len(messages) - 1},
             )
-            meta = {"kind": "group", "group_items": items, "inline": scope.inline}
+            meta = {"kind": "group", "clusters": items, "inline": scope.inline}
             return Result(
                 id=messages[0].message_id,
                 extra=[message.message_id for message in messages[1:]],

--- a/adapters/telegram/gateway/util.py
+++ b/adapters/telegram/gateway/util.py
@@ -27,33 +27,33 @@ def _digest(message: Message) -> dict:
             and not getattr(message, "audio", None) and not getattr(message, "animation", None):
         return {"kind": "text", "text": message.text, "inline": None}
     if getattr(message, "photo", None):
-        return {"kind": "media", "media_type": "photo", "file_id": message.photo[-1].file_id, "caption": message.caption, "inline": None}
+        return {"kind": "media", "medium": "photo", "file": message.photo[-1].file_id, "caption": message.caption, "inline": None}
     if getattr(message, "video", None):
-        return {"kind": "media", "media_type": "video", "file_id": message.video.file_id, "caption": message.caption,
+        return {"kind": "media", "medium": "video", "file": message.video.file_id, "caption": message.caption,
                 "inline": None}
     if getattr(message, "animation", None):
-        return {"kind": "media", "media_type": "animation", "file_id": message.animation.file_id, "caption": message.caption,
+        return {"kind": "media", "medium": "animation", "file": message.animation.file_id, "caption": message.caption,
                 "inline": None}
     if getattr(message, "document", None):
-        return {"kind": "media", "media_type": "document", "file_id": message.document.file_id, "caption": message.caption,
+        return {"kind": "media", "medium": "document", "file": message.document.file_id, "caption": message.caption,
                 "inline": None}
     if getattr(message, "audio", None):
-        return {"kind": "media", "media_type": "audio", "file_id": message.audio.file_id, "caption": message.caption,
+        return {"kind": "media", "medium": "audio", "file": message.audio.file_id, "caption": message.caption,
                 "inline": None}
     if getattr(message, "voice", None):
-        return {"kind": "media", "media_type": "voice", "file_id": message.voice.file_id, "caption": message.caption,
+        return {"kind": "media", "medium": "voice", "file": message.voice.file_id, "caption": message.caption,
                 "inline": None}
     if getattr(message, "video_note", None):
-        return {"kind": "media", "media_type": "video_note", "file_id": message.video_note.file_id, "caption": None,
+        return {"kind": "media", "medium": "video_note", "file": message.video_note.file_id, "caption": None,
                 "inline": None}
     return {"kind": "text", "text": getattr(message, "text", None), "inline": None}
 
 
 def extract(outcome: Any, payload: Any, scope: Scope) -> dict:
     """
-    Возвращает dict: kind, media_type, file_id, caption, text, group_items, inline.
+    Возвращает dict: kind, medium, file, caption, text, clusters, inline.
     Для inline всегда проставлять inline из scope.
-    Для media_group собирать group_items в send.py и передавать сюда готовым dict.
+    Для media_group собирать clusters в send.py и передавать сюда готовым dict.
     """
     token = getattr(scope, "inline", None)
     if hasattr(outcome, "message_id"):
@@ -61,16 +61,16 @@ def extract(outcome: Any, payload: Any, scope: Scope) -> dict:
         body["inline"] = token
         return body
     if getattr(payload, "group", None):
-        return {"kind": "group", "group_items": None, "inline": token}
+        return {"kind": "group", "clusters": None, "inline": token}
     if getattr(payload, "media", None):
         media = getattr(payload.media.type, "value", None)
         return {
             "kind": "media",
-            "media_type": media,
-            "file_id": None,
+            "medium": media,
+            "file": None,
             "caption": None,
             "text": None,
-            "group_items": None,
+            "clusters": None,
             "inline": token,
         }
     return {"kind": "text", "text": getattr(payload, "text", None), "inline": token}

--- a/application/map/entry.py
+++ b/application/map/entry.py
@@ -47,23 +47,23 @@ class EntryMapper:
             if k == "text":
                 text, media, group = meta.get("text"), None, None
             elif k == "media":
-                variant = meta.get("media_type")
+                variant = meta.get("medium")
                 if payload.media:
                     mtype = payload.media.type
                 elif isinstance(variant, str):
                     mtype = MediaType(variant)
                 else:
-                    raise ValueError("meta_missing_media_type")
-                mi = MediaItem(type=mtype, path=meta.get("file_id"), caption=meta.get("caption"))
+                    raise ValueError("meta_missing_medium")
+                mi = MediaItem(type=mtype, path=meta.get("file"), caption=meta.get("caption"))
                 text, media, group = None, mi, None
             elif k == "group":
                 items = []
-                for it in (meta.get("group_items") or []):
-                    variant = it.get("media_type")
+                for it in (meta.get("clusters") or []):
+                    variant = it.get("medium")
                     if not isinstance(variant, str):
-                        raise ValueError("meta_missing_group_media_type")
+                        raise ValueError("meta_missing_group_medium")
                     items.append(
-                        MediaItem(type=MediaType(variant), path=it.get("file_id"), caption=it.get("caption"))
+                        MediaItem(type=MediaType(variant), path=it.get("file"), caption=it.get("caption"))
                     )
                 text, media, group = None, None, items
 

--- a/application/usecase/last.py
+++ b/application/usecase/last.py
@@ -102,7 +102,7 @@ class Tailer:
                 break
 
         if anchor is not None:
-            choice = decision.decide(anchor, normal, self._orchestrator.rendering_config)
+            choice = decision.decide(anchor, normal, self._orchestrator.rendering)
         else:
             if normal.media:
                 choice = decision.Decision.EDIT_MEDIA
@@ -157,7 +157,7 @@ class Tailer:
                 tail=head,
                 inline=True,
                 swap=self._orchestrator.swap,
-                config=self._orchestrator.rendering_config,
+                config=self._orchestrator.rendering,
             )
         else:
             result = await self._orchestrator.swap(scope, normal, base, choice)

--- a/domain/port/message.py
+++ b/domain/port/message.py
@@ -12,11 +12,11 @@ class Result:
     id: int
     extra: List[int]
     kind: Literal["text", "media", "group"]
-    media_type: Optional[str] = None
-    file_id: Optional[str] = None
+    medium: Optional[str] = None
+    file: Optional[str] = None
     caption: Optional[str] = None
     text: Optional[str] = None
-    group_items: Optional[List[dict]] = None
+    clusters: Optional[List[dict]] = None
     inline: Optional[str] = None
 
 

--- a/domain/service/rendering/helpers.py
+++ b/domain/service/rendering/helpers.py
@@ -9,7 +9,7 @@ def classify(p: Payload) -> Dict[str, Any]:
     if p.group:
         return {"kind": "group", "group_len": len(p.group)}
     if p.media:
-        return {"kind": "media", "media_type": getattr(p.media.type, "value", None)}
+        return {"kind": "media", "medium": getattr(p.media.type, "value", None)}
     return {"kind": "text"}
 
 

--- a/infrastructure/di/container.py
+++ b/infrastructure/di/container.py
@@ -60,7 +60,7 @@ class AppContainer(containers.DeclarativeContainer):
         ViewOrchestrator,
         gateway=gateway,
         inline=strategy,
-        rendering_config=rendering,
+        rendering=rendering,
     )
     restorer = providers.Factory(
         ViewRestorer, codec=codec, ledger=ledger


### PR DESCRIPTION
## Summary
- rename message result metadata fields from `media_type`/`file_id`/`group_items` to single-word keys `medium`/`file`/`clusters`
- update orchestrator accessors and dependency wiring to use the shorter `rendering` name
- refresh the renaming plan to capture the completed vocabulary changes

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d03d746bd08330a78e2b64f0f9cee4