### PR TITLE
Rename view orchestrator render flow

### DIFF
--- a/Renaming.md
+++ b/Renaming.md
@@ -21,6 +21,7 @@
 - Logging decorator utilities now rely on `_capture` and `_snapshot`, with the `trace` decorator exposing the public `begin`/`success`/`skip` argument trio for clarity.
 - Gateway error pattern builders collapse to the classmethod `collect`, removing the final `from_phrases` snake-case entry point.
 - Gateway result metadata now settles on single-word keys `medium`/`file`/`clusters`, with the view orchestrator mirroring the terminology through its `rendering` profile accessor.
+- View orchestrator API now exposes `render` with single-word helpers (`head`/`album`/`refine`/`verify`) and accumulators (`primary`/`bundles`/`notes`) to replace the legacy `render_node` flow.
 
 ## Next Steps
 - Migrate remaining domain and application layer helpers (e.g., mapper converters, orchestrator builders) that still rely on snake_case naming to single-word equivalents while keeping semantic clarity.

--- a/application/usecase/add.py
+++ b/application/usecase/add.py
@@ -54,7 +54,7 @@ class Appender:
             scope=profile(scope),
         )
         trail = records[-1] if records else None
-        render = await self._orchestrator.render_node("add", scope, adjusted, trail, inline=bool(scope.inline))
+        render = await self._orchestrator.render("add", scope, adjusted, trail, inline=bool(scope.inline))
         if not render or not render.ids or not render.changed:
             jlog(logger, logging.INFO, LogCode.RENDER_SKIP, op="add")
             return

--- a/application/usecase/back.py
+++ b/application/usecase/back.py
@@ -55,7 +55,7 @@ class Rewinder:
         restored = await self._restorer.revive(target, merged, inline=inline)
         resolved = [normalize(p) for p in restored]
         if not inline:
-            render = await self._orchestrator.render_node(
+            render = await self._orchestrator.render(
                 "back",
                 scope,
                 resolved,
@@ -63,7 +63,7 @@ class Rewinder:
                 inline=False,
             )
         else:
-            render = await self._orchestrator.render_node(
+            render = await self._orchestrator.render(
                 "back",
                 scope,
                 resolved,

--- a/application/usecase/replace.py
+++ b/application/usecase/replace.py
@@ -40,7 +40,7 @@ class Swapper:
         records = await self._archive.recall()
         jlog(logger, logging.DEBUG, LogCode.HISTORY_LOAD, op="replace", history={"len": len(records)})
         trail = records[-1] if records else None
-        render = await self._orchestrator.render_node(
+        render = await self._orchestrator.render(
             "replace", scope, adjusted, trail, inline=bool(scope.inline)
         )
         if not render or not render.ids or not render.changed:

--- a/application/usecase/set.py
+++ b/application/usecase/set.py
@@ -77,7 +77,7 @@ class Setter:
         restored = await self._restorer.revive(target, merged, inline=inline)
         resolved = [normalize(p) for p in restored]
         if not inline:
-            render = await self._orchestrator.render_node(
+            render = await self._orchestrator.render(
                 "set",
                 scope,
                 resolved,
@@ -85,7 +85,7 @@ class Setter:
                 inline=False,
             )
         else:
-            render = await self._orchestrator.render_node(
+            render = await self._orchestrator.render(
                 "set",
                 scope,
                 resolved,

--- a/domain/service/rendering/decision.py
+++ b/domain/service/rendering/decision.py
@@ -180,7 +180,7 @@ def decide(old: Optional[object], new: Payload, config: RenderingConfig) -> Deci
     Контракт:
     - Любые группы в old/new ⇒ DELETE_SEND.
     - Частичное редактирование альбомов выполняется вне decide: ранняя ветка в
-      ViewOrchestrator.render_node обрабатывает совместимые альбомы.
+      ViewOrchestrator.render обрабатывает совместимые альбомы.
     - Inline-ограничения и ремап DELETE_SEND применяются на уровне стратегий inline.
     """
     if not old:


### PR DESCRIPTION
## Summary
- rename ViewOrchestrator helpers to single-word variants and expose a single render entry point
- update use cases and rendering decision documentation to reference the new render method
- extend the renaming plan with the orchestrator migration details

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d0b7201f0083309a73fde484caa85a