### PR TITLE
Enforce single-word naming across helpers

### DIFF
--- a/Renaming.md
+++ b/Renaming.md
@@ -26,6 +26,10 @@
 - Domain history message entity now uses the full word `Message`, with mapper/store helpers replacing `msg`/`msgs` locals by `message`/`messages` and removing short aliases such as `mid`/`idx`/`vk`.
 - Last message storage protocol shortened to `LatestRepository`, with adapters and use-cases updated accordingly.
 - Telegram helpers adopt single-word module names (`screen`, `codec`) while the state tracker moves to `graph`/`recorder` modules for clarity.
+- FSM state payload helper now maps data through `mapping`, replacing the interim `data_map` alias.
+- Telegram gateway helpers drop the `media_mapper` alias in favour of direct `media.compose`/`assemble`/`convert`/`adapt` usage.
+- Serializer and logging utilities now reference standard helpers through their parent modules (`dataclasses.is_dataclass`, `time.perf_counter`), and protocol decorators rely on `typing.runtime_checkable` to keep local namespaces underscore-free.
+- Navigator logging context uses the single-word `handlers` key when capturing callback metadata.
 
 ## Next Steps
 - Migrate remaining domain and application layer helpers (e.g., mapper converters, orchestrator builders) that still rely on snake_case naming to single-word equivalents while keeping semantic clarity.

--- a/adapters/storage/status.py
+++ b/adapters/storage/status.py
@@ -44,8 +44,8 @@ class Status(StateRepository):
              graph={"nodes_len": len(graph.nodes), "edges_keys": len(graph.edges)})
 
     async def payload(self) -> Dict[str, Any]:
-        data_map = await self._state.get_data()
-        filtered = {k: v for k, v in data_map.items() if not str(k).startswith("nav")}
+        mapping = await self._state.get_data()
+        filtered = {k: v for k, v in mapping.items() if not str(k).startswith("nav")}
         count = len(filtered)
         jlog(logger, logging.DEBUG, LogCode.STATE_DATA_GET, data={"keys": count})
         return filtered

--- a/adapters/telegram/gateway/edit.py
+++ b/adapters/telegram/gateway/edit.py
@@ -4,7 +4,7 @@ from typing import Any, Dict
 from .common import markup, finalize
 from .retry import invoke
 from .util import targets as _targets
-from .. import media as media_mapper
+from .. import media
 from .. import serializer
 from ..screen import screen
 from ....domain.constants import CaptionLimit, TextLimit
@@ -66,7 +66,7 @@ async def recast(bot, codec: MarkupCodec, scope: Scope, message: int, payload, *
     caption = serializer.caption(payload)
     native = not bool(scope.inline)
     try:
-        medium = media_mapper.compose(
+        medium = media.compose(
             payload.media, caption, extra=extras, native=native, truncate=truncate
         )
     except MessageEditForbidden:

--- a/adapters/telegram/gateway/send.py
+++ b/adapters/telegram/gateway/send.py
@@ -6,7 +6,7 @@ from .common import markup
 from .retry import invoke
 from .util import extract
 from .util import targets as _targets
-from .. import media as media_mapper
+from .. import media
 from .. import serializer
 from ..screen import screen
 from ....domain.constants import CaptionLimit, TextLimit
@@ -29,7 +29,7 @@ async def dispatch(bot, codec: MarkupCodec, scope: Scope, payload, *, truncate: 
     try:
         if payload.group:
             extras = serializer.scrub(scope, payload.extra, editing=False)
-            bundle = media_mapper.assemble(
+            bundle = media.assemble(
                 payload.group, extra=extras, native=native, truncate=truncate
             )
             filtered = screen(bot.send_media_group, context)
@@ -62,7 +62,7 @@ async def dispatch(bot, codec: MarkupCodec, scope: Scope, payload, *, truncate: 
             )
         if payload.media:
             try:
-                medium = media_mapper.convert(payload.media, native=native)
+                medium = media.convert(payload.media, native=native)
             except MessageEditForbidden:
                 jlog(
                     logger,
@@ -97,7 +97,7 @@ async def dispatch(bot, codec: MarkupCodec, scope: Scope, payload, *, truncate: 
                     settings["start_timestamp"] = options.get("start")
             if kind in ("video", "animation", "audio", "document"):
                 if options.get("thumb") is not None:
-                    settings["thumbnail"] = media_mapper.adapt(
+                    settings["thumbnail"] = media.adapt(
                         options.get("thumb"), native=native
                     )
             if kind == "audio":

--- a/adapters/telegram/serializer.py
+++ b/adapters/telegram/serializer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import is_dataclass
+import dataclasses
 from typing import Dict, Any, Optional
 
 from aiogram.types import LinkPreviewOptions
@@ -27,7 +27,7 @@ def decode(codec, reply):
 def preview(preview):
     if not preview:
         return None
-    if is_dataclass(preview):
+    if dataclasses.is_dataclass(preview):
         return LinkPreviewOptions(
             url=preview.url,
             prefer_small_media=preview.small,

--- a/application/locks.py
+++ b/application/locks.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import typing
 from dataclasses import dataclass
-from typing import Protocol, runtime_checkable
+from typing import Protocol
 from weakref import WeakValueDictionary
 
 """
@@ -25,7 +26,7 @@ def _key(scope: ScopeForm) -> tuple[object | None, object | None]:
     )
 
 
-@runtime_checkable
+@typing.runtime_checkable
 class _LatchLike(Protocol):
     async def acquire(self) -> bool: ...
 

--- a/application/log/decorators.py
+++ b/application/log/decorators.py
@@ -1,7 +1,7 @@
 import inspect
 import logging
 from functools import wraps
-from time import perf_counter
+import time
 from typing import Any, Optional, Callable, Tuple, Dict
 
 from .emit import jlog
@@ -40,7 +40,7 @@ def trace(begin, success, skip, augment: Optional[Callable[[Any], dict]] = None)
         async def wrapper(*args: Any, **kwargs: Any):
             module = getattr(fn, "__module__", __name__)
             logger = logging.getLogger(module)
-            start = perf_counter()
+            start = time.perf_counter()
             scope, payload = _capture(fn, args, kwargs)
             if begin is not None:
                 fields: Dict[str, Any] = {}
@@ -50,7 +50,7 @@ def trace(begin, success, skip, augment: Optional[Callable[[Any], dict]] = None)
                     fields["payload"] = payload
                 jlog(logger, logging.INFO, begin, **fields)
             result = await fn(*args, **kwargs)
-            duration = int((perf_counter() - start) * 1000)
+            duration = int((time.perf_counter() - start) * 1000)
             if success is not None or skip is not None:
                 fields: Dict[str, Any] = {"duration_ms": duration}
                 if scope is not None:

--- a/domain/port/factory.py
+++ b/domain/port/factory.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
-from typing import Protocol, Callable, Awaitable, runtime_checkable
+import typing
+from typing import Protocol, Callable, Awaitable
 
 from ..value.content import Payload
 
 ViewForge = Callable[..., Awaitable[Payload]]
 
 
-@runtime_checkable
+@typing.runtime_checkable
 class ViewLedger(Protocol):
     def get(self, key: str) -> ViewForge: ...
 

--- a/domain/port/history.py
+++ b/domain/port/history.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import Protocol, List, runtime_checkable
+import typing
+from typing import Protocol, List
 
 from ..entity.history import Entry
 
 
-@runtime_checkable
+@typing.runtime_checkable
 class HistoryRepository(Protocol):
     """Storage for navigation history."""
 

--- a/domain/port/last.py
+++ b/domain/port/last.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import Protocol, Optional, runtime_checkable
+import typing
+from typing import Protocol, Optional
 
 
-@runtime_checkable
+@typing.runtime_checkable
 class LatestRepository(Protocol):
     """Storage for latest sent message identifier."""
 

--- a/domain/port/markup.py
+++ b/domain/port/markup.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import Protocol, Optional, Any, runtime_checkable
+import typing
+from typing import Protocol, Optional, Any
 
 from ..entity.markup import Markup
 
 
-@runtime_checkable
+@typing.runtime_checkable
 class MarkupCodec(Protocol):
     """Codec to serialize and deserialize reply markups."""
 

--- a/domain/port/message.py
+++ b/domain/port/message.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+import typing
 from dataclasses import dataclass
-from typing import Protocol, List, Optional, Literal, runtime_checkable
+from typing import Protocol, List, Optional, Literal
 
 from ..value.content import Payload
 from ..value.message import Scope
@@ -20,7 +21,7 @@ class Result:
     inline: Optional[str] = None
 
 
-@runtime_checkable
+@typing.runtime_checkable
 class MessageGateway(Protocol):
     async def send(self, scope: Scope, payload: Payload) -> Result:
         ...

--- a/domain/port/state.py
+++ b/domain/port/state.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import Protocol, Optional, Dict, Any, runtime_checkable
+import typing
+from typing import Protocol, Optional, Dict, Any
 
 from ..entity.graph import Graph
 
 
-@runtime_checkable
+@typing.runtime_checkable
 class StateRepository(Protocol):
     """FSM state and graph storage."""
 

--- a/domain/port/temp.py
+++ b/domain/port/temp.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import Protocol, List, runtime_checkable
+import typing
+from typing import Protocol, List
 
 
-@runtime_checkable
+@typing.runtime_checkable
 class TemporaryRepository(Protocol):
     """Storage for temporary message ids."""
 

--- a/domain/port/transition.py
+++ b/domain/port/transition.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from typing import Protocol, Optional, runtime_checkable
+import typing
+from typing import Protocol, Optional
 
 
-@runtime_checkable
+@typing.runtime_checkable
 class TransitionObserver(Protocol):
     """Observer for state transitions."""
 

--- a/presentation/navigator.py
+++ b/presentation/navigator.py
@@ -178,7 +178,7 @@ class Navigator:
             LogCode.NAVIGATOR_API,
             method="back",
             scope=profile(self._scope),
-            handler_keys=sorted(list(context.keys())) if isinstance(context, dict) else None,
+            handlers=sorted(list(context.keys())) if isinstance(context, dict) else None,
         )
         async with locks.guard(self._scope):
             await self._rewinder.execute(self._scope, context)


### PR DESCRIPTION
## Summary
- rename remaining snake_case locals and aliases to single words across storage, gateway, and presentation layers, and document the changes in the renaming plan
- import standard helpers through their modules and wrap protocol decorators with typing.runtime_checkable to avoid snake_case symbols in the public namespace
- align navigator logging metadata with the new single-word vocabulary

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d0c2f431f8833084ab5a06f2fab67b