### PR TITLE
Rename abbreviations for clarity

### DIFF
--- a/Renaming.md
+++ b/Renaming.md
@@ -30,6 +30,8 @@
 - Telegram gateway helpers drop the `media_mapper` alias in favour of direct `media.compose`/`assemble`/`convert`/`adapt` usage.
 - Serializer and logging utilities now reference standard helpers through their parent modules (`dataclasses.is_dataclass`, `time.perf_counter`), and protocol decorators rely on `typing.runtime_checkable` to keep local namespaces underscore-free.
 - Navigator logging context uses the single-word `handlers` key when capturing callback metadata.
+- View orchestrator internals drop single-letter placeholders by funnelling decision flow through `verdict`, mapping gateway outputs to `result`, and aligning album iteration on `stored`/`incoming` counters and `latest` media markers.
+- Storage helpers replace residual one-letter locals: persistence now accepts an `operation` keyword, the history chronicle iterates over each `record`/`message`, status payload filters operate on `key`/`value` pairs, and the view ledger exposes the collected `signature`.
 
 ## Next Steps
 - Migrate remaining domain and application layer helpers (e.g., mapper converters, orchestrator builders) that still rely on snake_case naming to single-word equivalents while keeping semantic clarity.

--- a/adapters/factory/registry.py
+++ b/adapters/factory/registry.py
@@ -30,9 +30,9 @@ class ViewLedger(ViewLedgerProtocol):
         jlog(logger, logging.INFO, LogCode.REGISTRY_REGISTER, key=name, note="ok")
 
     def enlist(self, forge: ViewForge) -> str:
-        k = _stamp(forge)
-        self.register(k, forge)
-        return k
+        signature = _stamp(forge)
+        self.register(signature, forge)
+        return signature
 
     def get(self, key: str) -> ViewForge:
         try:

--- a/adapters/storage/status.py
+++ b/adapters/storage/status.py
@@ -45,7 +45,11 @@ class Status(StateRepository):
 
     async def payload(self) -> Dict[str, Any]:
         mapping = await self._state.get_data()
-        filtered = {k: v for k, v in mapping.items() if not str(k).startswith("nav")}
+        filtered = {
+            key: value
+            for key, value in mapping.items()
+            if not str(key).startswith("nav")
+        }
         count = len(filtered)
         jlog(logger, logging.DEBUG, LogCode.STATE_DATA_GET, data={"keys": count})
         return filtered

--- a/application/service/store.py
+++ b/application/service/store.py
@@ -17,22 +17,22 @@ def preserve(payload, entry):
     )
 
 
-async def persist(archive, ledger, policy, limit, history, *, op: str):
+async def persist(archive, ledger, policy, limit, history, *, operation: str):
     trimmed = policy.prune(history, limit)
     if len(trimmed) != len(history):
         jlog(
             logger,
             logging.DEBUG,
             LogCode.HISTORY_TRIM,
-            op=op,
+            op=operation,
             history={"before": len(history), "after": len(trimmed)},
         )
     await archive.archive(trimmed)
-    jlog(logger, logging.DEBUG, LogCode.HISTORY_SAVE, op=op, history={"len": len(trimmed)})
+    jlog(logger, logging.DEBUG, LogCode.HISTORY_SAVE, op=operation, history={"len": len(trimmed)})
     if trimmed and trimmed[-1].messages:
         marker = trimmed[-1].messages[0].id
         await ledger.mark(marker)
-        jlog(logger, logging.INFO, LogCode.LAST_SET, op=op, message={"id": marker})
+        jlog(logger, logging.INFO, LogCode.LAST_SET, op=operation, message={"id": marker})
 
 
 def reindex(entry: Entry, identifiers: List[int], extras: Optional[List[List[int]]] = None) -> Entry:

--- a/application/usecase/add.py
+++ b/application/usecase/add.py
@@ -74,5 +74,10 @@ class Appender:
         timeline = [entry] if root else (records + [entry])
         from ..service.store import persist
         await persist(
-            self._archive, self._tail, chronicle, self._limit, timeline, op="add"
+            self._archive,
+            self._tail,
+            chronicle,
+            self._limit,
+            timeline,
+            operation="add",
         )

--- a/application/usecase/replace.py
+++ b/application/usecase/replace.py
@@ -63,5 +63,10 @@ class Swapper:
             timeline = records[:-1] + [entry]
         from ..service.store import persist
         await persist(
-            self._archive, self._tail, chronicle, self._limit, timeline, op="replace"
+            self._archive,
+            self._tail,
+            chronicle,
+            self._limit,
+            timeline,
+            operation="replace",
         )


### PR DESCRIPTION
## Summary
- align the view orchestrator swap/render flows on descriptive names such as `verdict`, `result`, `stored`, and `incoming`
- rename the store persistence keyword to `operation` and update the add/replace use cases accordingly
- update storage/factory helpers to use meaningful names and document the renaming progress in `Renaming.md`

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68d149f535a4833083070e6a4825da5f