### PR TITLE
Avoid attaching DM topic ID to edit requests

### DIFF
--- a/adapters/telegram/gateway/edit.py
+++ b/adapters/telegram/gateway/edit.py
@@ -35,7 +35,7 @@ async def rewrite(bot, codec: MarkupCodec, scope: Scope, message: int, payload, 
     cleaned = serializer.cleanse(
         extras, captioning=False, target=bot.edit_message_text, length=len(raw)
     )
-    target = _targets(scope, message)
+    target = _targets(scope, message, include_topic=False)
     try:
         result = await invoke(
             bot.edit_message_text,
@@ -79,7 +79,7 @@ async def recast(bot, codec: MarkupCodec, scope: Scope, message: int, payload, *
             note="inline_upload_forbidden",
         )
         raise
-    target = _targets(scope, message)
+    target = _targets(scope, message, include_topic=False)
     try:
         result = await invoke(
             bot.edit_message_media,
@@ -109,7 +109,7 @@ async def retitle(bot, codec: MarkupCodec, scope: Scope, message: int, payload, 
     cleaned = serializer.cleanse(
         bundle["caption"], captioning=True, target=bot.edit_message_caption, length=length
     )
-    target = _targets(scope, message)
+    target = _targets(scope, message, include_topic=False)
     if caption is not None and len(caption) > CaptionLimit:
         if truncate:
             caption = caption[:CaptionLimit]
@@ -156,7 +156,7 @@ async def retitle(bot, codec: MarkupCodec, scope: Scope, message: int, payload, 
 
 
 async def remap(bot, codec: MarkupCodec, scope: Scope, message: int, payload) -> Result:
-    target = _targets(scope, message)
+    target = _targets(scope, message, include_topic=False)
     try:
         result = await invoke(
             bot.edit_message_reply_markup,

--- a/adapters/telegram/gateway/util.py
+++ b/adapters/telegram/gateway/util.py
@@ -5,7 +5,7 @@ from aiogram.types import Message
 from ....domain.value.message import Scope
 
 
-def targets(scope: Scope, message: Optional[int] = None) -> Dict[str, Any]:
+def targets(scope: Scope, message: Optional[int] = None, *, include_topic: bool = True) -> Dict[str, Any]:
     if scope.inline:
         data: Dict[str, Any] = {"inline_message_id": scope.inline}
     else:
@@ -14,7 +14,7 @@ def targets(scope: Scope, message: Optional[int] = None) -> Dict[str, Any]:
             data["message_id"] = message
     if scope.business:
         data["business_connection_id"] = scope.business
-    if scope.topic is not None:
+    if include_topic and scope.topic is not None:
         data["direct_messages_topic_id"] = scope.topic
     return data
 


### PR DESCRIPTION
## Summary
- add an include_topic flag to telegram target helper and guard adding the direct message topic id
- skip passing the topic for rewrite, recast, retitle, and remap edit operations

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d150d5dafc83308701efb53d1ac830