### PR TITLE
Remove user field from message scope

### DIFF
--- a/domain/value/message.py
+++ b/domain/value/message.py
@@ -7,7 +7,6 @@ from dataclasses import dataclass
 class Scope:
     chat: int | None
     lang: str | None = None
-    user: int | None = None
     inline: str | None = None
     business: str | None = None
     category: str | None = None

--- a/presentation/telegram/scope.py
+++ b/presentation/telegram/scope.py
@@ -6,21 +6,18 @@ def outline(event) -> Scope:
     language = (source or "en").split("-")[0].lower()
     inline = getattr(event, "inline_message_id", None)
     if inline:
-        user = getattr(getattr(event, "from_user", None), "id", None)
-        return Scope(chat=None, lang=language, user=user, inline=inline, category=None)
+        return Scope(chat=None, lang=language, inline=inline, category=None)
     message = event.message if hasattr(event, "message") else event
     chatinfo = getattr(message, "chat", None)
     chat = getattr(chatinfo, "id", None)
     kind = getattr(chatinfo, "type", None)
     category = "group" if kind == "supergroup" else (
         kind if kind in {"private", "group", "channel"} else None)
-    user = getattr(getattr(event, "from_user", None), "id", None)
     business = getattr(message, "business_connection_id", None)
     topic = getattr(getattr(message, "direct_messages_topic", None), "topic_id", None)
     return Scope(
         chat=chat,
         lang=language,
-        user=user,
         inline=None,
         business=business,
         category=category,


### PR DESCRIPTION
## Summary
- drop the unused user attribute from the message scope dataclass
- stop telegram scope outline from extracting and forwarding a user id

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d157cda0ec83309dad033175482f35