### PR TITLE
Remove inline parameter from InlineStrategy.handle

### DIFF
--- a/application/service/view/orchestrator.py
+++ b/application/service/view/orchestrator.py
@@ -456,7 +456,6 @@ class ViewOrchestrator:
                         scope=scope,
                         payload=current,
                         tail=previous,
-                        inline=True,
                         swap=self.swap,
                         config=self._rendering,
                     )
@@ -501,7 +500,6 @@ class ViewOrchestrator:
                         scope=scope,
                         payload=current,
                         tail=previous,
-                        inline=True,
                         swap=self.swap,
                         config=self._rendering,
                     )

--- a/application/usecase/last.py
+++ b/application/usecase/last.py
@@ -155,7 +155,6 @@ class Tailer:
                 scope=scope,
                 payload=normal,
                 tail=head,
-                inline=True,
                 swap=self._orchestrator.swap,
                 config=self._orchestrator.rendering,
             )


### PR DESCRIPTION
## Summary
- drop the unused `inline` flag from `InlineStrategy.handle` and always execute the inline edit flow
- update `ViewOrchestrator` and `Tailer` call sites to match the simplified signature

## Testing
- ruff check . *(fails: repository has numerous pre-existing lint violations)*
- mypy application/service/view/inline.py application/service/view/orchestrator.py application/usecase/last.py *(fails: repository has many existing type issues)*

------
https://chatgpt.com/codex/tasks/task_e_68d1594a253c83308ec501ae90a7cda0