### PR TITLE
Remove unused ViewRestorer.restore entry point

### DIFF
--- a/application/service/view/restorer.py
+++ b/application/service/view/restorer.py
@@ -38,10 +38,6 @@ class ViewRestorer:
                 return [content]
         return [self._static(m) for m in entry.messages]
 
-    async def restore(self, entry: Entry, context: Dict[str, Any], *, inline: bool = False) -> Payload:
-        res = await self.revive(entry, context, inline=inline)
-        return res[0] if res else Payload()
-
     async def _dynamic(
             self, key: str, context: Dict[str, Any]
     ) -> Optional[Payload | List[Payload]]:


### PR DESCRIPTION
## Summary
- remove the unused restore() helper from ViewRestorer so revive remains the public entry point

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d15d1d535083308c789a06b91199e3