### PR TITLE
Remove unused dedupe helper

### DIFF
--- a/domain/value/ids.py
+++ b/domain/value/ids.py
@@ -1,18 +1,5 @@
 from collections.abc import Iterable
 
 
-def dedupe(ids: Iterable[int], sort: bool = False) -> list[int]:
-    if sort:
-        return order(ids)
-    seen = set()
-    out = []
-    for x in ids or []:
-        i = int(x)
-        if i not in seen:
-            seen.add(i)
-            out.append(i)
-    return out
-
-
 def order(ids: Iterable[int]) -> list[int]:
     return sorted({int(x) for x in ids or []})


### PR DESCRIPTION
## Summary
- remove the unused `dedupe` helper from `domain/value/ids.py`
- keep the existing `order` helper intact

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1794f1a308330a3c54ff0de06e88d