### PR TITLE
Prevent _digest from accepting media groups

### DIFF
--- a/adapters/telegram/gateway/util.py
+++ b/adapters/telegram/gateway/util.py
@@ -21,7 +21,7 @@ def targets(scope: Scope, message: Optional[int] = None, *, include_topic: bool 
 
 def _digest(message: Message) -> dict:
     if getattr(message, "media_group_id", None):
-        pass
+        raise ValueError("Grouped messages are not supported in _digest")
     if getattr(message, "text", None) is not None and not getattr(message, "photo", None) \
             and not getattr(message, "document", None) and not getattr(message, "video", None) \
             and not getattr(message, "audio", None) and not getattr(message, "animation", None):

--- a/tests/adapters/telegram/gateway/test_util.py
+++ b/tests/adapters/telegram/gateway/test_util.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parents[4]
+_PARENT = _ROOT.parent
+for path in (_ROOT, _PARENT):
+    if str(path) not in sys.path:
+        sys.path.insert(0, str(path))
+
+import sitecustomize  # noqa: F401
+
+from navigator.adapters.telegram.gateway.util import _digest
+
+
+def test_digest_rejects_media_groups():
+    grouped_message = SimpleNamespace(media_group_id="group", text="ignored")
+
+    with pytest.raises(ValueError):
+        _digest(grouped_message)
+
+
+def test_digest_text_message_passthrough():
+    message = SimpleNamespace(media_group_id=None, text="hello")
+
+    assert _digest(message) == {"kind": "text", "text": "hello", "inline": None}


### PR DESCRIPTION
## Summary
- raise a ValueError in the Telegram gateway `_digest` helper when a media group identifier is present
- add regression tests confirming grouped messages are rejected and plain text messages still digest successfully

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d180cac3f48330b022dc7f7d40e2e0