### PR TITLE
Reject group payloads in legacy extract

### DIFF
--- a/adapters/telegram/gateway/util.py
+++ b/adapters/telegram/gateway/util.py
@@ -61,7 +61,7 @@ def extract(outcome: Any, payload: Any, scope: Scope) -> dict:
         body["inline"] = token
         return body
     if getattr(payload, "group", None):
-        return {"kind": "group", "clusters": None, "inline": token}
+        raise AssertionError("Grouped payloads must be handled before extract()")
     if getattr(payload, "media", None):
         media = getattr(payload.media.type, "value", None)
         return {

--- a/tests/adapters/telegram/gateway/test_util.py
+++ b/tests/adapters/telegram/gateway/test_util.py
@@ -12,7 +12,8 @@ for path in (_ROOT, _PARENT):
 
 import sitecustomize  # noqa: F401
 
-from navigator.adapters.telegram.gateway.util import _digest
+from navigator.adapters.telegram.gateway.util import _digest, extract
+from navigator.domain.value.message import Scope
 
 
 def test_digest_rejects_media_groups():
@@ -26,3 +27,11 @@ def test_digest_text_message_passthrough():
     message = SimpleNamespace(media_group_id=None, text="hello")
 
     assert _digest(message) == {"kind": "text", "text": "hello", "inline": None}
+
+
+def test_extract_rejects_group_payload_without_result_message_id():
+    scope = Scope(chat=123)
+    payload = SimpleNamespace(group=[object()])
+
+    with pytest.raises(AssertionError):
+        extract(SimpleNamespace(), payload, scope)


### PR DESCRIPTION
## Summary
- prevent grouped payloads from slipping through the legacy Telegram extract fallback by raising an assertion
- extend gateway util tests to cover grouped payload rejection

## Testing
- pytest tests/adapters/telegram/gateway -q

------
https://chatgpt.com/codex/tasks/task_e_68d182e2b0148330a25a2b7b1b9ff115