### PR TITLE
Remove unused inline log codes

### DIFF
--- a/domain/log/code.py
+++ b/domain/log/code.py
@@ -10,9 +10,7 @@ class LogCode(Enum):
     RERENDER_INLINE_NO_FALLBACK = "rerender_inline_no_fallback"
 
     # Inline
-    INLINE_DROP_EXTRA = "inline_drop_extra"
     INLINE_CONTENT_SWITCH_FORBIDDEN = "inline_content_switch_forbidden"
-    INLINE_TAIL_DELETE_IDS = "inline_tail_delete_ids"
     INLINE_REMAP_DELETE_SEND = "inline_remap_delete_send"
 
     # Albums


### PR DESCRIPTION
## Summary
- remove the unused inline drop extra and inline tail delete ids log codes from `LogCode`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d34b5f429c8330a709e0ecc99343aa