### PR TITLE
Simplify inline render guard

### DIFF
--- a/application/service/view/orchestrator.py
+++ b/application/service/view/orchestrator.py
@@ -299,7 +299,6 @@ class ViewOrchestrator:
                 }
             return {"kind": "text", "text": node.text, "inline": node.inline}
 
-        shield(scope, fresh[0] if fresh else Payload())
         ledger: List[Message] = list(trail.messages) if trail else []
 
         primary: List[int] = []


### PR DESCRIPTION
## Summary
- remove redundant shield invocation in view orchestrator render
- keep inline validation as the guard for inline flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d34d276958833081f15c6bf21b02f9