### PR TITLE
Remove unused legacy helpers and telemetry codes

### DIFF
--- a/adapters/factory/ledger.py
+++ b/adapters/factory/ledger.py
@@ -13,10 +13,6 @@ def _stamp(forger: ViewForge) -> str:
     return f"{module}:{qualname}"
 
 
-def key(forger: ViewForge) -> str:
-    return _stamp(forger)
-
-
 class ViewLedger(ViewLedgerProtocol):
     def __init__(self, telemetry: Telemetry | None = None) -> None:
         self._ledger: Dict[str, ViewForge] = {}
@@ -55,5 +51,5 @@ class ViewLedger(ViewLedgerProtocol):
         return exists
 
 
-__all__ = ["ViewLedger", "key"]
+__all__ = ["ViewLedger"]
 

--- a/app/internal/policy.py
+++ b/app/internal/policy.py
@@ -73,7 +73,3 @@ def validate_inline(
         if getattr(sample, "group", None):
             from ...core.error import InlineUnsupported
             raise InlineUnsupported(SHIELD_MESSAGE)
-
-
-def shield(scope, payload):
-    validate_inline(scope, payload)

--- a/core/port/telemetry.py
+++ b/core/port/telemetry.py
@@ -50,7 +50,6 @@ class LogCode(Enum):
     GATEWAY_EDIT_FAIL = "gateway_edit_fail"
     GATEWAY_DELETE_OK = "gateway_delete_ok"
     GATEWAY_DELETE_FAIL = "gateway_delete_fail"
-    GATEWAY_NOTIFY_EMPTY = "gateway_notify_empty"
     GATEWAY_NOTIFY_OK = "gateway_notify_ok"
     TELEGRAM_RETRY = "telegram_retry"
     TELEGRAM_UNHANDLED_ERROR = "telegram_unhandled_error"
@@ -58,7 +57,6 @@ class LogCode(Enum):
     # Extras / Serializer
     EXTRA_FILTERED_OUT = "extra_filtered_out"
     EXTRA_UNKNOWN_DROPPED = "extra_unknown_dropped"
-    EXTRA_EFFECT_STRIPPED = "extra_effect_stripped"
     MARKUP_ENCODE = "markup_encode"
     MARKUP_DECODE = "markup_decode"
 

--- a/presentation/navigator.py
+++ b/presentation/navigator.py
@@ -26,20 +26,16 @@ Navigator API — ключевые контракты:
 6) last.edit resend-fallback:
    - После resend история патчится и только затем обновляется last_id.
 
-7) effect_stripped:
-   - При нормализации extra эффект сообщения удаляется при edit и/или вне приватных чатов.
-   - В логах помечается note="effect_stripped".
-
-8) Inline: ремап DELETE_SEND:
+7) Inline: ремап DELETE_SEND:
    - В inline DELETE_SEND ремапится в EDIT_MEDIA; в EDIT_TEXT — только когда база и новый — текст.
    - Если медиа не редактируется, но меняется только клавиатура — допускается EDIT_MARKUP.
-    - Точки ремапа: InlineHandler.handle и Tailer.edit.
+   - Точки ремапа: InlineHandler.handle и Tailer.edit.
    - Лог-маркер: INLINE_REMAP_DELETE_SEND.
 
-9) Inline: last.delete без business — удаляет только из истории при TailPrune=True.
+8) Inline: last.delete без business — удаляет только из истории при TailPrune=True.
    Удаления в Telegram не выполняются.
 
-10) Inline: при edit_media, когда Telegram возвращает True, история фиксирует актуальную подпись и новый file_id
+9) Inline: при edit_media, когда Telegram возвращает True, история фиксирует актуальную подпись и новый file_id
     (если в payload.media.path передан строковый file_id). Это исключает устаревание caption/file_id в restore/back/set.
 """
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- remove the unused `shield` helper from the inline policy module so callers rely on `validate_inline`
- drop the redundant `key` alias from `ViewLedger` and tighten the telemetry log-code enum by pruning unused members
- update the Navigator API documentation to reflect the streamlined telemetry surface

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d3e5dbde44833088eccb1737d9ee50