### PR TITLE
Align helper names with single-word policy

### DIFF
--- a/RENAMING_PLAN.md
+++ b/RENAMING_PLAN.md
@@ -63,6 +63,14 @@ convention.
 | Album service | `_album_ids`, `_alter`, `_clone`, `_clusters` | `_lineup`, `_changed`, `_copy`, `_collect` | Private helpers now use one-word suffixes. |
 | Inline handler | `_handle_media`, `_handle_text`, `_fallback_markup` | `_mediate`, `_scribe`, `_fallback` | Inline helpers follow the single-word suffix rule. |
 | Tests | `trial.refine_meta` stub, `partial_update` stubs | `trial.refine` stub, `refresh` stubs | Synchronises test doubles with the runtime names. |
+| Bootstrap | `bootstrap.navigator._convert_scope` | `_scope` | Collapses the bootstrap scope adapter to a single noun. |
+| App setter | `Setter._load_history`, `_revive_payloads`, `_apply_render`, `_patch_entry` | `_recall`, `_revive`, `_apply`, `_patch` | Setter workflow verbs now use one-word helpers. |
+| App tailer | `Tailer._render_result`, `_apply_inline` | `_result`, `_mediate` | Inline editing helpers adopt single verbs. |
+| View planner | `ViewPlanner._apply_album_head`, `_sync_slots`, `_apply_inline`, `_record_inline`, `_apply_regular`, `_trim_tail`, `_append_missing` | `_head`, `_sync`, `_mediate`, `_record`, `_regular`, `_trim`, `_append` | Private planner steps now follow the single-word convention. |
+| Inline guard | `inline.guard._primary_media` | `_first` | Chooses the lead media payload with a single-word helper. |
+| Telegram media | `telegram.media._media_handler` | `_select` | Picks the media constructor using one-word naming. |
+| Preview codec | `serializer.preview._optional_flag` | `_maybe` | Streamlines the optional flag helper. |
+| Settings | `infra.config.settings._environment_overrides` | `_overrides` | Reduces the configuration shim to a single noun. |
 
 ## Scheduled Renames
 

--- a/adapters/telegram/media.py
+++ b/adapters/telegram/media.py
@@ -78,7 +78,7 @@ def convert(item: MediaItem, *, policy: MediaPathPolicy, native: bool) -> InputF
     return policy.adapt(item.path, native=native)
 
 
-def _media_handler(item: MediaItem):
+def _select(item: MediaItem):
     catalog = {
         MediaType.PHOTO: InputMediaPhoto,
         MediaType.VIDEO: InputMediaVideo,
@@ -105,7 +105,7 @@ def compose(
     limits: Limits,
     native: bool,
 ) -> InputMedia:
-    handler = _media_handler(item)
+    handler = _select(item)
     mapping: Dict[str, object] = {}
 
     if caption is not None:

--- a/adapters/telegram/serializer/preview.py
+++ b/adapters/telegram/serializer/preview.py
@@ -17,7 +17,7 @@ class TelegramLinkPreviewCodec(LinkPreviewCodec):
         return bool(value)
 
     @staticmethod
-    def _optional_flag(value: Any) -> Optional[bool]:
+    def _maybe(value: Any) -> Optional[bool]:
         if isinstance(value, Default) or value is None:
             return None
         return bool(value)
@@ -44,7 +44,7 @@ class TelegramLinkPreviewCodec(LinkPreviewCodec):
                 small=self._flag(getattr(data, "prefer_small_media", False)),
                 large=self._flag(getattr(data, "prefer_large_media", False)),
                 above=self._flag(getattr(data, "show_above_text", False)),
-                disabled=self._optional_flag(getattr(data, "is_disabled", None)),
+                disabled=self._maybe(getattr(data, "is_disabled", None)),
             )
         if isinstance(data, dict):
             return Preview(
@@ -52,7 +52,7 @@ class TelegramLinkPreviewCodec(LinkPreviewCodec):
                 small=self._flag(data.get("prefer_small_media", data.get("small", False))),
                 large=self._flag(data.get("prefer_large_media", data.get("large", False))),
                 above=self._flag(data.get("show_above_text", data.get("above", False))),
-                disabled=self._optional_flag(data.get("is_disabled", data.get("disabled"))),
+                disabled=self._maybe(data.get("is_disabled", data.get("disabled"))),
             )
         return None
 

--- a/app/service/view/inline/guard.py
+++ b/app/service/view/inline/guard.py
@@ -12,7 +12,7 @@ class InlineGuard:
         self._policy = policy
 
     def admissible(self, payload: Payload) -> bool:
-        media = _primary_media(payload)
+        media = _first(payload)
         if media is None:
             return False
         if media.type in (MediaType.VOICE, MediaType.VIDEO_NOTE):
@@ -20,7 +20,7 @@ class InlineGuard:
         return self._policy.admissible(media.path, inline=True)
 
 
-def _primary_media(payload: Payload):
+def _first(payload: Payload):
     if getattr(payload, "media", None):
         return payload.media
     group = getattr(payload, "group", None)

--- a/app/service/view/planner.py
+++ b/app/service/view/planner.py
@@ -107,30 +107,30 @@ class ViewPlanner:
         origin = 0
 
         if not inline:
-            origin, changed = await self._apply_album_head(scope, ledger, fresh, state)
+            origin, changed = await self._head(scope, ledger, fresh, state)
             mutated = mutated or changed
 
         stored = len(ledger)
         incoming = len(fresh)
-        mutated = mutated or await self._sync_slots(
+        mutated = mutated or await self._sync(
             scope,
             fresh,
             ledger,
             state,
             start=origin,
-            inline_mode=inline,
+            mode=inline,
         )
 
         if not inline:
-            mutated = mutated or await self._trim_tail(scope, ledger, incoming)
-            mutated = mutated or await self._append_missing(scope, fresh, stored, state)
+            mutated = mutated or await self._trim(scope, ledger, incoming)
+            mutated = mutated or await self._append(scope, fresh, stored, state)
 
         if not state.ids:
             return None
 
         return RenderNode(ids=state.ids, extras=state.extras, metas=state.metas, changed=mutated)
 
-    async def _apply_album_head(
+    async def _head(
         self,
         scope: Scope,
         ledger: List[Message],
@@ -150,13 +150,13 @@ class ViewPlanner:
             self._channel.emit(logging.INFO, LogCode.ALBUM_PARTIAL_FALLBACK)
             return 0, False
 
-        head_id, extras, meta, changed = album
-        state.ids.append(head_id)
+        head, extras, meta, changed = album
+        state.ids.append(head)
         state.extras.append(extras)
         state.metas.append(meta)
         return 1, changed
 
-    async def _sync_slots(
+    async def _sync(
         self,
         scope: Scope,
         fresh: List[Payload],
@@ -164,7 +164,7 @@ class ViewPlanner:
         state: _RenderState,
         *,
         start: int,
-        inline_mode: bool,
+        mode: bool,
     ) -> bool:
         mutated = False
         limit = min(len(ledger), len(fresh))
@@ -177,21 +177,21 @@ class ViewPlanner:
                 state.retain(previous)
                 continue
 
-            if inline_mode:
-                changed = await self._apply_inline(scope, current, previous, state)
+            if mode:
+                changed = await self._mediate(scope, current, previous, state)
                 if not changed:
                     state.retain(previous)
                 mutated = mutated or changed
                 continue
 
-            changed = await self._apply_regular(scope, verdict, current, previous, state)
+            changed = await self._regular(scope, verdict, current, previous, state)
             if not changed:
                 state.retain(previous)
             mutated = mutated or changed
 
         return mutated
 
-    async def _apply_inline(
+    async def _mediate(
         self,
         scope: Scope,
         payload: Payload,
@@ -207,14 +207,14 @@ class ViewPlanner:
         )
         if outcome is None:
             return False
-        return self._record_inline(outcome, state)
+        return self._record(outcome, state)
 
-    def _record_inline(self, outcome: InlineOutcome, state: _RenderState) -> bool:
+    def _record(self, outcome: InlineOutcome, state: _RenderState) -> bool:
         meta = self._executor.refine(outcome.execution, outcome.decision, outcome.payload)
         state.collect(outcome.execution, meta)
         return True
 
-    async def _apply_regular(
+    async def _regular(
         self,
         scope: Scope,
         verdict: decision.Decision,
@@ -229,7 +229,7 @@ class ViewPlanner:
         state.collect(execution, meta)
         return True
 
-    async def _trim_tail(self, scope: Scope, ledger: List[Message], incoming: int) -> bool:
+    async def _trim(self, scope: Scope, ledger: List[Message], incoming: int) -> bool:
         if len(ledger) <= incoming:
             return False
         targets: List[int] = []
@@ -241,7 +241,7 @@ class ViewPlanner:
         await self._executor.delete(scope, targets)
         return True
 
-    async def _append_missing(
+    async def _append(
         self,
         scope: Scope,
         fresh: List[Payload],

--- a/bootstrap/navigator.py
+++ b/bootstrap/navigator.py
@@ -28,7 +28,7 @@ class _LedgerAdapter(ViewLedger):
         return bool(self._ledger.has(key))
 
 
-def _convert_scope(dto: ScopeDTO) -> Scope:
+def _scope(dto: ScopeDTO) -> Scope:
     return Scope(
         chat=getattr(dto, "chat", None),
         lang=getattr(dto, "lang", None),
@@ -46,8 +46,8 @@ async def assemble(
     ledger: ViewLedgerDTO,
     scope: ScopeDTO,
 ) -> Navigator:
-    telemetry_port = PythonLoggingTelemetry()
-    telemetry = Telemetry(telemetry_port)
+    port = PythonLoggingTelemetry()
+    telemetry = Telemetry(port)
     container = AppContainer(
         event=event,
         state=state,
@@ -59,7 +59,7 @@ async def assemble(
     mode = getattr(settings, "redaction", "")
     telemetry.calibrate(mode)
     instrument(telemetry)
-    return compose(container, _convert_scope(scope))
+    return compose(container, _scope(scope))
 
 
 __all__ = ["assemble"]

--- a/infra/config/settings.py
+++ b/infra/config/settings.py
@@ -37,7 +37,7 @@ _ENV_MAPPING: Dict[str, str] = {
 }
 
 
-def _environment_overrides() -> Dict[str, str]:
+def _overrides() -> Dict[str, str]:
     values: Dict[str, str] = {}
     for field, env_key in _ENV_MAPPING.items():
         raw = os.getenv(env_key)
@@ -75,7 +75,7 @@ class Settings(BaseSettings):
 def load() -> Settings:
     if _HAS_SETTINGS:
         return Settings()
-    return Settings(**_environment_overrides())
+    return Settings(**_overrides())
 
 
 __all__ = ["Settings", "load"]


### PR DESCRIPTION
## Summary
- rename bootstrap, setter, tailer, and planner helpers to compliant single-word names
- align inline guard, telegram media utilities, preview codec, and settings override helpers with the policy
- extend the renaming plan with the latest completed updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d414139cc4833099cf128ec52f0c15