### PR TITLE
Rename helpers to single-word identifiers

### DIFF
--- a/RENAMING_PLAN.md
+++ b/RENAMING_PLAN.md
@@ -63,6 +63,14 @@ convention.
 | Album service | `_album_ids`, `_alter`, `_clone`, `_clusters` | `_lineup`, `_changed`, `_copy`, `_collect` | Private helpers now use one-word suffixes. |
 | Inline handler | `_handle_media`, `_handle_text`, `_fallback_markup` | `_mediate`, `_scribe`, `_fallback` | Inline helpers follow the single-word suffix rule. |
 | Tests | `trial.refine_meta` stub, `partial_update` stubs | `trial.refine` stub, `refresh` stubs | Synchronises test doubles with the runtime names. |
+| Bootstrap | `bootstrap.navigator._convert_scope` | `bootstrap.navigator._scope` | Scope adapter inlines the single-word helper. |
+| Tail workflow | `Tailer._render_result`, `Tailer._apply_inline` | `Tailer._result`, `Tailer._inlay` | Streamlines the edit pipeline internals. |
+| Setter workflow | `Setter._load_history`, `_revive_payloads`, `_apply_render`, `_patch_entry` | `Setter._history`, `_revive`, `_imprint`, `_patch` | Aligns the state restoration helpers with the policy. |
+| Preview codec | `TelegramLinkPreviewCodec._optional_flag` | `TelegramLinkPreviewCodec._maybe` | Shortens the optional flag decoder. |
+| Media adapter | `adapters.telegram.media._media_handler` | `adapters.telegram.media._creator` | Picks media constructors with a single noun. |
+| Settings | `infra.config.settings._environment_overrides` | `infra.config.settings._environ` | Keeps configuration loading compliant with the naming scheme. |
+| Inline guard | `app.service.view.inline.guard._primary_media` | `app.service.view.inline.guard._primary` | Refines the media probe helper. |
+| View planner | `_apply_album_head`, `_sync_slots`, `_apply_inline`, `_record_inline`, `_apply_regular`, `_trim_tail`, `_append_missing` | `_header`, `_align`, `_inset`, `_record`, `_regular`, `_prune`, `_append` | Brings the planning workflow verbs down to single words. |
 
 ## Scheduled Renames
 

--- a/adapters/telegram/media.py
+++ b/adapters/telegram/media.py
@@ -78,7 +78,7 @@ def convert(item: MediaItem, *, policy: MediaPathPolicy, native: bool) -> InputF
     return policy.adapt(item.path, native=native)
 
 
-def _media_handler(item: MediaItem):
+def _creator(item: MediaItem):
     catalog = {
         MediaType.PHOTO: InputMediaPhoto,
         MediaType.VIDEO: InputMediaVideo,
@@ -105,7 +105,7 @@ def compose(
     limits: Limits,
     native: bool,
 ) -> InputMedia:
-    handler = _media_handler(item)
+    handler = _creator(item)
     mapping: Dict[str, object] = {}
 
     if caption is not None:

--- a/adapters/telegram/serializer/preview.py
+++ b/adapters/telegram/serializer/preview.py
@@ -17,7 +17,7 @@ class TelegramLinkPreviewCodec(LinkPreviewCodec):
         return bool(value)
 
     @staticmethod
-    def _optional_flag(value: Any) -> Optional[bool]:
+    def _maybe(value: Any) -> Optional[bool]:
         if isinstance(value, Default) or value is None:
             return None
         return bool(value)
@@ -44,7 +44,7 @@ class TelegramLinkPreviewCodec(LinkPreviewCodec):
                 small=self._flag(getattr(data, "prefer_small_media", False)),
                 large=self._flag(getattr(data, "prefer_large_media", False)),
                 above=self._flag(getattr(data, "show_above_text", False)),
-                disabled=self._optional_flag(getattr(data, "is_disabled", None)),
+                disabled=self._maybe(getattr(data, "is_disabled", None)),
             )
         if isinstance(data, dict):
             return Preview(
@@ -52,7 +52,7 @@ class TelegramLinkPreviewCodec(LinkPreviewCodec):
                 small=self._flag(data.get("prefer_small_media", data.get("small", False))),
                 large=self._flag(data.get("prefer_large_media", data.get("large", False))),
                 above=self._flag(data.get("show_above_text", data.get("above", False))),
-                disabled=self._optional_flag(data.get("is_disabled", data.get("disabled"))),
+                disabled=self._maybe(data.get("is_disabled", data.get("disabled"))),
             )
         return None
 

--- a/app/service/view/inline/guard.py
+++ b/app/service/view/inline/guard.py
@@ -12,7 +12,7 @@ class InlineGuard:
         self._policy = policy
 
     def admissible(self, payload: Payload) -> bool:
-        media = _primary_media(payload)
+        media = _primary(payload)
         if media is None:
             return False
         if media.type in (MediaType.VOICE, MediaType.VIDEO_NOTE):
@@ -20,7 +20,7 @@ class InlineGuard:
         return self._policy.admissible(media.path, inline=True)
 
 
-def _primary_media(payload: Payload):
+def _primary(payload: Payload):
     if getattr(payload, "media", None):
         return payload.media
     group = getattr(payload, "group", None)

--- a/app/usecase/set.py
+++ b/app/usecase/set.py
@@ -51,7 +51,7 @@ class Setter:
         goal: str,
         context: Dict[str, Any],
     ) -> None:
-        history = await self._load_history(scope)
+        history = await self._history(scope)
         cursor = self._locate(history, goal)
         target = history[cursor]
         inline = bool(scope.inline)
@@ -64,14 +64,14 @@ class Setter:
             op="set",
             state={"target": target.state},
         )
-        resolved = await self._revive_payloads(target, context, inline)
+        resolved = await self._revive(target, context, inline)
         render = await self._render(scope, resolved, tail, inline)
         if render and render.changed:
-            await self._apply_render(scope, render)
+            await self._imprint(scope, render)
         else:
             await self._skip(scope, target)
 
-    async def _load_history(self, scope: Scope) -> List[Any]:
+    async def _history(self, scope: Scope) -> List[Any]:
         history = await self._ledger.recall()
         self._channel.emit(
             logging.DEBUG,
@@ -98,7 +98,7 @@ class Setter:
             history={"len": len(trimmed)},
         )
 
-    async def _revive_payloads(
+    async def _revive(
         self,
         target,
         context: Dict[str, Any],
@@ -123,11 +123,11 @@ class Setter:
             inline=inline,
         )
 
-    async def _apply_render(self, scope: Scope, render: RenderNode) -> None:
+    async def _imprint(self, scope: Scope, render: RenderNode) -> None:
         current = await self._ledger.recall()
         if current:
             tail = current[-1]
-            patched = self._patch_entry(tail, render)
+            patched = self._patch(tail, render)
             await self._ledger.archive(current[:-1] + [patched])
             self._channel.emit(
                 logging.DEBUG,
@@ -143,7 +143,7 @@ class Setter:
             message={"id": render.ids[0]},
         )
 
-    def _patch_entry(self, entry, render: RenderNode):
+    def _patch(self, entry, render: RenderNode):
         limit = min(len(entry.messages), len(render.ids))
         messages = []
         for index in range(limit):

--- a/bootstrap/navigator.py
+++ b/bootstrap/navigator.py
@@ -28,7 +28,7 @@ class _LedgerAdapter(ViewLedger):
         return bool(self._ledger.has(key))
 
 
-def _convert_scope(dto: ScopeDTO) -> Scope:
+def _scope(dto: ScopeDTO) -> Scope:
     return Scope(
         chat=getattr(dto, "chat", None),
         lang=getattr(dto, "lang", None),
@@ -59,7 +59,7 @@ async def assemble(
     mode = getattr(settings, "redaction", "")
     telemetry.calibrate(mode)
     instrument(telemetry)
-    return compose(container, _convert_scope(scope))
+    return compose(container, _scope(scope))
 
 
 __all__ = ["assemble"]

--- a/infra/config/settings.py
+++ b/infra/config/settings.py
@@ -37,7 +37,7 @@ _ENV_MAPPING: Dict[str, str] = {
 }
 
 
-def _environment_overrides() -> Dict[str, str]:
+def _environ() -> Dict[str, str]:
     values: Dict[str, str] = {}
     for field, env_key in _ENV_MAPPING.items():
         raw = os.getenv(env_key)
@@ -75,7 +75,7 @@ class Settings(BaseSettings):
 def load() -> Settings:
     if _HAS_SETTINGS:
         return Settings()
-    return Settings(**_environment_overrides())
+    return Settings(**_environ())
 
 
 __all__ = ["Settings", "load"]


### PR DESCRIPTION
## Summary
- rename bootstrap scope adapter and tailer helpers to single-word names
- align setter, planner, and guard internals with the single-word naming convention
- update telemetry helpers and renaming plan to document the migration

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d414139cc4833099cf128ec52f0c15