### PR TITLE
Enforce single-word naming in DI bindings

### DIFF
--- a/RENAMING_PLAN.md
+++ b/RENAMING_PLAN.md
@@ -71,6 +71,10 @@ convention.
 | Telegram media | `telegram.media._media_handler` | `_select` | Picks the media constructor using one-word naming. |
 | Preview codec | `serializer.preview._optional_flag` | `_maybe` | Streamlines the optional flag helper. |
 | Settings | `infra.config.settings._environment_overrides` | `_overrides` | Reduces the configuration shim to a single noun. |
+| Presentation bootstrap | `presentation.bootstrap.navigator.guard_factory` | `sentinel` | Local guard factory binding renamed to a single-word noun. |
+| Telegram container | `infra.di.container.telegram.inline_guard`, `inline_remapper`, `inline_editor` | `sentinel`, `mapper`, `scribe` | Provider bindings now comply with the single-word policy. |
+| Core container | `infra.di.container.core.load_settings` alias, `lock_provider` binding | `ingest`, `locker` | Aligns import alias and lock provider attribute with the rule. |
+| Settings overrides | `infra.config.settings.env_key` | `variable` | Simplifies the environment variable loop binding. |
 
 ## Scheduled Renames
 
@@ -79,6 +83,9 @@ be addressed incrementally. Proposed target names are provided for future work:
 
 * Identify any remaining compound identifiers in the inline workflow once new
   features land and continue migrating them to the single-word style.
+* Continue auditing dependency-injector containers for nested provider
+  attributes that still rely on compound snake_case placeholders (for instance
+  HTTP bindings) and schedule concise replacements as they appear.
 
 Each future step should follow the same approach as this update: choose the
 shortest precise word, refactor call sites, and update exports (`__all__`,

--- a/infra/config/settings.py
+++ b/infra/config/settings.py
@@ -39,8 +39,8 @@ _ENV_MAPPING: Dict[str, str] = {
 
 def _overrides() -> Dict[str, str]:
     values: Dict[str, str] = {}
-    for field, env_key in _ENV_MAPPING.items():
-        raw = os.getenv(env_key)
+    for field, variable in _ENV_MAPPING.items():
+        raw = os.getenv(variable)
         if raw is not None:
             values[field] = raw
     return values

--- a/infra/di/container/core.py
+++ b/infra/di/container/core.py
@@ -8,7 +8,7 @@ from navigator.core.port.factory import ViewLedger
 from navigator.core.service.rendering.config import RenderingConfig
 from navigator.core.telemetry import Telemetry
 from navigator.infra.clock.system import SystemClock
-from navigator.infra.config.settings import load as load_settings
+from navigator.infra.config.settings import load as ingest
 from navigator.infra.limits.config import ConfigLimits
 from navigator.infra.locks.memory import MemoryLockProvider
 
@@ -20,7 +20,7 @@ class CoreContainer(containers.DeclarativeContainer):
     alert = providers.Dependency()
     telemetry = providers.Dependency(instance_of=Telemetry)
 
-    settings = providers.Singleton(load_settings)
+    settings = providers.Singleton(ingest)
     clock = providers.Singleton(SystemClock)
     limits = providers.Singleton(
         ConfigLimits,
@@ -30,8 +30,8 @@ class CoreContainer(containers.DeclarativeContainer):
         maximum=settings.provided.groupmax,
         mix=settings.provided.mixset,
     )
-    lock_provider = providers.Singleton(MemoryLockProvider)
-    guard = providers.Factory(GuardFactory, provider=lock_provider)
+    locker = providers.Singleton(MemoryLockProvider)
+    guard = providers.Factory(GuardFactory, provider=locker)
     rendering = providers.Factory(RenderingConfig, thumbguard=settings.provided.thumbguard)
 
 

--- a/infra/di/container/telegram.py
+++ b/infra/di/container/telegram.py
@@ -37,14 +37,14 @@ class TelegramContainer(containers.DeclarativeContainer):
         deletepause=core.settings.provided.deletepause,
         telemetry=telemetry,
     )
-    inline_guard = providers.Factory(InlineGuard, policy=policy)
-    inline_remapper = providers.Factory(InlineRemapper)
-    inline_editor = providers.Factory(InlineEditor)
+    sentinel = providers.Factory(InlineGuard, policy=policy)
+    mapper = providers.Factory(InlineRemapper)
+    scribe = providers.Factory(InlineEditor)
     inline = providers.Factory(
         InlineHandler,
-        guard=inline_guard,
-        remapper=inline_remapper,
-        editor=inline_editor,
+        guard=sentinel,
+        remapper=mapper,
+        editor=scribe,
         telemetry=telemetry,
     )
     executor = providers.Factory(EditExecutor, gateway=gateway, telemetry=telemetry)

--- a/presentation/bootstrap/navigator.py
+++ b/presentation/bootstrap/navigator.py
@@ -48,7 +48,7 @@ def compose(
 
     core = container.core()
     usecases = container.usecases()
-    guard_factory = guard or core.guard()
+    sentinel = guard or core.guard()
     return Navigator(
         appender=usecases.appender(),
         swapper=usecases.swapper(),
@@ -59,7 +59,7 @@ def compose(
         tailer=usecases.tailer(),
         alarm=usecases.alarm(),
         scope=scope,
-        guard=guard_factory,
+        guard=sentinel,
         telemetry=core.telemetry(),
     )
 


### PR DESCRIPTION
## Summary
- rename dependency-injector bindings and bootstrap locals to single-word identifiers
- adjust settings override helper variable naming to follow the policy
- document the changes and future audits in the renaming plan

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4b2aeac388330b7b433bbe74b321e