### PR TITLE
Rename telegram extras to single-word identifiers

### DIFF
--- a/RENAMING_PLAN.md
+++ b/RENAMING_PLAN.md
@@ -75,6 +75,11 @@ convention.
 | Telegram container | `infra.di.container.telegram.inline_guard`, `inline_remapper`, `inline_editor` | `sentinel`, `mapper`, `scribe` | Provider bindings now comply with the single-word policy. |
 | Core container | `infra.di.container.core.load_settings` alias, `lock_provider` binding | `ingest`, `locker` | Aligns import alias and lock provider attribute with the rule. |
 | Settings overrides | `infra.config.settings.env_key` | `variable` | Simplifies the environment variable loop binding. |
+| Extra schema | `ExtraSchema.send caption_len`, `ExtraSchema.edit caption_len` | `span` | Shared parameter now uses a single concise noun for measured length. |
+| Telegram extra schema | `caption_block`, `text_block`, `media_block`, positional `caption_len` argument | `sections[...]`, `span` | Composed payload uses word-compliant section mapping and the new length noun. |
+| Telegram media | `caption_extra`, `media_extra`, `filtered_caption`, `filtered_settings` | `captionmeta`, `mediameta`, `captionview`, `settingview` | Media assembly helpers now expose one-word arguments and locals. |
+| Telegram gateway | `reply_markup`, `caption_text`, `payload_item`, `file_id` locals | `markup`, `caption`, `member`, `filetoken` | Entry points reuse concise one-word variables while delegating new argument names. |
+| Album service | `former_group`, `latter_group`, `caption_payload`, `target_id`, `same_path` | `formerband`, `latterband`, `captiondraft`, `target`, `pathmatch` | Group refresh logic now avoids snake_case locals. |
 
 ## Scheduled Renames
 

--- a/adapters/telegram/gateway/edit.py
+++ b/adapters/telegram/gateway/edit.py
@@ -47,7 +47,7 @@ async def rewrite(
             )
         else:
             raise TextOverflow()
-    extras = schema.edit(scope, payload.extra, caption_len=len(text), media=False)
+    extras = schema.edit(scope, payload.extra, span=len(text), media=False)
     markup = text_tools.decode(codec, payload.reply)
     options = None
     if preview is not None and payload.preview is not None:
@@ -83,10 +83,10 @@ async def recast(
     truncate: bool,
     channel: TelemetryChannel,
 ):
-    caption_text = caption_tools.caption(payload)
-    if caption_text is not None and len(caption_text) > limits.captionlimit():
+    caption = caption_tools.caption(payload)
+    if caption is not None and len(caption) > limits.captionlimit():
         if truncate:
-            caption_text = caption_text[: limits.captionlimit()]
+            caption = caption[: limits.captionlimit()]
             channel.emit(
                 logging.INFO,
                 LogCode.TOO_LONG_TRUNCATED,
@@ -95,12 +95,12 @@ async def recast(
             )
         else:
             raise CaptionOverflow()
-    extras = schema.edit(scope, payload.extra, caption_len=len(caption_text or ""), media=True)
+    extras = schema.edit(scope, payload.extra, span=len(caption or ""), media=True)
     media = compose(
         payload.media,
-        caption=caption_text,
-        caption_extra=extras.get("caption", {}),
-        media_extra=extras.get("media", {}),
+        caption=caption,
+        captionmeta=extras.get("caption", {}),
+        mediameta=extras.get("media", {}),
         policy=policy,
         screen=screen,
         limits=limits,
@@ -135,10 +135,10 @@ async def retitle(
     truncate: bool,
     channel: TelemetryChannel,
 ):
-    caption_text = caption_tools.restate(payload)
-    if caption_text is not None and len(caption_text) > limits.captionlimit():
+    caption = caption_tools.restate(payload)
+    if caption is not None and len(caption) > limits.captionlimit():
         if truncate:
-            caption_text = caption_text[: limits.captionlimit()]
+            caption = caption[: limits.captionlimit()]
             channel.emit(
                 logging.INFO,
                 LogCode.TOO_LONG_TRUNCATED,
@@ -147,11 +147,11 @@ async def retitle(
             )
         else:
             raise CaptionOverflow()
-    extras = schema.edit(scope, payload.extra, caption_len=len(caption_text or ""), media=True)
+    extras = schema.edit(scope, payload.extra, span=len(caption or ""), media=True)
     markup = text_tools.decode(codec, payload.reply)
     message = await bot.edit_message_caption(
         **util.targets(scope, message_id),
-        caption=caption_text,
+        caption=caption,
         reply_markup=markup,
         **screen.filter(bot.edit_message_caption, extras.get("caption", {})),
     )

--- a/adapters/telegram/media.py
+++ b/adapters/telegram/media.py
@@ -98,8 +98,8 @@ def compose(
     item: MediaItem,
     *,
     caption: str | None,
-    caption_extra: Dict[str, object],
-    media_extra: Dict[str, object],
+    captionmeta: Dict[str, object],
+    mediameta: Dict[str, object],
     policy: MediaPathPolicy,
     screen: SignatureScreen,
     limits: Limits,
@@ -113,38 +113,38 @@ def compose(
             raise CaptionOverflow()
         mapping["caption"] = caption
 
-    filtered_caption = screen.filter(handler, caption_extra)
-    mapping.update(filtered_caption)
+    captionview = screen.filter(handler, captionmeta)
+    mapping.update(captionview)
 
     settings: Dict[str, object] = {}
-    if media_extra.get("spoiler") is not None:
-        settings["has_spoiler"] = bool(media_extra.get("spoiler"))
-    if media_extra.get("show_caption_above_media") is not None:
-        settings["show_caption_above_media"] = bool(media_extra.get("show_caption_above_media"))
-    if media_extra.get("start") is not None:
-        settings["start_timestamp"] = media_extra.get("start")
-    if media_extra.get("supports_streaming") is not None:
-        settings["supports_streaming"] = bool(media_extra.get("supports_streaming"))
+    if mediameta.get("spoiler") is not None:
+        settings["has_spoiler"] = bool(mediameta.get("spoiler"))
+    if mediameta.get("show_caption_above_media") is not None:
+        settings["show_caption_above_media"] = bool(mediameta.get("show_caption_above_media"))
+    if mediameta.get("start") is not None:
+        settings["start_timestamp"] = mediameta.get("start")
+    if mediameta.get("supports_streaming") is not None:
+        settings["supports_streaming"] = bool(mediameta.get("supports_streaming"))
 
-    if media_extra.get("cover") is not None:
-        settings["cover"] = policy.adapt(media_extra.get("cover"), native=native)
-    if media_extra.get("thumb") is not None:
-        settings["thumbnail"] = policy.adapt(media_extra.get("thumb"), native=native)
+    if mediameta.get("cover") is not None:
+        settings["cover"] = policy.adapt(mediameta.get("cover"), native=native)
+    if mediameta.get("thumb") is not None:
+        settings["thumbnail"] = policy.adapt(mediameta.get("thumb"), native=native)
 
-    if media_extra.get("title") is not None:
-        settings["title"] = str(media_extra.get("title"))
-    if media_extra.get("performer") is not None:
-        settings["performer"] = str(media_extra.get("performer"))
-    if media_extra.get("duration") is not None:
-        settings["duration"] = int(media_extra.get("duration"))
+    if mediameta.get("title") is not None:
+        settings["title"] = str(mediameta.get("title"))
+    if mediameta.get("performer") is not None:
+        settings["performer"] = str(mediameta.get("performer"))
+    if mediameta.get("duration") is not None:
+        settings["duration"] = int(mediameta.get("duration"))
 
-    if media_extra.get("width") is not None:
-        settings["width"] = int(media_extra.get("width"))
-    if media_extra.get("height") is not None:
-        settings["height"] = int(media_extra.get("height"))
+    if mediameta.get("width") is not None:
+        settings["width"] = int(mediameta.get("width"))
+    if mediameta.get("height") is not None:
+        settings["height"] = int(mediameta.get("height"))
 
-    filtered_settings = screen.filter(handler, settings)
-    mapping.update(filtered_settings)
+    settingview = screen.filter(handler, settings)
+    mapping.update(settingview)
 
     arguments = {"media": convert(item, policy=policy, native=native), **mapping}
     return handler(**arguments)
@@ -153,8 +153,8 @@ def compose(
 def assemble(
     items: List[MediaItem],
     *,
-    caption_extra: Dict[str, object],
-    media_extra: Dict[str, object],
+    captionmeta: Dict[str, object],
+    mediameta: Dict[str, object],
     policy: MediaPathPolicy,
     screen: SignatureScreen,
     limits: Limits,
@@ -184,8 +184,8 @@ def assemble(
             compose(
                 item,
                 caption=text,
-                caption_extra=caption_extra,
-                media_extra=media_extra,
+                captionmeta=captionmeta,
+                mediameta=mediameta,
                 policy=policy,
                 screen=screen,
                 limits=limits,

--- a/core/port/extraschema.py
+++ b/core/port/extraschema.py
@@ -13,7 +13,7 @@ class ExtraSchema(Protocol):
         scope: Scope,
         extra: dict | None,
         *,
-        caption_len: int,
+        span: int,
         media: bool,
     ) -> dict:
         ...
@@ -23,7 +23,7 @@ class ExtraSchema(Protocol):
         scope: Scope,
         extra: dict | None,
         *,
-        caption_len: int,
+        span: int,
         media: bool,
     ) -> dict:
         ...


### PR DESCRIPTION
## Summary
- rename the extra schema caption length parameter to the single-word name `span` and adapt the concrete telegram schema implementation
- update telegram media helpers and gateways to use one-word argument and variable names while maintaining behaviour
- align album refresh locals with the naming policy and record the changes in the renaming plan

## Testing
- python -m compileall adapters app core entrypoints infra presentation

------
https://chatgpt.com/codex/tasks/task_e_68d4b443656c83308ac73bc92991ffd6