### PR TITLE
Align telegram naming with single-word policy

### DIFF
--- a/RENAMING_PLAN.md
+++ b/RENAMING_PLAN.md
@@ -43,6 +43,7 @@ convention.
 | Public API | `api.build_navigator` | `api.assemble` | Propagated through bootstrap modules and entry points. |
 | Presentation | `presentation.alerts.prev_not_found` | `presentation.alerts.missing` | Keeps the absent-history alert. |
 | Presentation | `presentation.alerts.inline_unsupported` | `presentation.alerts.barred` | Signals that inline mode is not supported. |
+| Presentation | `presentation.alerts._Lexicon["prev_not_found"]`, `..."inline_unsupported"` | `presentation.alerts._Lexicon["missing"]`, `..."barred"` | Lexicon keys now mirror the exported helper names. |
 | Presentation | `presentation.alerts.back_label` | `presentation.alerts.revert` | Supplies the “Back” button label. |
 | Presentation | `presentation.telegram.router.configure_telemetry` | `presentation.telegram.router.instrument` | Describes telemetry wiring with a single word. |
 | Tests | `trial.stub_telemetry` | `trial.monitor` | Returns a monitoring stub for telemetry. |
@@ -79,6 +80,7 @@ convention.
 | Telegram extra schema | `caption_block`, `text_block`, `media_block`, positional `caption_len` argument | `sections[...]`, `span` | Composed payload uses word-compliant section mapping and the new length noun. |
 | Telegram media | `caption_extra`, `media_extra`, `filtered_caption`, `filtered_settings` | `captionmeta`, `mediameta`, `captionview`, `settingview` | Media assembly helpers now expose one-word arguments and locals. |
 | Telegram gateway | `reply_markup`, `caption_text`, `payload_item`, `file_id` locals | `markup`, `caption`, `member`, `filetoken` | Entry points reuse concise one-word variables while delegating new argument names. |
+| Telegram gateway | `delete_action`, `delete_kwargs`, `scope_profile` locals | `eraser`, `params`, `scopeview` | Delete batch execution uses single-word locals. |
 | Album service | `former_group`, `latter_group`, `caption_payload`, `target_id`, `same_path` | `formerband`, `latterband`, `captiondraft`, `target`, `pathmatch` | Group refresh logic now avoids snake_case locals. |
 
 ## Scheduled Renames

--- a/adapters/telegram/gateway/delete.py
+++ b/adapters/telegram/gateway/delete.py
@@ -47,26 +47,26 @@ class DeleteBatch:
             chunks=total,
             chunk=self._chunk,
         )
-        scope_profile = profile(scope)
+        scopeview = profile(scope)
         if scope.business:
-            delete_action = self._bot.delete_business_messages
-            delete_kwargs = {"business_connection_id": scope.business}
+            eraser = self._bot.delete_business_messages
+            params = {"business_connection_id": scope.business}
         else:
-            delete_action = self._bot.delete_messages
-            delete_kwargs = {"chat_id": scope.chat}
+            eraser = self._bot.delete_messages
+            params = {"chat_id": scope.chat}
         try:
             for index, group in enumerate(groups, start=1):
                 try:
                     await invoke(
-                        delete_action,
+                        eraser,
                         message_ids=group,
-                        **delete_kwargs,
+                        **params,
                         channel=self._channel,
                     )
                     self._channel.emit(
                         logging.INFO,
                         LogCode.GATEWAY_DELETE_OK,
-                        scope=scope_profile,
+                        scope=scopeview,
                         message={"deleted": len(group)},
                         chunk={"index": index, "total": total},
                     )
@@ -80,7 +80,7 @@ class DeleteBatch:
             self._channel.emit(
                 logging.WARNING,
                 LogCode.GATEWAY_DELETE_FAIL,
-                scope=scope_profile,
+                scope=scopeview,
                 count=len(unique),
                 note=type(error).__name__,
             )

--- a/presentation/alerts.py
+++ b/presentation/alerts.py
@@ -5,11 +5,11 @@ from typing import Mapping
 from ..core.value.message import Scope
 
 _Lexicon = {
-    "prev_not_found": {
+    "missing": {
         "en": "⚠️ Previous state not found.",
         "ru": "⚠️ Предыдущий экран не найден.",
     },
-    "inline_unsupported": {
+    "barred": {
         "en": "⚠️ This screen is not available in an inline message.",
         "ru": "⚠️ Этот экран недоступен в инлайн-сообщении.",
     },
@@ -28,11 +28,11 @@ def lexeme(key: str, locale: str | None = None) -> str:
 
 
 def missing(scope: Scope) -> str:
-    return lexeme("prev_not_found", scope.lang)
+    return lexeme("missing", scope.lang)
 
 
 def barred(scope: Scope) -> str:
-    return lexeme("inline_unsupported", scope.lang)
+    return lexeme("barred", scope.lang)
 
 
 def revert(locale: str | None) -> str:

--- a/presentation/telegram/router.py
+++ b/presentation/telegram/router.py
@@ -75,7 +75,7 @@ async def retreat(cb: CallbackQuery, navigator: NavigatorLike, **data: Dict[str,
                 kind="callback",
                 note="history_empty",
             )
-        await cb.answer(lexeme("prev_not_found", _tongue(cb)), show_alert=True)
+        await cb.answer(lexeme("missing", _tongue(cb)), show_alert=True)
     except StateNotFound:
         if channel:
             channel.emit(
@@ -84,16 +84,16 @@ async def retreat(cb: CallbackQuery, navigator: NavigatorLike, **data: Dict[str,
                 kind="callback",
                 note="state_not_found",
             )
-        await cb.answer(lexeme("prev_not_found", _tongue(cb)), show_alert=True)
+        await cb.answer(lexeme("missing", _tongue(cb)), show_alert=True)
     except InlineUnsupported:
         if channel:
             channel.emit(
                 logging.WARNING,
                 LogCode.ROUTER_BACK_FAIL,
                 kind="callback",
-                note="inline_unsupported",
+                note="barred",
             )
-        await cb.answer(lexeme("inline_unsupported", _tongue(cb)), show_alert=True)
+        await cb.answer(lexeme("barred", _tongue(cb)), show_alert=True)
     except Exception:
         if channel:
             channel.emit(
@@ -102,7 +102,7 @@ async def retreat(cb: CallbackQuery, navigator: NavigatorLike, **data: Dict[str,
                 kind="callback",
                 note="generic",
             )
-        await cb.answer(lexeme("prev_not_found", _tongue(cb)), show_alert=True)
+        await cb.answer(lexeme("missing", _tongue(cb)), show_alert=True)
 
 
 __all__ = ["router", "NavigatorLike", "retreat", "BACK_CALLBACK_DATA"]


### PR DESCRIPTION
## Summary
- align the presentation lexicon keys with the single-word helper names and refresh the router usage
- rename the telegram delete batch locals to single-word identifiers and document the migration in the renaming plan

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4b649c3d483309d2a9f1250f42610