### PR TITLE
Rename lock providers to single-word classes

### DIFF
--- a/RENAMING_PLAN.md
+++ b/RENAMING_PLAN.md
@@ -82,6 +82,8 @@ convention.
 | Telegram gateway | `reply_markup`, `caption_text`, `payload_item`, `file_id` locals | `markup`, `caption`, `member`, `filetoken` | Entry points reuse concise one-word variables while delegating new argument names. |
 | Telegram gateway | `delete_action`, `delete_kwargs`, `scope_profile` locals | `eraser`, `params`, `scopeview` | Delete batch execution uses single-word locals. |
 | Album service | `former_group`, `latter_group`, `caption_payload`, `target_id`, `same_path` | `formerband`, `latterband`, `captiondraft`, `target`, `pathmatch` | Group refresh logic now avoids snake_case locals. |
+| Lock providers | `infra.locks.memory.MemoryLockProvider` | `infra.locks.memory.MemoryLatch` | Memory-backed provider now uses a single-word class name. |
+| Lock providers | `infra.locks.redis.RedisLockProvider`, `_RedisLock` | `infra.locks.redis.RedisLatch`, `_Latch` | Redis-backed lock provider adopts one-word naming for the public class and helper. |
 
 ## Scheduled Renames
 

--- a/infra/di/container/core.py
+++ b/infra/di/container/core.py
@@ -10,7 +10,7 @@ from navigator.core.telemetry import Telemetry
 from navigator.infra.clock.system import SystemClock
 from navigator.infra.config.settings import load as ingest
 from navigator.infra.limits.config import ConfigLimits
-from navigator.infra.locks.memory import MemoryLockProvider
+from navigator.infra.locks.memory import MemoryLatch
 
 
 class CoreContainer(containers.DeclarativeContainer):
@@ -30,7 +30,7 @@ class CoreContainer(containers.DeclarativeContainer):
         maximum=settings.provided.groupmax,
         mix=settings.provided.mixset,
     )
-    locker = providers.Singleton(MemoryLockProvider)
+    locker = providers.Singleton(MemoryLatch)
     guard = providers.Factory(GuardFactory, provider=locker)
     rendering = providers.Factory(RenderingConfig, thumbguard=settings.provided.thumbguard)
 

--- a/infra/locks/memory.py
+++ b/infra/locks/memory.py
@@ -25,7 +25,7 @@ class _LockWrapper(Lock):
         return self._lock.locked()
 
 
-class MemoryLockProvider(LockProvider):
+class MemoryLatch(LockProvider):
     def __init__(self) -> None:
         self._locks: Dict[Tuple[object, object | None], _LockWrapper] = {}
 
@@ -35,4 +35,4 @@ class MemoryLockProvider(LockProvider):
         return self._locks[key]
 
 
-__all__ = ["MemoryLockProvider"]
+__all__ = ["MemoryLatch"]

--- a/infra/locks/redis.py
+++ b/infra/locks/redis.py
@@ -14,7 +14,7 @@ from navigator.core.port.locks import Lock, LockProvider
 logger = logging.getLogger(__name__)
 
 
-class _RedisLock(Lock):
+class _Latch(Lock):
     def __init__(self, redis: Any, name: str, ttl: float, blocking: float) -> None:
         self._redis = redis
         self._name = name
@@ -51,7 +51,7 @@ class _RedisLock(Lock):
         return self._held
 
 
-class RedisLockProvider(LockProvider):
+class RedisLatch(LockProvider):
     def __init__(self, url: str, *, ttl: float, blocking: float) -> None:
         if Redis is None:
             raise RuntimeError("redis package not installed")
@@ -61,7 +61,7 @@ class RedisLockProvider(LockProvider):
 
     def latch(self, key: tuple[object, object | None]) -> Lock:
         name = f"nav:lock:{key[0]}:{key[1]}"
-        return _RedisLock(self._redis, name, self._ttl, self._blocking)
+        return _Latch(self._redis, name, self._ttl, self._blocking)
 
 
-__all__ = ["RedisLockProvider"]
+__all__ = ["RedisLatch"]


### PR DESCRIPTION
## Summary
- rename the in-memory lock provider to `MemoryLatch` and update dependency injection bindings
- rename the Redis lock provider helper to `_Latch` and export it as `RedisLatch`
- record the new naming changes in the renaming plan

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4b7f970448330b1a977058ddd127c