### PR TITLE
Rename guard factory helper to Guardian

### DIFF
--- a/RENAMING_PLAN.md
+++ b/RENAMING_PLAN.md
@@ -53,6 +53,7 @@ convention.
 | Core limits | `ConfigLimits` constructor `floor`, `ceiling`, `blend` | `minimum`, `maximum`, `mix` | Keeps the configuration wiring aligned with the new protocol. |
 | Settings | `text_limit`, `caption_limit`, `album_floor`, `album_ceiling`, `album_blend`, `album_blend_set`, `delete_delay`, `delete_delay_ms` | `textlimit`, `captionlimit`, `groupmin`, `groupmax`, `mixcodes`, `mixset`, `deletepause`, `deletepausems` | Updated environment mapping and dependency injection bindings. |
 | Telegram gateway | `delete_delay` argument | `deletepause` | Matches the configuration name and emphasises the pacing behaviour. |
+| Locks | `app.locks.guard.GuardFactory` | `app.locks.guard.Guardian` | Lock guard provider now carries a single-word class name. |
 | Extra schema | `ExtraSchema.for_send`, `for_edit`, `for_history` | `send`, `edit`, `history` | Reflected in the Telegram serializer and gateway usage. |
 | Gateway util | `result_from_message` | `derive` | Shortens the helper that builds message results. |
 | Presentation | `presentation.markup.sanitize_caption` | `presentation.markup.purify` | Keeps the markup helper compliant even though it is currently unused. |
@@ -95,6 +96,8 @@ be addressed incrementally. Proposed target names are provided for future work:
 * Continue auditing dependency-injector containers for nested provider
   attributes that still rely on compound snake_case placeholders (for instance
   HTTP bindings) and schedule concise replacements as they appear.
+* Review remaining `*Factory` helper classes across adapters and services so
+  that they eventually converge on single-word nouns similar to `Guardian`.
 
 Each future step should follow the same approach as this update: choose the
 shortest precise word, refactor call sites, and update exports (`__all__`,

--- a/app/locks/guard.py
+++ b/app/locks/guard.py
@@ -34,7 +34,7 @@ class _Guard:
             self.lock.release()
 
 
-class GuardFactory:
+class Guardian:
     def __init__(self, provider: LockProvider) -> None:
         self._provider = provider
 
@@ -43,4 +43,4 @@ class GuardFactory:
         return _Guard(lock=latch)
 
 
-__all__ = ["GuardFactory"]
+__all__ = ["Guardian"]

--- a/infra/di/container/core.py
+++ b/infra/di/container/core.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from aiogram.fsm.context import FSMContext
 from dependency_injector import containers, providers
 
-from navigator.app.locks.guard import GuardFactory
+from navigator.app.locks.guard import Guardian
 from navigator.core.port.factory import ViewLedger
 from navigator.core.service.rendering.config import RenderingConfig
 from navigator.core.telemetry import Telemetry
@@ -31,7 +31,7 @@ class CoreContainer(containers.DeclarativeContainer):
         mix=settings.provided.mixset,
     )
     locker = providers.Singleton(MemoryLatch)
-    guard = providers.Factory(GuardFactory, provider=locker)
+    guard = providers.Factory(Guardian, provider=locker)
     rendering = providers.Factory(RenderingConfig, thumbguard=settings.provided.thumbguard)
 
 

--- a/presentation/bootstrap/navigator.py
+++ b/presentation/bootstrap/navigator.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Protocol
 
-from ...app.locks.guard import GuardFactory
+from ...app.locks.guard import Guardian
 from ...app.usecase.add import Appender
 from ...app.usecase.alarm import Alarm
 from ...app.usecase.back import Rewinder
@@ -18,7 +18,7 @@ from ..navigator import Navigator
 
 
 class _Core(Protocol):
-    def guard(self) -> GuardFactory: ...
+    def guard(self) -> Guardian: ...
     def telemetry(self) -> Telemetry: ...
 
 
@@ -42,7 +42,7 @@ def compose(
     container: NavigatorContainer,
     scope: Scope,
     *,
-    guard: GuardFactory | None = None,
+    guard: Guardian | None = None,
 ) -> Navigator:
     """Construct a Navigator facade from a DI container."""
 

--- a/presentation/navigator.py
+++ b/presentation/navigator.py
@@ -53,7 +53,7 @@ from ..app.usecase.pop import Trimmer
 from ..app.usecase.rebase import Shifter
 from ..app.usecase.replace import Swapper
 from ..app.usecase.set import Setter
-from ..app.locks.guard import GuardFactory
+from ..app.locks.guard import Guardian
 from ..core.error import StateNotFound
 from ..core.service.scope import profile
 from ..core.telemetry import LogCode, Telemetry, TelemetryChannel
@@ -67,7 +67,7 @@ class _Tail:
         self,
         flow: Tailer,
         scope: Scope,
-        guard: GuardFactory,
+        guard: Guardian,
         telemetry: Telemetry,
     ):
         self._tailer = flow
@@ -128,7 +128,7 @@ class Navigator:
             tailer: Tailer,
             alarm: Alarm,
             scope: Scope,
-            guard: GuardFactory,
+            guard: Guardian,
             telemetry: Telemetry,
     ):
         self._appender = appender


### PR DESCRIPTION
## Summary
- rename the lock guard provider class to `Guardian` and update all call sites
- extend the renaming plan to document the completed change and outline future factory audits

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4b9242ca88330b3d144b9f51f8cf9