### PR TITLE
Rename Telegram gateway identifiers to single words

### DIFF
--- a/RENAMING_PLAN.md
+++ b/RENAMING_PLAN.md
@@ -82,9 +82,12 @@ convention.
 | Telegram media | `caption_extra`, `media_extra`, `filtered_caption`, `filtered_settings` | `captionmeta`, `mediameta`, `captionview`, `settingview` | Media assembly helpers now expose one-word arguments and locals. |
 | Telegram gateway | `reply_markup`, `caption_text`, `payload_item`, `file_id` locals | `markup`, `caption`, `member`, `filetoken` | Entry points reuse concise one-word variables while delegating new argument names. |
 | Telegram gateway | `delete_action`, `delete_kwargs`, `scope_profile` locals | `eraser`, `params`, `scopeview` | Delete batch execution uses single-word locals. |
+| Telegram gateway | `gateway aliases caption_tools`, `text_tools` | `captionkit`, `textkit` | Serializer helpers now use single-word module handles. |
+| Telegram gateway | `message_id` parameters | `identifier` | Rewrite, recast, retitle and remap operations share a concise identifier noun. |
 | Album service | `former_group`, `latter_group`, `caption_payload`, `target_id`, `same_path` | `formerband`, `latterband`, `captiondraft`, `target`, `pathmatch` | Group refresh logic now avoids snake_case locals. |
 | Lock providers | `infra.locks.memory.MemoryLockProvider` | `infra.locks.memory.MemoryLatch` | Memory-backed provider now uses a single-word class name. |
 | Lock providers | `infra.locks.redis.RedisLockProvider`, `_RedisLock` | `infra.locks.redis.RedisLatch`, `_Latch` | Redis-backed lock provider adopts one-word naming for the public class and helper. |
+| Tests | `trial.delete_module` | `eraser` | Telegram delete gateway import alias now follows the single-word rule. |
 
 ## Scheduled Renames
 

--- a/adapters/telegram/gateway/__init__.py
+++ b/adapters/telegram/gateway/__init__.py
@@ -69,7 +69,7 @@ class TelegramGateway(MessageGateway):
         )
         return Result(id=message.message_id, extra=extras, meta=meta)
 
-    async def rewrite(self, scope: Scope, message: int, payload: Payload) -> Result:
+    async def rewrite(self, scope: Scope, identifier: int, payload: Payload) -> Result:
         outcome = await rewrite(
             self._bot,
             codec=self._codec,
@@ -78,16 +78,16 @@ class TelegramGateway(MessageGateway):
             limits=self._limits,
             preview=self._preview,
             scope=scope,
-            message_id=message,
+            identifier=identifier,
             payload=payload,
             truncate=self._truncate,
             channel=self._channel,
         )
         meta = util.extract(outcome, payload, scope)
-        identifier = getattr(outcome, "message_id", message)
-        return Result(id=identifier, extra=[], meta=meta)
+        resultid = getattr(outcome, "message_id", identifier)
+        return Result(id=resultid, extra=[], meta=meta)
 
-    async def recast(self, scope: Scope, message: int, payload: Payload) -> Result:
+    async def recast(self, scope: Scope, identifier: int, payload: Payload) -> Result:
         outcome = await recast(
             self._bot,
             codec=self._codec,
@@ -96,16 +96,16 @@ class TelegramGateway(MessageGateway):
             policy=self._policy,
             limits=self._limits,
             scope=scope,
-            message_id=message,
+            identifier=identifier,
             payload=payload,
             truncate=self._truncate,
             channel=self._channel,
         )
         meta = util.extract(outcome, payload, scope)
-        identifier = getattr(outcome, "message_id", message)
-        return Result(id=identifier, extra=[], meta=meta)
+        resultid = getattr(outcome, "message_id", identifier)
+        return Result(id=resultid, extra=[], meta=meta)
 
-    async def retitle(self, scope: Scope, message: int, payload: Payload) -> Result:
+    async def retitle(self, scope: Scope, identifier: int, payload: Payload) -> Result:
         outcome = await retitle(
             self._bot,
             codec=self._codec,
@@ -113,27 +113,27 @@ class TelegramGateway(MessageGateway):
             screen=self._screen,
             limits=self._limits,
             scope=scope,
-            message_id=message,
+            identifier=identifier,
             payload=payload,
             truncate=self._truncate,
             channel=self._channel,
         )
         meta = util.extract(outcome, payload, scope)
-        identifier = getattr(outcome, "message_id", message)
-        return Result(id=identifier, extra=[], meta=meta)
+        resultid = getattr(outcome, "message_id", identifier)
+        return Result(id=resultid, extra=[], meta=meta)
 
-    async def remap(self, scope: Scope, message: int, payload: Payload) -> Result:
+    async def remap(self, scope: Scope, identifier: int, payload: Payload) -> Result:
         outcome = await remap(
             self._bot,
             codec=self._codec,
             scope=scope,
-            message_id=message,
+            identifier=identifier,
             payload=payload,
             channel=self._channel,
         )
         meta = util.extract(outcome, payload, scope)
-        identifier = getattr(outcome, "message_id", message)
-        return Result(id=identifier, extra=[], meta=meta)
+        resultid = getattr(outcome, "message_id", identifier)
+        return Result(id=resultid, extra=[], meta=meta)
 
     async def delete(self, scope: Scope, identifiers: List[int]) -> None:
         await self._delete.run(scope, identifiers)

--- a/adapters/telegram/gateway/send.py
+++ b/adapters/telegram/gateway/send.py
@@ -20,8 +20,8 @@ from navigator.core.value.content import Payload
 from navigator.core.value.message import Scope
 
 from ..media import assemble
-from ..serializer import caption as caption_tools
-from ..serializer import text as text_tools
+from ..serializer import caption as captionkit
+from ..serializer import text as textkit
 from ..serializer.screen import SignatureScreen
 from . import util
 
@@ -43,14 +43,14 @@ async def send(
     if scope.inline:
         raise InlineUnsupported("inline_send_not_supported")
 
-    markup = text_tools.decode(codec, payload.reply)
+    markup = textkit.decode(codec, payload.reply)
     options = None
     if preview is not None and payload.preview is not None:
         options = preview.encode(payload.preview)
     targets = util.targets(scope)
 
     if payload.group:
-        caption = caption_tools.caption(payload)
+        caption = captionkit.caption(payload)
         extras = schema.send(scope, payload.extra, span=len(caption or ""), media=True)
         effect = extras.get("effect")
         bundle = assemble(
@@ -125,7 +125,7 @@ async def send(
         return head, extras, meta
 
     if payload.media:
-        caption = caption_tools.caption(payload)
+        caption = captionkit.caption(payload)
         if caption is not None and len(caption) > limits.captionlimit():
             if truncate:
                 caption = caption[: limits.captionlimit()]

--- a/core/port/message.py
+++ b/core/port/message.py
@@ -21,16 +21,16 @@ class MessageGateway(Protocol):
     async def send(self, scope: Scope, payload: Payload) -> Result:
         ...
 
-    async def rewrite(self, scope: Scope, message: int, payload: Payload) -> Result:
+    async def rewrite(self, scope: Scope, identifier: int, payload: Payload) -> Result:
         ...
 
-    async def recast(self, scope: Scope, message: int, payload: Payload) -> Result:
+    async def recast(self, scope: Scope, identifier: int, payload: Payload) -> Result:
         ...
 
-    async def retitle(self, scope: Scope, message: int, payload: Payload) -> Result:
+    async def retitle(self, scope: Scope, identifier: int, payload: Payload) -> Result:
         ...
 
-    async def remap(self, scope: Scope, message: int, payload: Payload) -> Result:
+    async def remap(self, scope: Scope, identifier: int, payload: Payload) -> Result:
         ...
 
     async def delete(self, scope: Scope, identifiers: List[int]) -> None:

--- a/trial.py
+++ b/trial.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, Mock
 
 from navigator.adapters.telegram.errors import dismissible
 from navigator.adapters.telegram.gateway import TelegramGateway
-from navigator.adapters.telegram.gateway import delete as delete_module
+from navigator.adapters.telegram.gateway import delete as eraser
 from navigator.adapters.telegram.gateway.delete import DeleteBatch
 from navigator.adapters.telegram.serializer.screen import SignatureScreen
 from navigator.app.service.view.planner import ViewPlanner
@@ -391,12 +391,12 @@ def commerce() -> None:
         captured.append((action, args, kwargs))
         return await action(*args, **kwargs)
 
-    original_invoke = delete_module.invoke
-    delete_module.invoke = capture
+    original_invoke = eraser.invoke
+    eraser.invoke = capture
     try:
         asyncio.run(runner.run(scope, [9, 1, 2]))
     finally:
-        delete_module.invoke = original_invoke
+        eraser.invoke = original_invoke
 
     assert bot.delete_messages.await_count == 0
     assert bot.delete_business_messages.await_count == 2


### PR DESCRIPTION
## Summary
- update the renaming plan with the latest gateway and test identifier changes
- rename Telegram gateway edit/send helpers to use single-word aliases and identifier parameters
- align the message gateway protocol and trials with the new single-word naming

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4baaad728833092442744195ae1c2