### PR TITLE
Handle missing base entry in store preserve helper

### DIFF
--- a/app/service/store.py
+++ b/app/service/store.py
@@ -8,7 +8,9 @@ from ...core.entity.history import Entry, Message
 from ...core.telemetry import LogCode, Telemetry, TelemetryChannel
 
 
-def preserve(payload, entry):
+def preserve(payload, entry: Message | None):
+    if entry is None:
+        return payload
     return replace(
         payload,
         preview=payload.preview if payload.preview is not None else entry.preview,


### PR DESCRIPTION
## Summary
- avoid AttributeError in store.preserve by returning the payload unchanged when no base message is available
- keep existing preview/extra merge behaviour for inline updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4bfa26e348330854cf2540d4dab79