### PR TITLE
Fix DeleteBatch chunk lower bound

### DIFF
--- a/adapters/telegram/gateway/delete.py
+++ b/adapters/telegram/gateway/delete.py
@@ -15,7 +15,8 @@ from .retry import invoke
 class DeleteBatch:
     def __init__(self, bot, *, chunk: int, delay: float, telemetry: Telemetry) -> None:
         self._bot = bot
-        self._chunk = min(int(chunk), 100)
+        size = int(chunk)
+        self._chunk = max(min(size, 100), 1)
         self._delay = max(float(delay), 0.0)
         self._channel: TelemetryChannel = telemetry.channel(__name__)
 


### PR DESCRIPTION
## Summary
- ensure DeleteBatch enforces a minimum chunk size to avoid zero-step batching loops

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4bfa26e348330854cf2540d4dab79