### PR TITLE
Fix InlineHandler telemetry channel assignment when using dataclass slots

### DIFF
--- a/app/service/view/inline/__init__.py
+++ b/app/service/view/inline/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from navigator.core.entity.history import Message
 from navigator.core.service.rendering import decision as D
@@ -23,9 +23,10 @@ class InlineHandler:
     remapper: InlineRemapper
     editor: InlineEditor
     telemetry: Telemetry
+    _channel: TelemetryChannel = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
-        self._channel: TelemetryChannel = self.telemetry.channel(__name__)
+        self._channel = self.telemetry.channel(__name__)
 
     async def handle(
         self,


### PR DESCRIPTION
## Summary
- declare `_channel` as a dataclass field on `InlineHandler` so the slot exists
- initialize the telemetry channel without triggering an AttributeError

## Testing
- PYTHONPATH=.. python - <<'PY'
from navigator import trial
for name in [
    'reliance','override','absence','veto','assent','surface','rebuff','refuse',
    'decline','siren','wording','translation','commerce','fragments'
]:
    print('running', name)
    getattr(trial, name)()
print('done')
PY

------
https://chatgpt.com/codex/tasks/task_e_68d4c18bc2708330beb282540ef7be92