### PR TITLE
Handle missing state payload in setter

### DIFF
--- a/app/usecase/set.py
+++ b/app/usecase/set.py
@@ -105,6 +105,8 @@ class Setter:
         inline: bool,
     ) -> List[Payload]:
         memory = await self._status.payload()
+        if memory is None:
+            memory = {}
         merged = {**memory, **context}
         restored = await self._restorer.revive(target, merged, inline=inline)
         return [normalize(p) for p in restored]

--- a/tests/app/usecase/test_set.py
+++ b/tests/app/usecase/test_set.py
@@ -1,0 +1,42 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+from navigator.app.usecase.set import Setter
+from navigator.core.telemetry import Telemetry
+from navigator.core.value.content import Payload
+
+
+class StubTelemetryPort:
+    def calibrate(self, mode: str) -> None:
+        return None
+
+    def emit(self, *args, **kwargs) -> None:
+        return None
+
+
+def make_setter(*, payload_return):
+    ledger = SimpleNamespace(recall=AsyncMock(return_value=[SimpleNamespace(state="goal", messages=[])]), archive=AsyncMock())
+    status = SimpleNamespace(assign=AsyncMock(), payload=AsyncMock(return_value=payload_return))
+    gateway = SimpleNamespace()
+    restorer = SimpleNamespace(revive=AsyncMock(return_value=[Payload(text="ok")]))
+    planner = SimpleNamespace(render=AsyncMock(return_value=None))
+    latest = SimpleNamespace(mark=AsyncMock())
+    telemetry = Telemetry(StubTelemetryPort())
+    return Setter(
+        ledger=ledger,
+        status=status,
+        gateway=gateway,
+        restorer=restorer,
+        planner=planner,
+        latest=latest,
+        telemetry=telemetry,
+    ), restorer
+
+
+def test_revive_merges_none_payload_with_context():
+    setter, restorer = make_setter(payload_return=None)
+
+    asyncio.run(setter._revive(SimpleNamespace(state="goal"), {"foo": "bar"}, inline=False))
+
+    assert restorer.revive.await_args.args[1] == {"foo": "bar"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,5 @@
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT.parent))


### PR DESCRIPTION
## Summary
- default empty state payload when StateRepository returns None
- add regression test for Setter._revive handling absent payload data
- configure pytest test suite to import the navigator package during tests

## Testing
- pytest -o python_files=test_*.py -o python_functions=test_* tests/app/usecase/test_set.py

------
https://chatgpt.com/codex/tasks/task_e_68d4c18bc2708330beb282540ef7be92