### PR TITLE
Fix Telegram thread targeting and preview payloads

### DIFF
--- a/adapters/telegram/gateway/util.py
+++ b/adapters/telegram/gateway/util.py
@@ -12,16 +12,19 @@ from navigator.core.value.message import Scope
 
 
 def targets(scope: Scope, message: Optional[int] = None, *, topical: bool = True) -> Dict[str, Any]:
+    data: Dict[str, Any] = {}
     if scope.inline:
-        data: Dict[str, Any] = {"inline_message_id": scope.inline}
-    else:
-        data = {"chat_id": scope.chat}
+        data["inline_message_id"] = scope.inline
+    elif scope.business:
+        data["business_connection_id"] = scope.business
         if message is not None:
             data["message_id"] = message
-    if scope.business:
-        data["business_connection_id"] = scope.business
-    if topical and scope.topic is not None:
-        data["direct_messages_topic_id"] = scope.topic
+    else:
+        data["chat_id"] = scope.chat
+        if message is not None:
+            data["message_id"] = message
+    if topical and scope.topic is not None and not scope.inline:
+        data["message_thread_id"] = scope.topic
     return data
 
 

--- a/adapters/telegram/serializer/preview.py
+++ b/adapters/telegram/serializer/preview.py
@@ -24,11 +24,12 @@ class TelegramLinkPreviewCodec(LinkPreviewCodec):
 
     def encode(self, preview: Preview) -> LinkPreviewOptions:
         payload = {
-            "url": preview.url,
             "prefer_small_media": bool(preview.small),
             "prefer_large_media": bool(preview.large),
             "show_above_text": bool(preview.above),
         }
+        if preview.url is not None:
+            payload["url"] = preview.url
         if preview.disabled is not None:
             payload["is_disabled"] = bool(preview.disabled)
         return LinkPreviewOptions(**payload)

--- a/entrypoints/telegram/scope.py
+++ b/entrypoints/telegram/scope.py
@@ -14,7 +14,9 @@ def outline(event) -> Scope:
     category = "group" if kind == "supergroup" else (
         kind if kind in {"private", "group", "channel"} else None)
     business = getattr(message, "business_connection_id", None)
-    topic = getattr(getattr(message, "direct_messages_topic", None), "topic_id", None)
+    topic = getattr(message, "message_thread_id", None)
+    if topic is None:
+        topic = getattr(getattr(message, "direct_messages_topic", None), "topic_id", None)
     return Scope(
         chat=chat,
         lang=language,


### PR DESCRIPTION
## Summary
- send `message_thread_id` instead of the deprecated topic id parameter
- derive thread ids from `message_thread_id` on incoming updates, with a safe fallback
- avoid passing `url=None` when building link preview options
- ensure business sends omit `chat_id`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4d02fabb88330b286647a0dee558d