### PR TITLE
Support direct message topics in Telegram scope

### DIFF
--- a/adapters/telegram/gateway/util.py
+++ b/adapters/telegram/gateway/util.py
@@ -23,8 +23,11 @@ def targets(scope: Scope, message: Optional[int] = None, *, topical: bool = True
         data["chat_id"] = scope.chat
         if message is not None:
             data["message_id"] = message
-    if topical and scope.topic is not None and not scope.inline:
-        data["message_thread_id"] = scope.topic
+    if topical and not scope.inline and scope.topic is not None:
+        if getattr(scope, "direct", False):
+            data["direct_messages_topic_id"] = scope.topic
+        else:
+            data["message_thread_id"] = scope.topic
     return data
 
 

--- a/api/contracts.py
+++ b/api/contracts.py
@@ -15,6 +15,7 @@ class ScopeDTO:
     business: str | None = None
     category: str | None = None
     topic: int | None = None
+    direct: bool = False
 
 
 @runtime_checkable

--- a/bootstrap/navigator.py
+++ b/bootstrap/navigator.py
@@ -36,6 +36,7 @@ def _scope(dto: ScopeDTO) -> Scope:
         business=getattr(dto, "business", None),
         category=getattr(dto, "category", None),
         topic=getattr(dto, "topic", None),
+        direct=bool(getattr(dto, "direct", False)),
     )
 
 

--- a/core/service/scope.py
+++ b/core/service/scope.py
@@ -4,7 +4,12 @@ from ..value.message import Scope
 
 
 def profile(s: Scope) -> Dict[str, Any]:
-    data: Dict[str, Any] = {"chat": s.chat, "inline": bool(s.inline), "category": s.category}
+    data: Dict[str, Any] = {
+        "chat": s.chat,
+        "inline": bool(s.inline),
+        "category": s.category,
+        "direct": bool(getattr(s, "direct", False)),
+    }
     if s.topic is not None:
         data["topic"] = s.topic
     return data

--- a/core/value/message.py
+++ b/core/value/message.py
@@ -11,3 +11,4 @@ class Scope:
     business: str | None = None
     category: str | None = None
     topic: int | None = None
+    direct: bool = False

--- a/entrypoints/telegram/scope.py
+++ b/entrypoints/telegram/scope.py
@@ -13,10 +13,14 @@ def outline(event) -> Scope:
     kind = getattr(chatinfo, "type", None)
     category = "group" if kind == "supergroup" else (
         kind if kind in {"private", "group", "channel"} else None)
+    direct_topic = getattr(
+        getattr(message, "direct_messages_topic", None), "topic_id", None
+    )
+    direct_chat = bool(getattr(chatinfo, "is_direct_messages", False)) or bool(direct_topic)
     business = getattr(message, "business_connection_id", None)
     topic = getattr(message, "message_thread_id", None)
-    if topic is None:
-        topic = getattr(getattr(message, "direct_messages_topic", None), "topic_id", None)
+    if topic is None and direct_topic is not None:
+        topic = direct_topic
     return Scope(
         chat=chat,
         lang=language,
@@ -24,4 +28,5 @@ def outline(event) -> Scope:
         business=business,
         category=category,
         topic=topic,
+        direct=direct_chat,
     )


### PR DESCRIPTION
## Summary
- add a `direct` flag to the Telegram scope DTO/model to track channel direct messages
- surface the flag through dependency wiring and scope detection for updates
- include `direct_messages_topic_id` when targeting Telegram methods so sends succeed in Bot API 9.2 direct message topics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d4dc1ba4a48330b42be75b0572682a