### PR TITLE
Remove obsolete compatibility layers

### DIFF
--- a/adapters/telegram/codec.py
+++ b/adapters/telegram/codec.py
@@ -51,11 +51,7 @@ class AiogramCodec(MarkupCodec):
         target = self._MAP.get(stored.kind)
         if target:
             try:
-                # Prefer Pydantic v2 path when available
-                if hasattr(target, "model_validate"):
-                    obj = target.model_validate(stored.data)  # type: ignore[attr-defined]
-                else:
-                    obj = target(**stored.data)
+                obj = target.model_validate(stored.data)
                 self._channel.emit(
                     logging.DEBUG,
                     LogCode.MARKUP_DECODE,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ redis>=5.0
 aiogram==3.22.0
 aiohttp==3.11.18
 pydantic~=2.11
+pydantic-settings>=2.3,<3
 dependency-injector==4.48.1


### PR DESCRIPTION
## Summary
- drop the local pydantic-settings fallback by wiring BaseSettings aliases directly
- simplify the Telegram markup codec to rely on pydantic v2 validation exclusively
- declare pydantic-settings as a required dependency

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d4e77269b48330b19c992c7af28953