### PR TITLE
Improve rendering decision flow documentation

### DIFF
--- a/core/service/rendering/album.py
+++ b/core/service/rendering/album.py
@@ -1,36 +1,41 @@
-from typing import List, Literal, Optional, Set
+"""Validate and compare media albums for multi-item submissions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Literal, Optional, Set
 
 from ...entity.media import MediaItem, MediaType
 from ...error import NavigatorError
 from ...port.limits import Limits
 
 
+@dataclass(frozen=True, slots=True)
 class AlbumInvalid(NavigatorError):
-    def __init__(
-            self,
-            *,
-            empty: bool,
-            limit: bool,
-            forbidden: bool,
-            audio: bool,
-            document: bool,
-    ):
-        self.empty = empty
-        self.limit = limit
-        self.forbidden = forbidden
-        self.audio = audio
-        self.document = document
+    """Signal that a payload album violates delivery constraints."""
+
+    empty: bool
+    limit: bool
+    forbidden: bool
+    audio: bool
+    document: bool
+
+    def __post_init__(self) -> None:
         super().__init__("group_invalid")
 
 
-def _audit(items: Optional[List[MediaItem]], *, limits: Limits) -> List[str]:
+def _audit(items: Optional[Iterable[MediaItem]], *, limits: Limits) -> List[str]:
+    """Collect album rule violations for the provided media set."""
+
+    material = list(items or [])
+    if not material:
+        return ["empty"]
+
     issues: List[str] = []
-    if not items:
-        issues.append("empty")
-        return issues
-    if len(items) < limits.groupmin() or len(items) > limits.groupmax():
+    if len(material) < limits.groupmin() or len(material) > limits.groupmax():
         issues.append("limit")
-    kinds: Set[MediaType] = {item.type for item in items}
+
+    kinds: Set[MediaType] = {item.type for item in material}
     if kinds & {MediaType.ANIMATION, MediaType.VOICE, MediaType.VIDEO_NOTE}:
         issues.append("forbidden")
     if MediaType.AUDIO in kinds and kinds != {MediaType.AUDIO}:
@@ -41,6 +46,8 @@ def _audit(items: Optional[List[MediaItem]], *, limits: Limits) -> List[str]:
 
 
 def validate(items: List[MediaItem], *, limits: Limits) -> None:
+    """Reject albums that fail validation by raising an explicit error."""
+
     issues = _audit(items, limits=limits)
     if issues:
         raise AlbumInvalid(
@@ -53,6 +60,8 @@ def validate(items: List[MediaItem], *, limits: Limits) -> None:
 
 
 def nature(items: List[MediaItem]) -> Literal["audio", "document", "mixed"]:
+    """Classify a group by the dominant media class it contains."""
+
     kinds = {item.type for item in items or []}
     if kinds == {MediaType.AUDIO}:
         return "audio"
@@ -62,6 +71,8 @@ def nature(items: List[MediaItem]) -> Literal["audio", "document", "mixed"]:
 
 
 def aligned(old: List[MediaItem], new: List[MediaItem], *, limits: Limits) -> bool:
+    """Check whether two albums remain compatible for in-place edits."""
+
     if len(old) != len(new):
         return False
     mood = nature(old)

--- a/core/service/rendering/helpers.py
+++ b/core/service/rendering/helpers.py
@@ -1,28 +1,43 @@
+"""Support lightweight classification and comparison of payload metadata."""
+
+from __future__ import annotations
+
 import json
-from typing import Dict, Any
+from collections.abc import Mapping
+from typing import Any, Dict
 
 from ...entity.markup import Markup
 from ...value.content import Payload
 
 
-def classify(p: Payload) -> Dict[str, Any]:
-    if p.group:
-        return {"kind": "group", "group_len": len(p.group)}
-    if p.media:
-        return {"kind": "media", "medium": getattr(p.media.type, "value", None)}
+def classify(payload: Payload) -> Dict[str, Any]:
+    """Describe the payload family to drive downstream rendering choices."""
+
+    if payload.group:
+        return {"kind": "group", "group_len": len(payload.group)}
+    if payload.media:
+        medium = getattr(payload.media.type, "value", None)
+        return {"kind": "media", "medium": medium}
     return {"kind": "text"}
 
 
-def _canon(d):
-    return json.dumps(d, sort_keys=True, separators=(",", ":")) if isinstance(d, dict) else None
+def _canonicalize(data: object) -> str | None:
+    """Serialize mapping-like objects into a canonical JSON snapshot."""
+
+    if not isinstance(data, Mapping):
+        return None
+    return json.dumps(dict(data), sort_keys=True, separators=(",", ":"))
 
 
-def match(a: Markup | None, b: Markup | None) -> bool:
-    if a is None and b is None:
+def match(first: Markup | None, second: Markup | None) -> bool:
+    """Check whether markups share the same structural intent."""
+
+    if first is None and second is None:
         return True
-    if (a is None) != (b is None):
+    if (first is None) != (second is None):
         return False
     return (
-            getattr(a, "kind", None) == getattr(b, "kind", None)
-            and _canon(getattr(a, "data", None)) == _canon(getattr(b, "data", None))
+        getattr(first, "kind", None) == getattr(second, "kind", None)
+        and _canonicalize(getattr(first, "data", None))
+        == _canonicalize(getattr(second, "data", None))
     )


### PR DESCRIPTION
## Summary
- restructure the rendering decision workflow around a shared `NormalizedView` surface and English documentation
- clarify album validation semantics with a dataclass-based error payload and narrative docstrings
- document helper classification utilities and canonical markup comparison helpers

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_68d4f0e95f988330b6cc2dcdff5af14a