### PR TITLE
Refine history persistence helpers

### DIFF
--- a/app/service/store.py
+++ b/app/service/store.py
@@ -1,82 +1,126 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable, Sequence
 from dataclasses import replace
-from typing import List, Optional
 
 from ...core.entity.history import Entry, Message
+from ...core.port.history import HistoryRepository
+from ...core.port.last import LatestRepository
 from ...core.telemetry import LogCode, Telemetry, TelemetryChannel
+from ...core.value.content import Payload
 
 
-def preserve(payload, entry: Message | None):
+def preserve(payload: Payload, entry: Message | None) -> Payload:
+    """Keep payload preview and extra in sync with latest entry."""
+
     if entry is None:
         return payload
-    return replace(
-        payload,
-        preview=payload.preview if payload.preview is not None else entry.preview,
-        extra=payload.extra if payload.extra is not None else entry.extra,
-    )
+
+    preview = payload.preview if payload.preview is not None else entry.preview
+    extra = payload.extra if payload.extra is not None else entry.extra
+    if preview is payload.preview and extra is payload.extra:
+        return payload
+    return replace(payload, preview=preview, extra=extra)
+
+
+def _emit(
+    channel: TelemetryChannel | None,
+    level: int,
+    code: LogCode,
+    **payload: object,
+) -> None:
+    if channel is None:
+        return
+    channel.emit(level, code, **payload)
+
+
+def _latest_marker(history: Sequence[Entry]) -> int | None:
+    if not history:
+        return None
+    messages = history[-1].messages
+    if not messages:
+        return None
+    return messages[0].id
 
 
 async def persist(
-    archive,
-    ledger,
-    policy,
-    limit,
-    history,
+    archive: HistoryRepository,
+    ledger: LatestRepository,
+    prune_history: Callable[[list[Entry], int], list[Entry]],
+    limit: int,
+    history: Sequence[Entry],
     *,
     operation: str,
     telemetry: Telemetry | None = None,
-):
+) -> None:
+    """Persist updated history snapshots with telemetry support."""
+
     channel: TelemetryChannel | None = (
         telemetry.channel(__name__) if telemetry else None
     )
-    trimmed = policy.prune(history, limit)
-    if len(trimmed) != len(history) and channel is not None:
-        channel.emit(
+    snapshot = list(history)
+    trimmed = prune_history(snapshot, limit)
+    if len(trimmed) != len(snapshot):
+        _emit(
+            channel,
             logging.DEBUG,
             LogCode.HISTORY_TRIM,
             op=operation,
-            history={"before": len(history), "after": len(trimmed)},
+            history={"before": len(snapshot), "after": len(trimmed)},
         )
+
     await archive.archive(trimmed)
-    if channel is not None:
-        channel.emit(
-            logging.DEBUG,
-            LogCode.HISTORY_SAVE,
-            op=operation,
-            history={"len": len(trimmed)},
-        )
-    if trimmed and trimmed[-1].messages:
-        marker = trimmed[-1].messages[0].id
-        await ledger.mark(marker)
-        if channel is not None:
-            channel.emit(
-                logging.INFO,
-                LogCode.LAST_SET,
-                op=operation,
-                message={"id": marker},
-            )
+    _emit(
+        channel,
+        logging.DEBUG,
+        LogCode.HISTORY_SAVE,
+        op=operation,
+        history={"len": len(trimmed)},
+    )
+
+    marker = _latest_marker(trimmed)
+    if marker is None:
+        return
+
+    await ledger.mark(marker)
+    _emit(
+        channel,
+        logging.INFO,
+        LogCode.LAST_SET,
+        op=operation,
+        message={"id": marker},
+    )
 
 
-def reindex(entry: Entry, identifiers: List[int], extras: Optional[List[List[int]]] = None) -> Entry:
+def reindex(
+    entry: Entry,
+    identifiers: Sequence[int],
+    extras: Sequence[Sequence[int]] | None = None,
+) -> Entry:
+    """Rebuild entry messages with provided identifiers and extras."""
+
     limit = min(len(entry.messages), len(identifiers))
-    messages: List[Message] = []
+    if limit == 0:
+        return entry
+
+    updated: list[Message] = []
     for index in range(limit):
-        messages.append(
-            Message(
+        message = entry.messages[index]
+        provided = (
+            list(extras[index])
+            if extras is not None and index < len(extras)
+            else message.extras
+        )
+        updated.append(
+            replace(
+                message,
                 id=int(identifiers[index]),
-                text=entry.messages[index].text,
-                media=entry.messages[index].media,
-                group=entry.messages[index].group,
-                markup=entry.messages[index].markup,
-                preview=entry.messages[index].preview,
-                extra=entry.messages[index].extra,
-                extras=(extras[index] if extras and index < len(extras) else entry.messages[index].extras),
-                inline=entry.messages[index].inline,
-                automated=entry.messages[index].automated,
-                ts=entry.messages[index].ts,
+                extras=provided,
             )
         )
-    messages += entry.messages[limit:]
-    return Entry(state=entry.state, view=entry.view, messages=messages, root=entry.root)
+
+    if limit < len(entry.messages):
+        updated.extend(entry.messages[limit:])
+
+    return replace(entry, messages=updated)

--- a/app/usecase/add.py
+++ b/app/usecase/add.py
@@ -11,7 +11,7 @@ from ..service.view.policy import adapt
 from ...core.port.history import HistoryRepository
 from ...core.port.last import LatestRepository
 from ...core.port.state import StateRepository
-from ...core.service.history import policy as chronicle
+from ...core.service.history.policy import prune as prune_history
 from ...core.service.scope import profile
 from ...core.telemetry import LogCode, Telemetry, TelemetryChannel
 from ...core.value.content import Payload, normalize
@@ -106,7 +106,7 @@ class Appender:
         await persist(
             self._archive,
             self._tail,
-            chronicle,
+            prune_history,
             self._limit,
             timeline,
             operation="add",

--- a/app/usecase/replace.py
+++ b/app/usecase/replace.py
@@ -12,7 +12,7 @@ from ..service.view.policy import adapt
 from ...core.port.history import HistoryRepository
 from ...core.port.last import LatestRepository
 from ...core.port.state import StateRepository
-from ...core.service.history import policy as chronicle
+from ...core.service.history.policy import prune as prune_history
 from ...core.value.content import Payload, normalize
 from ...core.value.message import Scope
 
@@ -79,7 +79,7 @@ class Swapper:
         await persist(
             self._archive,
             self._tail,
-            chronicle,
+            prune_history,
             self._limit,
             timeline,
             operation="replace",


### PR DESCRIPTION
## Summary
- enrich the history store helpers with stronger typing, documentation, and smaller utilities to clarify data flow
- streamline history persistence by routing telemetry emission through helpers and isolating marker detection
- update add and replace use cases to pass the history pruner explicitly

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*


------
https://chatgpt.com/codex/tasks/task_e_68d4f36ed2ec833090921a32e4466a6c