### PR TITLE
Align purge naming

### DIFF
--- a/RenamingPlan.md
+++ b/RenamingPlan.md
@@ -11,6 +11,8 @@ This iteration covers the Telegram gateway deletion workflow.
 - Local list name `groups` → `batches` (single word that matches the semantics of chunked message groups).
 - Telegram gateway attribute `_delete` → `_purge` and its usage within `TelegramGateway.delete` (aligns with the new class name while keeping the private attribute prefix).
 - Trial helper instantiation `DeleteBatch` → `PurgeTask` within `trial.py` (keeps test coverage aligned with the rename).
+- Local helper reference `eraser` → `purger` inside `PurgeTask.execute` (aligns the temporary callable with the new purge terminology).
+- Trial module alias `eraser` → `purger` for consistent naming during retry monkeypatching.
 
 ## Follow-up
 Further iterations can extend this naming pass to the rest of the adapters package and the remaining application layers.

--- a/adapters/telegram/gateway/purge.py
+++ b/adapters/telegram/gateway/purge.py
@@ -50,17 +50,17 @@ class PurgeTask:
         )
         scopeview = profile(scope)
         if scope.business:
-            eraser = getattr(self._bot, "delete_business_messages", None)
+            purger = getattr(self._bot, "delete_business_messages", None)
             params = {"business_connection_id": scope.business}
         else:
-            eraser = getattr(self._bot, "delete_messages", None)
+            purger = getattr(self._bot, "delete_messages", None)
             params = {"chat_id": scope.chat}
         try:
             for index, batch in enumerate(batches, start=1):
                 try:
-                    if eraser is not None:
+                    if purger is not None:
                         await invoke(
-                            eraser,
+                            purger,
                             message_ids=batch,
                             **params,
                             channel=self._channel,

--- a/trial.py
+++ b/trial.py
@@ -2,7 +2,7 @@ import asyncio
 from contextlib import asynccontextmanager
 from navigator.adapters.telegram.errors import dismissible
 from navigator.adapters.telegram.gateway import TelegramGateway
-import navigator.adapters.telegram.gateway.purge as eraser
+import navigator.adapters.telegram.gateway.purge as purger
 from navigator.adapters.telegram.gateway.purge import PurgeTask
 from navigator.adapters.telegram.serializer.screen import SignatureScreen
 from navigator.app.service.view.planner import ViewPlanner
@@ -390,12 +390,12 @@ def commerce() -> None:
         captured.append((action, args, kwargs))
         return await action(*args, **kwargs)
 
-    baseline = eraser.invoke
-    eraser.invoke = capture
+    baseline = purger.invoke
+    purger.invoke = capture
     try:
         asyncio.run(runner.execute(scope, [9, 1, 2]))
     finally:
-        eraser.invoke = baseline
+        purger.invoke = baseline
 
     assert bot.delete_messages.await_count == 0
     assert bot.delete_business_messages.await_count == 2


### PR DESCRIPTION
## Summary
- extend the renaming plan to cover the purge helper alias updates
- rename the temporary purge callable and its trial alias to `purger` for consistent terminology

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d502e6eab88330ba65c43d1c462de4