### PR TITLE
Refine navigator API documentation and logging helpers

### DIFF
--- a/presentation/navigator.py
+++ b/presentation/navigator.py
@@ -1,47 +1,64 @@
-"""
-Navigator API — ключевые контракты:
+"""Document Navigator API invariants for inline and history flows.
 
-1) Эффекты сообщений (message_effect_id):
-   - Хранится в истории.
-   - Применяется только при отправке в приватных чатах.
-   - При edit и/или вне приватных чатов эффект удаляется нормализацией.
-   - Попытка «поменять только эффект» (без изменения текста/медиа/markup) = NO_CHANGE.
+Message effects (``message_effect_id``)
+======================================
+* History keeps the effect identifier but Telegram only applies it in
+  private chats during new sends.
+* Normalization strips effects from edits and from sends to non-private
+  chats.
+* Changing only the effect without touching text, media, or markup is
+  treated as ``NO_CHANGE``.
 
-2) Inline-режим в back/set:
-   - Редактируется только первое сообщение узла.
-   - Визуальное удаление «хвоста» контролируется флагом InlineTailDelete (по умолчанию False).
+Inline mode in ``back`` and ``set``
+==================================
+* Only the first message in the node is eligible for editing.
+* The ``InlineTailDelete`` flag controls visual tail deletion (default
+  ``False``).
 
-3) Inline-редакции без фоллбека:
-   - При EditForbidden/MessageUnchanged в inline не выполняется send+delete.
-   - Лог-маркер: RERENDER_INLINE_NO_FALLBACK.
+Inline edits without fallback
+=============================
+* ``EditForbidden`` and ``MessageUnchanged`` in inline mode do not trigger
+  ``send+delete`` fallbacks.
+* Telemetry marker: ``RERENDER_INLINE_NO_FALLBACK``.
 
-4) Inline: запрет смены типа контента:
-   - Смена «медиа ↔ текст» в inline не выполняется.
-   - Разрешено только EDIT_MARKUP над существующим медиа при изменении клавиатуры.
-   - Иначе: RENDER_SKIP (note="inline_no_content_type_switch").
+Inline content type restrictions
+================================
+* Inline mode never switches between media and text payload kinds.
+* ``EDIT_MARKUP`` is allowed when only the keyboard changes for an existing
+  media message.
+* Telemetry marker: ``RENDER_SKIP`` with ``note="inline_no_content_type_switch"``.
 
-5) Rebase при пустой истории:
-   - Операция no-op, last_id не изменяется.
+``rebase`` with empty history
+=============================
+* The operation is a no-op and ``last_id`` remains unchanged.
 
-6) last.edit resend-fallback:
-   - После resend история патчится и только затем обновляется last_id.
+``last.edit`` resend fallback
+=============================
+* After a resend fallback the history is patched before ``last_id`` is
+  updated.
 
-7) Inline: ремап DELETE_SEND:
-   - В inline DELETE_SEND ремапится в EDIT_MEDIA; в EDIT_TEXT — только когда база и новый — текст.
-   - Если медиа не редактируется, но меняется только клавиатура — допускается EDIT_MARKUP.
-   - Точки ремапа: InlineHandler.handle и Tailer.edit.
-   - Лог-маркер: INLINE_REMAP_DELETE_SEND.
+Inline ``DELETE_SEND`` remapping
+================================
+* Inline ``DELETE_SEND`` becomes ``EDIT_MEDIA``.
+* ``DELETE_SEND`` downgrades to ``EDIT_TEXT`` when both sides are textual.
+* ``EDIT_MARKUP`` is allowed when the media is left untouched.
+* Remapping happens in ``InlineHandler.handle`` and ``Tailer.edit``.
+* Telemetry marker: ``INLINE_REMAP_DELETE_SEND``.
 
-8) Inline: last.delete без business — удаляет только из истории при TailPrune=True.
-   Удаления в Telegram не выполняются.
+Inline ``last.delete`` without business context
+===============================================
+* Without ``business`` the operation only trims history when
+  ``TailPrune`` is ``True``; Telegram messages are left intact.
 
-9) Inline: при edit_media, когда Telegram возвращает True, история фиксирует актуальную подпись и новый file_id
-    (если в payload.media.path передан строковый file_id). Это исключает устаревание caption/file_id в restore/back/set.
+Inline ``edit_media`` success bookkeeping
+=========================================
+* When Telegram reports success the latest caption and ``file_id`` are
+  stored, preventing restore/back/set operations from using stale data.
 """
 from __future__ import annotations
 
 import logging
-from typing import Optional, Dict, Any, Union, SupportsInt
+from typing import Any, Dict, List, Optional, SupportsInt, Union
 
 from .alerts import missing
 from .types import StateLike
@@ -59,12 +76,16 @@ from ..app.usecase.set import Setter
 from ..core.error import StateNotFound
 from ..core.service.scope import profile
 from ..core.telemetry import LogCode, Telemetry, TelemetryChannel
+from ..core.value.content import Payload
 from ..core.value.message import Scope
 
 
 class _Tail:
+    """Expose tail operations guarded by telemetry and locking."""
+
     def __init__(
             self,
+            *,
             flow: Tailer,
             scope: Scope,
             guard: Guardian,
@@ -74,14 +95,10 @@ class _Tail:
         self._scope = scope
         self._guard = guard
         self._channel: TelemetryChannel = telemetry.channel(__name__)
+        self._scopeview = profile(scope)
 
     async def get(self) -> Optional[Dict[str, Any]]:
-        self._channel.emit(
-            logging.INFO,
-            LogCode.NAVIGATOR_API,
-            method="last.get",
-            scope=profile(self._scope),
-        )
+        self._emit("last.get")
         async with self._guard(self._scope):
             identifier = await self._tailer.peek()
         if identifier is None:
@@ -93,26 +110,32 @@ class _Tail:
         }
 
     async def delete(self) -> None:
-        self._channel.emit(
-            logging.INFO,
-            LogCode.NAVIGATOR_API,
-            method="last.delete",
-            scope=profile(self._scope),
-        )
+        self._emit("last.delete")
         async with self._guard(self._scope):
             await self._tailer.delete(self._scope)
 
     async def edit(self, content: Content) -> Optional[int]:
-        self._channel.emit(
-            logging.INFO,
-            LogCode.NAVIGATOR_API,
-            method="last.edit",
-            scope=profile(self._scope),
-            payload={"text": bool(content.text), "media": bool(content.media), "group": bool(content.group)},
+        self._emit(
+            "last.edit",
+            payload={
+                "text": bool(content.text),
+                "media": bool(content.media),
+                "group": bool(content.group),
+            },
         )
         async with self._guard(self._scope):
             result = await self._tailer.edit(self._scope, convert(content))
         return result
+
+    def _emit(self, method: str, **fields: Any) -> None:
+        self._channel.emit(
+            logging.INFO,
+            LogCode.NAVIGATOR_API,
+            method=method,
+            scope=self._scopeview,
+            **fields,
+        )
+
 
 
 class Navigator:
@@ -142,16 +165,13 @@ class Navigator:
         self._scope = scope
         self._guard = guard
         self._channel: TelemetryChannel = telemetry.channel(__name__)
+        self._scopeview = profile(scope)
         self.last = _Tail(flow=tailer, scope=scope, guard=guard, telemetry=telemetry)
 
     async def add(self, content: Union[Content, Node], *, key: Optional[str] = None, root: bool = False) -> None:
-        node = content if isinstance(content, Node) else Node(messages=[content])
-        payloads = collect(node)
-        self._channel.emit(
-            logging.INFO,
-            LogCode.NAVIGATOR_API,
-            method="add",
-            scope=profile(self._scope),
+        payloads = self._prepare_payloads(content)
+        self._emit_api(
+            "add",
             key=key,
             root=root,
             payload={"count": len(payloads)},
@@ -160,13 +180,9 @@ class Navigator:
             await self._appender.execute(self._scope, payloads, key, root=root)
 
     async def replace(self, content: Union[Content, Node]) -> None:
-        node = content if isinstance(content, Node) else Node(messages=[content])
-        payloads = collect(node)
-        self._channel.emit(
-            logging.INFO,
-            LogCode.NAVIGATOR_API,
-            method="replace",
-            scope=profile(self._scope),
+        payloads = self._prepare_payloads(content)
+        self._emit_api(
+            "replace",
             payload={"count": len(payloads)},
         )
         async with self._guard(self._scope):
@@ -174,36 +190,19 @@ class Navigator:
 
     async def rebase(self, message: int | SupportsInt) -> None:
         identifier = getattr(message, "id", message)
-        self._channel.emit(
-            logging.INFO,
-            LogCode.NAVIGATOR_API,
-            method="rebase",
-            scope=profile(self._scope),
-            message={"id": int(identifier)},
-        )
+        self._emit_api("rebase", message={"id": int(identifier)})
         async with self._guard(self._scope):
             await self._shifter.execute(int(identifier))
 
     async def back(self, context: Dict[str, Any]) -> None:
-        self._channel.emit(
-            logging.INFO,
-            LogCode.NAVIGATOR_API,
-            method="back",
-            scope=profile(self._scope),
-            handlers=sorted(list(context.keys())) if isinstance(context, dict) else None,
-        )
+        handlers = sorted(list(context.keys())) if isinstance(context, dict) else None
+        self._emit_api("back", handlers=handlers)
         async with self._guard(self._scope):
             await self._rewinder.execute(self._scope, context)
 
     async def set(self, state: Union[str, StateLike], context: Dict[str, Any] | None = None) -> None:
         status = getattr(state, "state", state)
-        self._channel.emit(
-            logging.INFO,
-            LogCode.NAVIGATOR_API,
-            method="set",
-            scope=profile(self._scope),
-            state=status,
-        )
+        self._emit_api("set", state=status)
         async with self._guard(self._scope):
             try:
                 await self._setter.execute(self._scope, status, context or {})
@@ -211,22 +210,24 @@ class Navigator:
                 await self._alarm.execute(self._scope, text=missing(self._scope))
 
     async def pop(self, count: int = 1) -> None:
-        self._channel.emit(
-            logging.INFO,
-            LogCode.NAVIGATOR_API,
-            method="pop",
-            scope=profile(self._scope),
-            count=count,
-        )
+        self._emit_api("pop", count=count)
         async with self._guard(self._scope):
             await self._trimmer.execute(count)
 
     async def alert(self) -> None:
+        self._emit_api("alert")
+        async with self._guard(self._scope):
+            await self._alarm.execute(self._scope)
+
+    def _prepare_payloads(self, content: Union[Content, Node]) -> List[Payload]:
+        node = content if isinstance(content, Node) else Node(messages=[content])
+        return collect(node)
+
+    def _emit_api(self, method: str, **fields: Any) -> None:
         self._channel.emit(
             logging.INFO,
             LogCode.NAVIGATOR_API,
-            method="alert",
-            scope=profile(self._scope),
+            method=method,
+            scope=self._scopeview,
+            **fields,
         )
-        async with self._guard(self._scope):
-            await self._alarm.execute(self._scope)


### PR DESCRIPTION
## Summary
- replace the Russian navigator module docstring with a concise English description of the key invariants and telemetry markers
- introduce helpers that cache the profiled scope and centralize payload preparation and logging across navigator operations for clearer data flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5069bb0548330889646966bebcb4d