### PR TITLE
Refine history workflows for clarity

### DIFF
--- a/app/map/entry.py
+++ b/app/map/entry.py
@@ -1,3 +1,5 @@
+"""Convert rendering outcomes into persisted history entries."""
+
 from __future__ import annotations
 
 from datetime import datetime, timezone
@@ -21,6 +23,8 @@ def _previous_extra(
         base: Optional[Entry],
         index: int,
 ) -> Optional[dict[str, Any]]:
+    """Return the previous message extra for ``index`` if available."""
+
     if base is None:
         return None
     messages = getattr(base, "messages", None) or []
@@ -30,6 +34,8 @@ def _previous_extra(
 
 
 def _media_item_from_meta(meta: MediaMeta, payload: Payload) -> MediaItem:
+    """Build a ``MediaItem`` using payload defaults when required."""
+
     variant = meta.medium
     if payload.media:
         return MediaItem(
@@ -47,6 +53,8 @@ def _media_item_from_meta(meta: MediaMeta, payload: Payload) -> MediaItem:
 
 
 def _group_items_from_meta(meta: GroupMeta) -> List[MediaItem]:
+    """Return media items representing grouped content metadata."""
+
     items: List[MediaItem] = []
     for cluster in meta.clusters:
         variant = cluster.medium
@@ -66,6 +74,8 @@ def _message_content(
         meta: Meta,
         payload: Payload,
 ) -> Tuple[Optional[str], Optional[MediaItem], Optional[List[MediaItem]]]:
+    """Return text, media, and group artefacts derived from ``meta``."""
+
     if isinstance(meta, TextMeta):
         return meta.text, None, None
     if isinstance(meta, MediaMeta):
@@ -80,6 +90,8 @@ def _caption_length(
         media: Optional[MediaItem],
         group: Optional[Iterable[MediaItem]],
 ) -> int:
+    """Return caption length for sanitising entity spans."""
+
     if group:
         first = next(iter(group), None)
         return len(getattr(first, "caption", None) or "") if first else 0
@@ -89,17 +101,23 @@ def _caption_length(
 
 
 def _resolve_inline(meta: Meta) -> Optional[bool]:
+    """Return inline flag derived from metadata if specified."""
+
     inline = getattr(meta, "inline", None)
     return bool(inline) if inline is not None else None
 
 
 def _view_if_known(ledger: ViewLedger, view: Optional[str]) -> Optional[str]:
+    """Return ``view`` only when the ledger recognises the identifier."""
+
     if view and ledger.has(view):
         return view
     return None
 
 
 class EntryMapper:
+    """Translate rendering outcomes into persisted history entries."""
+
     def __init__(self, ledger: ViewLedger):
         self._ledger = ledger
 
@@ -151,6 +169,8 @@ class EntryMapper:
 
 
 class Outcome:
+    """Provide convenient accessors around rendering outcome metadata."""
+
     def __init__(
             self,
             ids: Sequence[int],

--- a/app/usecase/add.py
+++ b/app/usecase/add.py
@@ -1,3 +1,5 @@
+"""Coordinate history append operations with view updates."""
+
 from __future__ import annotations
 
 import logging
@@ -6,8 +8,10 @@ from typing import List, Optional
 from ..log import events
 from ..log.aspect import TraceAspect
 from ..map.entry import EntryMapper, Outcome
+from ..service.store import persist
 from ..service.view.planner import ViewPlanner
 from ..service.view.policy import adapt
+from ...core.entity.history import Entry
 from ...core.port.history import HistoryRepository
 from ...core.port.last import LatestRepository
 from ...core.port.state import StateRepository
@@ -19,6 +23,8 @@ from ...core.value.message import Scope
 
 
 class Appender:
+    """Manage append operations against conversation history."""
+
     def __init__(
             self,
             archive: HistoryRepository,
@@ -46,6 +52,8 @@ class Appender:
             view: Optional[str],
             root: bool = False,
     ) -> None:
+        """Append ``bundle`` to ``scope`` while respecting ``view`` hints."""
+
         await self._trace.run(
             events.APPEND,
             self._perform,
@@ -63,16 +71,8 @@ class Appender:
             *,
             root: bool = False,
     ) -> None:
-        adjusted = [adapt(scope, normalize(p)) for p in bundle]
-        records = await self._archive.recall()
-        self._channel.emit(
-            logging.DEBUG,
-            LogCode.HISTORY_LOAD,
-            op="add",
-            history={"len": len(records)},
-            scope=profile(scope),
-        )
-
+        adjusted = self._normalize_bundle(scope, bundle)
+        records = await self._load_history(scope)
         trail = records[-1] if records else None
         render = await self._planner.render(
             scope,
@@ -91,18 +91,64 @@ class Appender:
             state={"current": status},
         )
 
-        usable = adjusted[:len(render.ids)]
-        entry = self._mapper.convert(
-            Outcome(render.ids, render.extras, render.metas),
+        entry = self._build_entry(adjusted, render, status, view, root)
+        timeline = self._timeline(records, entry, root)
+        await self._persist(timeline)
+
+    def _normalize_bundle(self, scope: Scope, bundle: List[Payload]) -> List[Payload]:
+        """Return payloads adapted to ``scope`` rendering expectations."""
+
+        return [adapt(scope, normalize(payload)) for payload in bundle]
+
+    async def _load_history(self, scope: Scope) -> List[Entry]:
+        """Load current history snapshot and report telemetry."""
+
+        records = await self._archive.recall()
+        self._channel.emit(
+            logging.DEBUG,
+            LogCode.HISTORY_LOAD,
+            op="add",
+            history={"len": len(records)},
+            scope=profile(scope),
+        )
+        return records
+
+    def _build_entry(
+            self,
+            adjusted: List[Payload],
+            render: object,
+            state: Optional[str],
+            view: Optional[str],
+            root: bool,
+    ) -> Entry:
+        """Convert render outcome and payloads into a history entry."""
+
+        identifiers = getattr(render, "ids", None) or []
+        usable = adjusted[:len(identifiers)]
+        outcome = Outcome(
+            identifiers,
+            getattr(render, "extras", None),
+            getattr(render, "metas", []),
+        )
+        return self._mapper.convert(
+            outcome,
             usable,
-            status,
+            state,
             view,
             root,
             base=None,
         )
 
-        timeline = [entry] if root else (records + [entry])
-        from ..service.store import persist
+    def _timeline(self, records: List[Entry], entry: Entry, root: bool) -> List[Entry]:
+        """Return a timeline that incorporates ``entry`` respecting ``root``."""
+
+        if root:
+            return [entry]
+        return [*records, entry]
+
+    async def _persist(self, timeline: List[Entry]) -> None:
+        """Persist ``timeline`` and refresh latest message marker."""
+
         await persist(
             self._archive,
             self._tail,

--- a/app/usecase/back.py
+++ b/app/usecase/back.py
@@ -1,23 +1,29 @@
+"""Restore the previous history entry and re-render when needed."""
+
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict
+from typing import Any, Dict, List, Sequence, Tuple
 
 from ..log import events
 from ..log.aspect import TraceAspect
 from ..service.view.planner import ViewPlanner
 from ..service.view.restorer import ViewRestorer
+from ...core.entity.history import Entry, Message
 from ...core.error import HistoryEmpty
 from ...core.port.history import HistoryRepository
 from ...core.port.last import LatestRepository
 from ...core.port.message import MessageGateway
 from ...core.port.state import StateRepository
+from ...core.service.scope import profile
 from ...core.telemetry import LogCode, Telemetry, TelemetryChannel
 from ...core.value.content import normalize
 from ...core.value.message import Scope
 
 
 class Rewinder:
+    """Coordinate rewind operations for conversation history."""
+
     def __init__(
             self,
             ledger: HistoryRepository,
@@ -27,7 +33,7 @@ class Rewinder:
             planner: ViewPlanner,
             latest: LatestRepository,
             telemetry: Telemetry,
-    ):
+    ) -> None:
         self._ledger = ledger
         self._status = status
         self._gateway = gateway
@@ -38,81 +44,140 @@ class Rewinder:
         self._trace = TraceAspect(telemetry)
 
     async def execute(self, scope: Scope, context: Dict[str, Any]) -> None:
+        """Rewind the history for ``scope`` using extra ``context`` hints."""
+
         await self._trace.run(events.BACK, self._perform, scope, context)
 
     async def _perform(self, scope: Scope, context: Dict[str, Any]) -> None:
+        history = await self._load_history(scope)
+        origin, target = self._select_targets(history)
+        inline = bool(scope.inline)
+        restored = await self._restore_payloads(target, context, inline)
+        resolved = [normalize(payload) for payload in restored]
+        render = await self._render(scope, resolved, origin, inline)
+
+        if not render or not getattr(render, "changed", False):
+            await self._handle_skip(history, target)
+            return
+
+        rebuilt = self._patch_entry(target, render)
+        await self._finalize(history, rebuilt, target, render)
+
+    async def _load_history(self, scope: Scope) -> List[Entry]:
+        """Return history snapshot while emitting telemetry."""
+
         history = await self._ledger.recall()
         self._channel.emit(
             logging.DEBUG,
             LogCode.HISTORY_LOAD,
             op="back",
             history={"len": len(history)},
-            scope={"chat": scope.chat, "inline": bool(scope.inline)},
+            scope=profile(scope),
         )
+        return history
+
+    def _select_targets(self, history: Sequence[Entry]) -> Tuple[Entry, Entry]:
+        """Return current and previous entries ensuring rewind is valid."""
+
         if len(history) < 2:
             raise HistoryEmpty("Cannot go back, history is too short.")
-        origin = history[-1]
-        target = history[-2]
-        inline = bool(scope.inline)
+        return history[-1], history[-2]
+
+    async def _restore_payloads(
+            self,
+            target: Entry,
+            context: Dict[str, Any],
+            inline: bool,
+    ) -> List[Any]:
+        """Revive payloads using stored state merged with ``context``."""
+
         memory: Dict[str, Any] = await self._status.payload()
         merged = {**memory, **context}
-        restored = await self._restorer.revive(target, merged, inline=inline)
-        resolved = [normalize(p) for p in restored]
-        if not inline:
-            render = await self._planner.render(
-                scope,
-                resolved,
-                origin,
-                inline=False,
-            )
-        else:
-            render = await self._planner.render(
-                scope,
-                resolved,
-                origin,
-                inline=True,
+        revived = await self._restorer.revive(target, merged, inline=inline)
+        return [*revived]
+
+    async def _render(
+            self,
+            scope: Scope,
+            payloads: List[Any],
+            origin: Entry,
+            inline: bool,
+    ) -> Any:
+        """Render ``payloads`` against ``origin`` entry respecting inline mode."""
+
+        return await self._planner.render(
+            scope,
+            payloads,
+            origin,
+            inline=inline,
+        )
+
+    async def _handle_skip(self, history: Sequence[Entry], target: Entry) -> None:
+        """Handle rewind when no rendering changes are required."""
+
+        self._channel.emit(logging.INFO, LogCode.RENDER_SKIP, op="back")
+        await self._status.assign(target.state)
+        if not target.messages:
+            return
+
+        marker = target.messages[0].id
+        await self._latest.mark(marker)
+        trimmed = list(history[:-1])
+        await self._ledger.archive(trimmed)
+        self._channel.emit(
+            logging.DEBUG,
+            LogCode.HISTORY_SAVE,
+            op="back",
+            history={"len": len(trimmed)},
+        )
+
+    def _patch_entry(self, target: Entry, render: Any) -> Entry:
+        """Return ``target`` with messages patched using ``render`` metadata."""
+
+        identifiers = [int(identifier) for identifier in getattr(render, "ids", None) or []]
+        raw_extras = getattr(render, "extras", None) or []
+        extras = [list(extra) for extra in raw_extras]
+        limit = min(len(target.messages), len(identifiers))
+        patched: List[Message] = []
+
+        for index in range(limit):
+            message = target.messages[index]
+            default = list(message.extras) if message.extras is not None else []
+            provided = extras[index] if index < len(extras) else default
+            patched.append(
+                type(message)(
+                    id=int(identifiers[index]),
+                    text=message.text,
+                    media=message.media,
+                    group=message.group,
+                    markup=message.markup,
+                    preview=message.preview,
+                    extra=message.extra,
+                    extras=list(provided),
+                    inline=message.inline,
+                    automated=message.automated,
+                    ts=message.ts,
+                )
             )
 
-        if not render or not render.changed:
-            self._channel.emit(logging.INFO, LogCode.RENDER_SKIP, op="back")
-            await self._status.assign(target.state)
-            if target.messages:
-                marker = target.messages[0].id
-                await self._latest.mark(marker)
-                trimmed = history[:-1]
-                await self._ledger.archive(trimmed)
-                self._channel.emit(
-                    logging.DEBUG,
-                    LogCode.HISTORY_SAVE,
-                    op="back",
-                    history={"len": len(trimmed)},
-                )
-            return
-        limit = min(len(target.messages), len(render.ids))
-        patched = [
-            type(target.messages[i])(
-                id=render.ids[i],
-                text=target.messages[i].text,
-                media=target.messages[i].media,
-                group=target.messages[i].group,
-                markup=target.messages[i].markup,
-                preview=target.messages[i].preview,
-                extra=target.messages[i].extra,
-                extras=render.extras[i],
-                inline=target.messages[i].inline,
-                automated=target.messages[i].automated,
-                ts=target.messages[i].ts,
-            )
-            for i in range(limit)
-        ]
-        merged = patched + target.messages[limit:]
-        rebuilt = type(target)(
+        patched.extend(target.messages[limit:])
+        return type(target)(
             state=target.state,
             view=target.view,
-            messages=merged,
+            messages=patched,
             root=target.root,
         )
-        trimmed = history[:-1]
+
+    async def _finalize(
+            self,
+            history: Sequence[Entry],
+            rebuilt: Entry,
+            target: Entry,
+            render: Any,
+    ) -> None:
+        """Persist rebuilt entry and update state/marker telemetry."""
+
+        trimmed = list(history[:-1])
         trimmed[-1] = rebuilt
         await self._ledger.archive(trimmed)
         self._channel.emit(
@@ -128,10 +193,13 @@ class Rewinder:
             op="back",
             state={"target": target.state},
         )
-        await self._latest.mark(render.ids[0])
+        identifiers = [int(identifier) for identifier in getattr(render, "ids", None) or []]
+        if not identifiers:
+            return
+        await self._latest.mark(identifiers[0])
         self._channel.emit(
             logging.INFO,
             LogCode.LAST_SET,
             op="back",
-            message={"id": render.ids[0]},
+            message={"id": identifiers[0]},
         )

--- a/app/usecase/rebase.py
+++ b/app/usecase/rebase.py
@@ -1,3 +1,5 @@
+"""Rebase the latest entry marker onto a supplied message identifier."""
+
 from __future__ import annotations
 
 import logging
@@ -12,6 +14,8 @@ from ...core.telemetry import LogCode, Telemetry, TelemetryChannel
 
 
 class Shifter:
+    """Shift the latest message marker to a newly provided ``marker``."""
+
     def __init__(self, ledger: HistoryRepository, latest: LatestRepository, telemetry: Telemetry):
         self._ledger = ledger
         self._latest = latest
@@ -19,30 +23,55 @@ class Shifter:
         self._trace = TraceAspect(telemetry)
 
     async def execute(self, marker: int) -> None:
+        """Rebase history marker onto ``marker`` value."""
+
         await self._trace.run(events.REBASE, self._perform, marker)
 
     async def _perform(self, marker: int) -> None:
-        history = await self._ledger.recall()
-        self._channel.emit(
-            logging.DEBUG, LogCode.HISTORY_LOAD, op="rebase", history={"len": len(history)}
-        )
+        history = await self._load_history()
         if not history:
             return
 
         last = history[-1]
         if not last.messages:
-            await self._latest.mark(int(marker))
-            self._channel.emit(
-                logging.INFO, LogCode.LAST_SET, op="rebase", message={"id": int(marker)}
-            )
-            self._channel.emit(
-                logging.INFO,
-                LogCode.REBASE_SUCCESS,
-                op="rebase",
-                message={"id": int(marker)},
-                history={"len": len(history)},
-            )
+            await self._update_marker_only(marker, len(history))
             return
+
+        rebuilt = self._patch_entry(history, last, marker)
+        await self._persist(rebuilt, marker)
+
+    async def _load_history(self) -> List[Entry]:
+        """Return history snapshots while emitting telemetry."""
+
+        history = await self._ledger.recall()
+        self._channel.emit(
+            logging.DEBUG,
+            LogCode.HISTORY_LOAD,
+            op="rebase",
+            history={"len": len(history)},
+        )
+        return history
+
+    async def _update_marker_only(self, marker: int, history_len: int) -> None:
+        """Update latest marker when history has no persisted messages."""
+
+        await self._latest.mark(int(marker))
+        self._channel.emit(
+            logging.INFO,
+            LogCode.LAST_SET,
+            op="rebase",
+            message={"id": int(marker)},
+        )
+        self._channel.emit(
+            logging.INFO,
+            LogCode.REBASE_SUCCESS,
+            op="rebase",
+            message={"id": int(marker)},
+            history={"len": history_len},
+        )
+
+    def _patch_entry(self, history: List[Entry], last: Entry, marker: int) -> List[Entry]:
+        """Return rebuilt history with ``last`` message id replaced."""
 
         first = last.messages[0]
         patched = Message(
@@ -61,10 +90,14 @@ class Shifter:
         trailer = Entry(
             state=last.state,
             view=last.view,
-            messages=[patched] + last.messages[1:],
+            messages=[patched, *last.messages[1:]],
             root=last.root,
         )
-        rebuilt: List[Entry] = history[:-1] + [trailer]
+        rebuilt: List[Entry] = [*history[:-1], trailer]
+        return rebuilt
+
+    async def _persist(self, rebuilt: List[Entry], marker: int) -> None:
+        """Persist rebuilt history snapshot and update marker telemetry."""
 
         await self._ledger.archive(rebuilt)
         self._channel.emit(
@@ -73,12 +106,13 @@ class Shifter:
             op="rebase",
             history={"len": len(rebuilt)},
         )
-
         await self._latest.mark(int(marker))
         self._channel.emit(
-            logging.INFO, LogCode.LAST_SET, op="rebase", message={"id": int(marker)}
+            logging.INFO,
+            LogCode.LAST_SET,
+            op="rebase",
+            message={"id": int(marker)},
         )
-
         self._channel.emit(
             logging.INFO,
             LogCode.REBASE_SUCCESS,

--- a/app/usecase/replace.py
+++ b/app/usecase/replace.py
@@ -1,3 +1,5 @@
+"""Replace the latest history entry with freshly rendered payloads."""
+
 from __future__ import annotations
 
 import logging
@@ -6,8 +8,10 @@ from typing import List
 from ..log import events
 from ..log.aspect import TraceAspect
 from ..map.entry import EntryMapper, Outcome
+from ..service.store import persist
 from ..service.view.planner import ViewPlanner
 from ..service.view.policy import adapt
+from ...core.entity.history import Entry
 from ...core.port.history import HistoryRepository
 from ...core.port.last import LatestRepository
 from ...core.port.state import StateRepository
@@ -18,6 +22,8 @@ from ...core.value.message import Scope
 
 
 class Swapper:
+    """Replace the trailing history entry with a newly mapped version."""
+
     def __init__(
             self,
             archive: HistoryRepository,
@@ -39,17 +45,13 @@ class Swapper:
         self._trace = TraceAspect(telemetry)
 
     async def execute(self, scope: Scope, bundle: List[Payload]) -> None:
+        """Replace history entry within ``scope`` using ``bundle`` payloads."""
+
         await self._trace.run(events.REPLACE, self._perform, scope, bundle)
 
     async def _perform(self, scope: Scope, bundle: List[Payload]) -> None:
-        adjusted = [adapt(scope, normalize(p)) for p in bundle]
-        records = await self._archive.recall()
-        self._channel.emit(
-            logging.DEBUG,
-            LogCode.HISTORY_LOAD,
-            op="replace",
-            history={"len": len(records)},
-        )
+        adjusted = self._normalize_bundle(scope, bundle)
+        records = await self._load_history()
         trail = records[-1] if records else None
         render = await self._planner.render(
             scope,
@@ -63,20 +65,64 @@ class Swapper:
             return
         status = await self._state.status()
 
-        usable = adjusted[:len(render.ids)]
-        entry = self._mapper.convert(
-            Outcome(render.ids, render.extras, render.metas),
+        entry = self._build_entry(trail, adjusted, render, status)
+        timeline = self._timeline(records, entry)
+        await self._persist(timeline)
+
+    def _normalize_bundle(self, scope: Scope, bundle: List[Payload]) -> List[Payload]:
+        """Return payloads adapted to ``scope`` expectations."""
+
+        return [adapt(scope, normalize(payload)) for payload in bundle]
+
+    async def _load_history(self) -> List[Entry]:
+        """Load current history records and report telemetry."""
+
+        records = await self._archive.recall()
+        self._channel.emit(
+            logging.DEBUG,
+            LogCode.HISTORY_LOAD,
+            op="replace",
+            history={"len": len(records)},
+        )
+        return records
+
+    def _build_entry(
+            self,
+            trail: Entry | None,
+            adjusted: List[Payload],
+            render: object,
+            state: str | None,
+    ) -> Entry:
+        """Map ``render`` outcome to a persisted history entry."""
+
+        identifiers = getattr(render, "ids", None) or []
+        usable = adjusted[:len(identifiers)]
+        outcome = Outcome(
+            identifiers,
+            getattr(render, "extras", None),
+            getattr(render, "metas", []),
+        )
+        view = trail.view if trail else None
+        root = bool(trail.root) if trail else False
+        return self._mapper.convert(
+            outcome,
             usable,
-            status,
-            trail.view if trail else None,
-            root=bool(trail.root) if trail else False,
+            state,
+            view,
+            root,
             base=trail,
         )
+
+    def _timeline(self, records: List[Entry], entry: Entry) -> List[Entry]:
+        """Return a history timeline with ``entry`` as the newest snapshot."""
+
         if not records:
-            timeline = [entry]
-        else:
-            timeline = records[:-1] + [entry]
-        from ..service.store import persist
+            return [entry]
+        return [*records[:-1], entry]
+
+    async def _persist(self, timeline: List[Entry]) -> None:
+        """Persist ``timeline`` updates and latest marker."""
+
         await persist(
             self._archive,
             self._tail,

--- a/core/service/history/policy.py
+++ b/core/service/history/policy.py
@@ -1,13 +1,28 @@
+"""Trim stored history entries according to configured policies."""
+
+from __future__ import annotations
+
 from typing import List
 
 from ...entity.history import Entry
 
+HistoryList = List[Entry]
 
-def prune(history: List[Entry], limit: int) -> List[Entry]:
-    if len(history) <= limit:
+
+def prune(history: HistoryList, limit: int) -> HistoryList:
+    """Return history trimmed to ``limit`` while preserving the root."""
+
+    try:
+        maximum = max(0, int(limit))
+    except (TypeError, ValueError):
+        maximum = 0
+    if len(history) <= maximum:
         return history
-    overflow = len(history) - limit
+
+    overflow = len(history) - maximum
     if history and getattr(history[0], "root", False):
-        start = 1 + overflow
-        return [history[0]] + history[start:]
+        preserved = history[0]
+        start = min(len(history), 1 + overflow)
+        return [preserved, *history[start:]]
+
     return history[overflow:]


### PR DESCRIPTION
## Summary
- clarify telemetry tracing helpers and module documentation
- modularize history persistence use cases to separate loading, rendering, and storage responsibilities
- document entry mapping utilities and history pruning behaviour for future maintainers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d50a93b6c88330a5ef536aad26251e