### PR TITLE
Improve payload and media mappings clarity

### DIFF
--- a/adapters/telegram/codec.py
+++ b/adapters/telegram/codec.py
@@ -1,78 +1,79 @@
+"""Convert between aiogram keyboard objects and Navigator markup."""
+
+from __future__ import annotations
+
 import logging
+from typing import Any, Optional, Type
+
 from aiogram.types import (
-    InlineKeyboardMarkup, ReplyKeyboardMarkup, ReplyKeyboardRemove, ForceReply
+    ForceReply,
+    InlineKeyboardMarkup,
+    ReplyKeyboardMarkup,
+    ReplyKeyboardRemove,
 )
+
 from navigator.core.entity.markup import Markup
 from navigator.core.port.markup import MarkupCodec
 from navigator.core.telemetry import LogCode, Telemetry, TelemetryChannel
-from typing import Optional, Any
+
+_AIROGRAM_TYPES: dict[str, Type[Any]] = {
+    "InlineKeyboardMarkup": InlineKeyboardMarkup,
+    "ReplyKeyboardMarkup": ReplyKeyboardMarkup,
+    "ReplyKeyboardRemove": ReplyKeyboardRemove,
+    "ForceReply": ForceReply,
+}
 
 
 class AiogramCodec(MarkupCodec):
+    """Bridge aiogram keyboard objects with Navigator markup entities."""
+
     def __init__(self, telemetry: Telemetry) -> None:
         self._channel: TelemetryChannel = telemetry.channel(__name__)
 
-    _MAP = {
-        "InlineKeyboardMarkup": InlineKeyboardMarkup,
-        "ReplyKeyboardMarkup": ReplyKeyboardMarkup,
-        "ReplyKeyboardRemove": ReplyKeyboardRemove,
-        "ForceReply": ForceReply,
-    }
-
     def encode(self, markup: Any) -> Optional[Markup]:
+        """Translate aiogram markup objects into serialisable structures."""
+
         if not markup:
-            self._channel.emit(logging.DEBUG, LogCode.MARKUP_ENCODE, recognized=False)
+            self._emit(logging.DEBUG, LogCode.MARKUP_ENCODE, recognized=False)
             return None
         kind = markup.__class__.__name__
-        if kind in self._MAP:
-            self._channel.emit(
-                logging.DEBUG,
-                LogCode.MARKUP_ENCODE,
-                recognized=True,
-                kind=kind,
-            )
-            return Markup(
-                kind=kind,
-                data=markup.model_dump(exclude_none=True, by_alias=True)
-            )
-        self._channel.emit(
-            logging.DEBUG,
-            LogCode.MARKUP_ENCODE,
-            recognized=False,
+        target = _AIROGRAM_TYPES.get(kind)
+        if target is None:
+            self._emit(logging.DEBUG, LogCode.MARKUP_ENCODE, recognized=False, kind=kind)
+            return None
+        self._emit(logging.DEBUG, LogCode.MARKUP_ENCODE, recognized=True, kind=kind)
+        return Markup(
             kind=kind,
+            data=markup.model_dump(exclude_none=True, by_alias=True),
         )
-        return None
 
     def decode(self, stored: Optional[Markup]) -> Any:
+        """Reconstruct aiogram markup objects from stored metadata."""
+
         if not stored:
             return None
-        target = self._MAP.get(stored.kind)
-        if target:
-            try:
-                obj = target.model_validate(stored.data)
-                self._channel.emit(
-                    logging.DEBUG,
-                    LogCode.MARKUP_DECODE,
-                    recognized=True,
-                    kind=stored.kind,
-                )
-                return obj
-            except Exception:
-                self._channel.emit(
-                    logging.WARNING,
-                    LogCode.MARKUP_DECODE,
-                    recognized=False,
-                    kind=stored.kind,
-                    note="type_error",
-                )
-                return None
-        self._channel.emit(
-            logging.DEBUG,
-            LogCode.MARKUP_DECODE,
-            recognized=False,
-            kind=stored.kind,
-        )
-        return None
+        target = _AIROGRAM_TYPES.get(stored.kind)
+        if target is None:
+            self._emit(logging.DEBUG, LogCode.MARKUP_DECODE, recognized=False, kind=stored.kind)
+            return None
+        try:
+            result = target.model_validate(stored.data)
+        except Exception:
+            self._emit(
+                logging.WARNING,
+                LogCode.MARKUP_DECODE,
+                recognized=False,
+                kind=stored.kind,
+                note="type_error",
+            )
+            return None
+        self._emit(logging.DEBUG, LogCode.MARKUP_DECODE, recognized=True, kind=stored.kind)
+        return result
+
+    def _emit(self, level: int, code: LogCode, **fields: Any) -> None:
+        """Emit telemetry events only when a channel is available."""
+
+        self._channel.emit(level, code, **fields)
 
 
 __all__ = ["AiogramCodec"]

--- a/adapters/telegram/media.py
+++ b/adapters/telegram/media.py
@@ -1,7 +1,11 @@
+"""Provide Telegram media conversion helpers for Navigator payloads."""
+
 from __future__ import annotations
 
 import logging
 import re
+from collections.abc import Mapping
+
 from aiogram.types import (
     BufferedInputFile,
     FSInputFile,
@@ -12,6 +16,7 @@ from aiogram.types import (
     InputMediaVideo,
     URLInputFile,
 )
+
 from navigator.core.entity.media import MediaItem, MediaType
 from navigator.core.error import CaptionOverflow, EditForbidden, NavigatorError
 from navigator.core.port.limits import Limits
@@ -19,43 +24,72 @@ from navigator.core.port.pathpolicy import MediaPathPolicy
 from navigator.core.service.rendering.album import validate
 from navigator.core.telemetry import LogCode, Telemetry, TelemetryChannel
 from navigator.core.util.path import local, remote
-from typing import Dict, List, Union
 
 from .serializer.screen import SignatureScreen
 
-InputFile = Union[str, FSInputFile, BufferedInputFile, URLInputFile]
-InputMedia = Union[
-    InputMediaPhoto,
-    InputMediaVideo,
-    InputMediaDocument,
-    InputMediaAudio,
-    InputMediaAnimation,
-]
+InputFile = str | FSInputFile | BufferedInputFile | URLInputFile
+InputMedia = (
+    InputMediaPhoto
+    | InputMediaVideo
+    | InputMediaDocument
+    | InputMediaAudio
+    | InputMediaAnimation
+)
 
 _FILE_ID_RE = re.compile(r"^[A-Za-z0-9_.:\-=]{20,}$")
+_MEDIA_TYPE_HANDLERS: Mapping[MediaType, type[InputMedia]] = {
+    MediaType.PHOTO: InputMediaPhoto,
+    MediaType.VIDEO: InputMediaVideo,
+    MediaType.DOCUMENT: InputMediaDocument,
+    MediaType.AUDIO: InputMediaAudio,
+    MediaType.ANIMATION: InputMediaAnimation,
+}
+_BOOLEAN_SETTINGS = {
+    "spoiler": "has_spoiler",
+    "show_caption_above_media": "show_caption_above_media",
+    "supports_streaming": "supports_streaming",
+}
+_STRING_SETTINGS = {
+    "title": "title",
+    "performer": "performer",
+}
+_INTEGER_SETTINGS = {
+    "duration": "duration",
+    "width": "width",
+    "height": "height",
+}
+_TIMESTAMP_FIELDS = {"start": "start_timestamp"}
+_PATH_SETTINGS = {
+    "cover": "cover",
+    "thumb": "thumbnail",
+}
 
 
 class TelegramMediaPolicy(MediaPathPolicy):
+    """Enforce media path policies for Telegram transports."""
+
     def __init__(self, *, strict: bool = True) -> None:
         self._strict = strict
 
     def admissible(self, path: object, *, inline: bool) -> bool:
+        """Return ``True`` when ``path`` may be used for inline uploads."""
+
         if not inline:
             return True
         if isinstance(path, URLInputFile):
             return True
-        if isinstance(path, str):
-            if remote(path):
-                return True
-            if local(path):
-                return False
-            if self._strict:
-                return bool(_FILE_ID_RE.match(path))
+        if not isinstance(path, str):
+            return False
+        if remote(path):
             return True
-        return False
+        if local(path):
+            return False
+        return bool(_FILE_ID_RE.match(path)) if self._strict else True
 
     def adapt(self, path: object, *, native: bool) -> object:
-        if isinstance(path, (BufferedInputFile, URLInputFile)):
+        """Return a Telegram-compatible input for ``path`` respecting flags."""
+
+        if isinstance(path, BufferedInputFile | URLInputFile):
             return path
         if isinstance(path, FSInputFile):
             if not native:
@@ -73,92 +107,52 @@ class TelegramMediaPolicy(MediaPathPolicy):
 
 
 def convert(item: MediaItem, *, policy: MediaPathPolicy, native: bool) -> InputFile:
+    """Return Telegram input file representation for ``item``."""
+
     return policy.adapt(item.path, native=native)
-
-
-def _select(item: MediaItem):
-    catalog = {
-        MediaType.PHOTO: InputMediaPhoto,
-        MediaType.VIDEO: InputMediaVideo,
-        MediaType.DOCUMENT: InputMediaDocument,
-        MediaType.AUDIO: InputMediaAudio,
-        MediaType.ANIMATION: InputMediaAnimation,
-    }
-    handler = catalog.get(item.type)
-    if handler is None:
-        if item.type in (MediaType.VOICE, MediaType.VIDEO_NOTE):
-            raise EditForbidden("edit_media_type_forbidden")
-        raise ValueError(f"unsupported media type: {item.type}")
-    return handler
 
 
 def compose(
         item: MediaItem,
         *,
         caption: str | None,
-        captionmeta: Dict[str, object],
-        mediameta: Dict[str, object],
+        captionmeta: dict[str, object],
+        mediameta: dict[str, object],
         policy: MediaPathPolicy,
         screen: SignatureScreen,
         limits: Limits,
         native: bool,
 ) -> InputMedia:
+    """Compose Telegram media objects enriched with Navigator metadata."""
+
     handler = _select(item)
-    mapping: Dict[str, object] = {}
+    mapping: dict[str, object] = {}
 
     if caption is not None:
         if len(str(caption)) > limits.captionlimit():
             raise CaptionOverflow()
         mapping["caption"] = caption
 
-    captionview = screen.filter(handler, captionmeta)
-    mapping.update(captionview)
-
-    settings: Dict[str, object] = {}
-    if mediameta.get("spoiler") is not None:
-        settings["has_spoiler"] = bool(mediameta.get("spoiler"))
-    if mediameta.get("show_caption_above_media") is not None:
-        settings["show_caption_above_media"] = bool(mediameta.get("show_caption_above_media"))
-    if mediameta.get("start") is not None:
-        settings["start_timestamp"] = mediameta.get("start")
-    if mediameta.get("supports_streaming") is not None:
-        settings["supports_streaming"] = bool(mediameta.get("supports_streaming"))
-
-    if mediameta.get("cover") is not None:
-        settings["cover"] = policy.adapt(mediameta.get("cover"), native=native)
-    if mediameta.get("thumb") is not None:
-        settings["thumbnail"] = policy.adapt(mediameta.get("thumb"), native=native)
-
-    if mediameta.get("title") is not None:
-        settings["title"] = str(mediameta.get("title"))
-    if mediameta.get("performer") is not None:
-        settings["performer"] = str(mediameta.get("performer"))
-    if mediameta.get("duration") is not None:
-        settings["duration"] = int(mediameta.get("duration"))
-
-    if mediameta.get("width") is not None:
-        settings["width"] = int(mediameta.get("width"))
-    if mediameta.get("height") is not None:
-        settings["height"] = int(mediameta.get("height"))
-
-    settingview = screen.filter(handler, settings)
-    mapping.update(settingview)
+    mapping.update(screen.filter(handler, captionmeta))
+    mapping.update(_prepare_media_settings(mediameta, policy, native, handler, screen))
 
     arguments = {"media": convert(item, policy=policy, native=native), **mapping}
     return handler(**arguments)
 
 
 def assemble(
-        items: List[MediaItem],
+        items: list[MediaItem],
         *,
-        captionmeta: Dict[str, object],
-        mediameta: Dict[str, object],
+        captionmeta: dict[str, object],
+        mediameta: dict[str, object],
         policy: MediaPathPolicy,
         screen: SignatureScreen,
         limits: Limits,
         native: bool,
         telemetry: Telemetry | None = None,
-) -> List[InputMedia]:
+) -> list[InputMedia]:
+    """Compose album media structures for Telegram dispatch."""
+
     channel: TelemetryChannel | None = (
         telemetry.channel(__name__) if telemetry else None
     )
@@ -175,7 +169,7 @@ def assemble(
             )
         raise exc
 
-    result: List[InputMedia] = []
+    result: list[InputMedia] = []
     for index, item in enumerate(items):
         text = item.caption if index == 0 else ""
         result.append(
@@ -191,6 +185,94 @@ def assemble(
             )
         )
     return result
+
+
+def _select(item: MediaItem) -> type[InputMedia]:
+    """Return appropriate Telegram handler for ``item`` type."""
+
+    handler = _MEDIA_TYPE_HANDLERS.get(item.type)
+    if handler is None:
+        if item.type in (MediaType.VOICE, MediaType.VIDEO_NOTE):
+            raise EditForbidden("edit_media_type_forbidden")
+        raise ValueError(f"unsupported media type: {item.type}")
+    return handler
+
+
+def _prepare_media_settings(
+        mediameta: Mapping[str, object],
+        policy: MediaPathPolicy,
+        native: bool,
+        handler: type[InputMedia],
+        screen: SignatureScreen,
+) -> dict[str, object]:
+    """Normalise optional media metadata into Telegram-friendly keys."""
+
+    settings: dict[str, object] = {}
+    settings.update(_collect_boolean_flags(mediameta))
+    settings.update(_collect_string_fields(mediameta))
+    settings.update(_collect_integer_fields(mediameta))
+    settings.update(_collect_timestamp_fields(mediameta))
+    settings.update(_collect_path_fields(mediameta, policy, native))
+    filtered = screen.filter(handler, settings)
+    return filtered
+
+
+def _collect_boolean_flags(mediameta: Mapping[str, object]) -> dict[str, object]:
+    """Return boolean settings recognised by Telegram APIs."""
+
+    payload: dict[str, object] = {}
+    for key, target in _BOOLEAN_SETTINGS.items():
+        if key in mediameta and mediameta[key] is not None:
+            payload[target] = bool(mediameta[key])
+    return payload
+
+
+def _collect_string_fields(mediameta: Mapping[str, object]) -> dict[str, object]:
+    """Return string metadata prepared for Telegram models."""
+
+    payload: dict[str, object] = {}
+    for key, target in _STRING_SETTINGS.items():
+        value = mediameta.get(key)
+        if value is not None:
+            payload[target] = str(value)
+    return payload
+
+
+def _collect_integer_fields(mediameta: Mapping[str, object]) -> dict[str, object]:
+    """Return integer metadata prepared for Telegram models."""
+
+    payload: dict[str, object] = {}
+    for key, target in _INTEGER_SETTINGS.items():
+        value = mediameta.get(key)
+        if value is not None:
+            payload[target] = int(value)
+    return payload
+
+
+def _collect_timestamp_fields(mediameta: Mapping[str, object]) -> dict[str, object]:
+    """Return timestamp-like metadata prepared for Telegram models."""
+
+    payload: dict[str, object] = {}
+    for key, target in _TIMESTAMP_FIELDS.items():
+        value = mediameta.get(key)
+        if value is not None:
+            payload[target] = value
+    return payload
+
+
+def _collect_path_fields(
+        mediameta: Mapping[str, object],
+        policy: MediaPathPolicy,
+        native: bool,
+) -> dict[str, object]:
+    """Return path-like metadata adapted for Telegram transport rules."""
+
+    payload: dict[str, object] = {}
+    for key, target in _PATH_SETTINGS.items():
+        value = mediameta.get(key)
+        if value is not None:
+            payload[target] = policy.adapt(value, native=native)
+    return payload
 
 
 __all__ = ["TelegramMediaPolicy", "convert", "compose", "assemble"]

--- a/app/dto/content.py
+++ b/app/dto/content.py
@@ -1,3 +1,5 @@
+"""Define application-level DTOs for payload assembly."""
+
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
@@ -9,6 +11,8 @@ Extra = Dict[str, Any]
 
 @dataclass(frozen=True, slots=True)
 class Media:
+    """Represent media inputs captured from upstream adapters."""
+
     path: object
     type: Optional[str] = None
     caption: Optional[str] = None
@@ -16,19 +20,18 @@ class Media:
 
 @dataclass(frozen=True, slots=True)
 class Content:
-    """
-    DTO контента для Navigator.
+    """Describe Navigator content transfer object contract.
 
-    Поле `extra`:
-    - `message_effect_id` применяется только при отправке в приватных чатах.
-    - При редактировании и/или вне приватных чатов эффект удаляется нормализацией.
-    - Попытка изменить только эффект без изменения текста/медиа/markup логически приводит к NO_CHANGE.
+    Extra payload notes:
+    * ``message_effect_id`` applies only when targeting private chats.
+    * Normalisation strips unsupported effects when editing existing content.
+    * Updating only the effect without changing content does not trigger writes.
 
-    Очистка подписи:
-    - Если media и erase=True и text в значении None/"" →
-      в payload.text будет установлен "" и установлен маркер явной очистки.
-    - Если media и text == "" при erase=False → выбрасывается ValueError.
+    Caption erasure rules:
+    * ``media`` with ``erase=True`` and ``text`` in ``(None, "")`` clears captions.
+    * ``media`` with an empty caption requires ``erase`` to be ``True``.
     """
+
     text: Optional[str] = None
     media: Optional[Media] = None
     group: Optional[List[Media]] = None
@@ -40,6 +43,8 @@ class Content:
 
 @dataclass(frozen=True, slots=True)
 class Node:
+    """Group sequential content messages for batch operations."""
+
     messages: List[Content]
 
 

--- a/bootstrap/navigator.py
+++ b/bootstrap/navigator.py
@@ -1,4 +1,8 @@
+"""Bootstrap the Navigator runtime for telegram entrypoints."""
+
 from __future__ import annotations
+
+from typing import Any, cast
 
 from navigator.adapters.telemetry.logger import PythonLoggingTelemetry
 from navigator.api.contracts import ScopeDTO, ViewLedgerDTO
@@ -10,24 +14,31 @@ from navigator.presentation.alerts import missing
 from navigator.presentation.bootstrap.navigator import compose
 from navigator.presentation.navigator import Navigator
 from navigator.presentation.telegram import instrument
-from typing import Any, cast
 
 
 class _LedgerAdapter(ViewLedger):
+    """Expose a DTO-backed ledger through the domain ``ViewLedger``."""
+
     def __init__(self, ledger: ViewLedgerDTO) -> None:
         self._ledger = ledger
 
     def get(self, key: str) -> ViewForge:
+        """Return a forge callable for ``key`` ensuring callability."""
+
         forge = self._ledger.get(key)
         if not callable(forge):
             raise TypeError(f"Ledger forge for '{key}' is not callable")
         return cast(ViewForge, forge)
 
     def has(self, key: str) -> bool:
+        """Return ``True`` when the underlying ledger exposes ``key``."""
+
         return bool(self._ledger.has(key))
 
 
 def _scope(dto: ScopeDTO) -> Scope:
+    """Translate external ``ScopeDTO`` structures into domain scopes."""
+
     return Scope(
         chat=getattr(dto, "chat", None),
         lang=getattr(dto, "lang", None),
@@ -46,6 +57,8 @@ async def assemble(
         ledger: ViewLedgerDTO,
         scope: ScopeDTO,
 ) -> Navigator:
+    """Construct a Navigator instance from entrypoint payloads."""
+
     port = PythonLoggingTelemetry()
     telemetry = Telemetry(port)
     container = AppContainer(

--- a/core/service/history/policy.py
+++ b/core/service/history/policy.py
@@ -12,17 +12,28 @@ HistoryList = List[Entry]
 def prune(history: HistoryList, limit: int) -> HistoryList:
     """Return history trimmed to ``limit`` while preserving the root."""
 
-    try:
-        maximum = max(0, int(limit))
-    except (TypeError, ValueError):
-        maximum = 0
+    maximum = _coerce_limit(limit)
     if len(history) <= maximum:
         return history
 
     overflow = len(history) - maximum
     if history and getattr(history[0], "root", False):
-        preserved = history[0]
-        start = min(len(history), 1 + overflow)
-        return [preserved, *history[start:]]
-
+        return _preserve_root(history, overflow)
     return history[overflow:]
+
+
+def _coerce_limit(limit: int) -> int:
+    """Coerce ``limit`` into a non-negative integer bound."""
+
+    try:
+        return max(0, int(limit))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _preserve_root(history: HistoryList, overflow: int) -> HistoryList:
+    """Retain the root entry while trimming ``overflow`` items."""
+
+    preserved = history[0]
+    start = min(len(history), 1 + overflow)
+    return [preserved, *history[start:]]


### PR DESCRIPTION
## Summary
- clarify payload normalization and DTO semantics for downstream services
- refactor Telegram adapters to improve media policy and markup conversion readability
- document bootstrap and configuration helpers to better describe runtime wiring

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d510b34e78833092e36e56896bbbdb