### PR TITLE
Refine history management workflows and telemetry hooks

### DIFF
--- a/app/map/entry.py
+++ b/app/map/entry.py
@@ -107,6 +107,18 @@ def _resolve_inline(meta: Meta) -> Optional[bool]:
     return bool(inline) if inline is not None else None
 
 
+def _clean_extra(
+        payload: Payload,
+        base: Optional[Entry],
+        index: int,
+        length: int,
+) -> Optional[dict[str, Any]]:
+    """Return sanitised extra metadata for ``payload`` at ``index``."""
+
+    source = payload.extra if payload.extra is not None else _previous_extra(base, index)
+    return cleanse(source, length=length)
+
+
 def _view_if_known(ledger: ViewLedger, view: Optional[str]) -> Optional[str]:
     """Return ``view`` only when the ledger recognises the identifier."""
 
@@ -140,9 +152,8 @@ class EntryMapper:
             inline = _resolve_inline(meta)
             text, media, group = _message_content(meta, payload)
 
-            source = payload.extra if payload.extra is not None else _previous_extra(base, index)
             length = _caption_length(text, media, group)
-            extra = cleanse(source, length=length)
+            extra = _clean_extra(payload, base, index, length)
 
             messages.append(
                 Message(

--- a/app/service/store.py
+++ b/app/service/store.py
@@ -14,16 +14,22 @@ from ...core.value.content import Payload
 
 
 def preserve(payload: Payload, entry: Message | None) -> Payload:
-    """Return ``payload`` with fallback preview and extra from ``entry``."""
+    """Return ``payload`` with preview and extra inherited from ``entry``."""
 
     if entry is None:
         return payload
 
-    preview = payload.preview if payload.preview is not None else entry.preview
-    extra = payload.extra if payload.extra is not None else entry.extra
+    preview = _inherit(payload.preview, entry.preview)
+    extra = _inherit(payload.extra, entry.extra)
     if preview is payload.preview and extra is payload.extra:
         return payload
     return replace(payload, preview=preview, extra=extra)
+
+
+def _inherit(current: object | None, fallback: object | None) -> object | None:
+    """Return ``current`` unless it is ``None``, falling back to ``fallback``."""
+
+    return current if current is not None else fallback
 
 
 def _channel_for(telemetry: Telemetry | None) -> TelemetryChannel | None:

--- a/app/usecase/pop.py
+++ b/app/usecase/pop.py
@@ -1,15 +1,21 @@
+"""Coordinate history trimming while updating telemetry markers."""
+
 from __future__ import annotations
 
 import logging
+from typing import Sequence
 
 from ..log import events
 from ..log.aspect import TraceAspect
+from ...core.entity.history import Entry
 from ...core.port.history import HistoryRepository
 from ...core.port.last import LatestRepository
 from ...core.telemetry import LogCode, Telemetry, TelemetryChannel
 
 
 class Trimmer:
+    """Manage history pop operations with consistent telemetry reporting."""
+
     def __init__(self, ledger: HistoryRepository, latest: LatestRepository, telemetry: Telemetry):
         self._ledger = ledger
         self._latest = latest
@@ -17,30 +23,56 @@ class Trimmer:
         self._trace = TraceAspect(telemetry)
 
     async def execute(self, count: int = 1) -> None:
+        """Trim history by ``count`` entries while refreshing the latest marker."""
+
         await self._trace.run(events.POP, self._perform, count)
 
     async def _perform(self, count: int = 1) -> None:
+        """Execute the trimming workflow after validating ``count``."""
+
         if count <= 0:
-            self._channel.emit(logging.INFO, LogCode.RENDER_SKIP, op="pop", note="count_le_0")
+            self._emit_skip("count_le_0")
             return
+
+        history = await self._recall_history()
+        deletions = self._deletions(len(history), count)
+        if deletions <= 0:
+            return
+
+        trimmed = history[:-deletions]
+        await self._persist(trimmed, deletions)
+
+    async def _recall_history(self) -> Sequence[Entry]:
+        """Return the current history snapshot with telemetry bookkeeping."""
+
         history = await self._ledger.recall()
         self._channel.emit(
-            logging.DEBUG, LogCode.HISTORY_LOAD, op="pop", history={"len": len(history)}
+            logging.DEBUG,
+            LogCode.HISTORY_LOAD,
+            op="pop",
+            history={"len": len(history)},
         )
-        if len(history) <= 1:
-            return
-        limit = min(count, len(history) - 1)
-        if limit <= 0:
-            return
-        trimmed = history[:-limit]
-        await self._ledger.archive(trimmed)
+        return history
+
+    def _deletions(self, history_len: int, requested: int) -> int:
+        """Return the number of entries that should be removed."""
+
+        if history_len <= 1:
+            return 0
+        return min(requested, history_len - 1)
+
+    async def _persist(self, trimmed: Sequence[Entry], deletions: int) -> None:
+        """Persist ``trimmed`` entries and refresh telemetry markers."""
+
+        await self._ledger.archive(list(trimmed))
         self._channel.emit(
-            logging.DEBUG, LogCode.HISTORY_SAVE, op="pop", history={"len": len(trimmed)}
+            logging.DEBUG,
+            LogCode.HISTORY_SAVE,
+            op="pop",
+            history={"len": len(trimmed)},
         )
 
-        marker = None
-        if trimmed and trimmed[-1].messages:
-            marker = int(trimmed[-1].messages[0].id)
+        marker = self._latest_marker(trimmed)
         await self._latest.mark(marker)
         self._channel.emit(
             logging.INFO,
@@ -54,5 +86,20 @@ class Trimmer:
             LogCode.POP_SUCCESS,
             op="pop",
             history={"len": len(trimmed)},
-            note=f"deleted:{limit}",
+            note=f"deleted:{deletions}",
         )
+
+    def _latest_marker(self, history: Sequence[Entry]) -> int | None:
+        """Return the newest message identifier from ``history`` when present."""
+
+        if not history:
+            return None
+        messages = history[-1].messages
+        if not messages:
+            return None
+        return int(messages[0].id)
+
+    def _emit_skip(self, note: str) -> None:
+        """Record a skip decision with ``note`` for traceability."""
+
+        self._channel.emit(logging.INFO, LogCode.RENDER_SKIP, op="pop", note=note)

--- a/core/error.py
+++ b/core/error.py
@@ -2,15 +2,15 @@ from __future__ import annotations
 
 
 class NavigatorError(Exception):
-    """Base error for navigator domain."""
+    """Represent navigator domain errors."""
 
 
 class HistoryEmpty(NavigatorError):
-    """History is too short to perform the operation."""
+    """Signal that history is too short for the requested operation."""
 
 
 class StateNotFound(NavigatorError):
-    """Requested state is missing from history."""
+    """Report that a requested state could not be located."""
 
     def __init__(self, state: str | None = None):
         message = "state_not_found" if state is None else f"state_not_found:{state}"
@@ -25,31 +25,31 @@ class EditForbidden(NavigatorError):
 
 
 class MessageUnchanged(NavigatorError):
-    """Edit operation produced no changes."""
+    """Report an edit that produced no changes."""
 
 
 class InlineUnsupported(NavigatorError):
-    """Operation is not supported in inline context."""
+    """Reject operations that are not supported inline."""
 
 
 class EmptyPayload(NavigatorError):
-    """Attempt to send or edit with empty payload."""
+    """Reject attempts to send or edit with empty payload."""
 
 
 class TextOverflow(NavigatorError):
-    """Text payload exceeds gateway limits."""
+    """Signal that text payload exceeds gateway limits."""
 
 
 class CaptionOverflow(NavigatorError):
-    """Caption payload exceeds gateway limits."""
+    """Signal that caption payload exceeds gateway limits."""
 
 
 class ExtraForbidden(NavigatorError):
-    """Extra payload rejected by codec."""
+    """Reject extra payload that the codec disallows."""
 
 
 class MetadataError(NavigatorError):
-    """Base class for metadata mapping errors."""
+    """Represent errors encountered while mapping metadata."""
 
 
 class MetadataKindMissing(MetadataError):


### PR DESCRIPTION
## Summary
- reorganized the history pop, rebase, set, and back use-cases to improve telemetry reporting, input validation, and entry mutation clarity
- extracted helpers for cleaning extras and preserving payload defaults to tighten history mapping
- cached trace signature inspection and refreshed domain error documentation for clearer diagnostics

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d513f950a48330a74d5286bdc0f822