### PR TITLE
Add Navigator middleware for Telegram entrypoints

### DIFF
--- a/entrypoints/telegram/__init__.py
+++ b/entrypoints/telegram/__init__.py
@@ -1,7 +1,8 @@
 """Telegram integration helpers."""
 
 from .assemble import assemble
+from .middleware import NavigatorMiddleware
 from .router import router
 from .scope import outline
 
-__all__ = ["assemble", "router", "outline"]
+__all__ = ["assemble", "router", "outline", "NavigatorMiddleware"]

--- a/entrypoints/telegram/middleware.py
+++ b/entrypoints/telegram/middleware.py
@@ -1,0 +1,6 @@
+"""Telegram entrypoint middleware helpers."""
+from navigator.presentation.telegram import NavigatorMiddleware
+
+
+__all__ = ["NavigatorMiddleware"]
+

--- a/entrypoints/telegram/scope.py
+++ b/entrypoints/telegram/scope.py
@@ -1,32 +1,6 @@
-from navigator.core.value.message import Scope
+"""Telegram entrypoint scope helpers."""
+from navigator.presentation.telegram.scope import outline
 
 
-def outline(event) -> Scope:
-    source = getattr(getattr(event, "from_user", None), "language_code", None)
-    language = (source or "en").split("-")[0].lower()
-    inline = getattr(event, "inline_message_id", None)
-    if inline:
-        return Scope(chat=None, lang=language, inline=inline, category=None)
-    message = event.message if hasattr(event, "message") else event
-    chatinfo = getattr(message, "chat", None)
-    chat = getattr(chatinfo, "id", None)
-    kind = getattr(chatinfo, "type", None)
-    category = "group" if kind == "supergroup" else (
-        kind if kind in {"private", "group", "channel"} else None)
-    direct_topic = getattr(
-        getattr(message, "direct_messages_topic", None), "topic_id", None
-    )
-    direct_chat = bool(getattr(chatinfo, "is_direct_messages", False)) or bool(direct_topic)
-    business = getattr(message, "business_connection_id", None)
-    topic = getattr(message, "message_thread_id", None)
-    if topic is None and direct_topic is not None:
-        topic = direct_topic
-    return Scope(
-        chat=chat,
-        lang=language,
-        inline=None,
-        business=business,
-        category=category,
-        topic=topic,
-        direct=direct_chat,
-    )
+__all__ = ["outline"]
+

--- a/presentation/telegram/__init__.py
+++ b/presentation/telegram/__init__.py
@@ -1,5 +1,15 @@
 """Telegram presentation bindings."""
 
+from .middleware import NavigatorMiddleware
 from .router import BACK_CALLBACK_DATA, NavigatorLike, instrument, retreat, router
+from .scope import outline
 
-__all__ = ["router", "retreat", "NavigatorLike", "BACK_CALLBACK_DATA", "instrument"]
+__all__ = [
+    "router",
+    "retreat",
+    "NavigatorLike",
+    "BACK_CALLBACK_DATA",
+    "instrument",
+    "NavigatorMiddleware",
+    "outline",
+]

--- a/presentation/telegram/middleware.py
+++ b/presentation/telegram/middleware.py
@@ -1,0 +1,43 @@
+"""Aiogram middleware that injects a Navigator instance into handler context."""
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Dict
+
+from aiogram import BaseMiddleware
+from aiogram.fsm.context import FSMContext
+from aiogram.types import TelegramObject
+
+from navigator.api import assemble as assemble_navigator
+from navigator.core.port.factory import ViewLedger
+from .scope import outline
+
+Handler = Callable[[TelegramObject, Dict[str, Any]], Awaitable[Any]]
+
+
+class NavigatorMiddleware(BaseMiddleware):
+    """Construct and attach Navigator facades for every incoming event."""
+
+    def __init__(self, ledger: ViewLedger) -> None:
+        self._ledger = ledger
+
+    async def __call__(
+        self,
+        handler: Handler,
+        event: TelegramObject,
+        data: Dict[str, Any],
+    ) -> Any:
+        state = data.get("state")
+        if not isinstance(state, FSMContext):  # pragma: no cover - runtime guard
+            raise RuntimeError("FSMContext instance is required to assemble Navigator")
+        navigator = await assemble_navigator(
+            event=event,
+            state=state,
+            ledger=self._ledger,
+            scope=outline(event),
+        )
+        data["navigator"] = navigator
+        return await handler(event, data)
+
+
+__all__ = ["NavigatorMiddleware", "Handler"]
+

--- a/presentation/telegram/scope.py
+++ b/presentation/telegram/scope.py
@@ -1,0 +1,42 @@
+"""Helpers for deriving Navigator scopes from Telegram events."""
+from __future__ import annotations
+
+from navigator.core.value.message import Scope
+
+
+def outline(event) -> Scope:
+    """Translate an incoming Telegram event into a Navigator scope."""
+
+    source = getattr(getattr(event, "from_user", None), "language_code", None)
+    language = (source or "en").split("-")[0].lower()
+    inline = getattr(event, "inline_message_id", None)
+    if inline:
+        return Scope(chat=None, lang=language, inline=inline, category=None)
+    message = event.message if hasattr(event, "message") else event
+    chatinfo = getattr(message, "chat", None)
+    chat = getattr(chatinfo, "id", None)
+    kind = getattr(chatinfo, "type", None)
+    category = "group" if kind == "supergroup" else (
+        kind if kind in {"private", "group", "channel"} else None
+    )
+    direct_topic = getattr(
+        getattr(message, "direct_messages_topic", None), "topic_id", None
+    )
+    direct_chat = bool(getattr(chatinfo, "is_direct_messages", False)) or bool(direct_topic)
+    business = getattr(message, "business_connection_id", None)
+    topic = getattr(message, "message_thread_id", None)
+    if topic is None and direct_topic is not None:
+        topic = direct_topic
+    return Scope(
+        chat=chat,
+        lang=language,
+        inline=None,
+        business=business,
+        category=category,
+        topic=topic,
+        direct=direct_chat,
+    )
+
+
+__all__ = ["outline"]
+


### PR DESCRIPTION
## Summary
- add an aiogram middleware that assembles Navigator instances and injects them into handler data
- expose the scope helper from the presentation layer and re-export the middleware for telegram entrypoints

## Testing
- ruff check *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d51629892c83309e65ebcd25c11e51