### PR TITLE
refactor: clarify view orchestration and logging flows

### DIFF
--- a/app/log/events.py
+++ b/app/log/events.py
@@ -1,4 +1,5 @@
-"""Telemetry trace specifications for application use-cases."""
+"""Define telemetry trace specifications for async workflows."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -15,12 +16,18 @@ class TraceSpec:
     failure: LogCode
 
 
-APPEND = TraceSpec(LogCode.RENDER_START, LogCode.RENDER_OK, LogCode.RENDER_SKIP)
-REPLACE = TraceSpec(LogCode.RENDER_START, LogCode.RENDER_OK, LogCode.RENDER_SKIP)
-SET = TraceSpec(LogCode.RENDER_START, LogCode.RENDER_OK, LogCode.RENDER_SKIP)
-BACK = TraceSpec(LogCode.RENDER_START, LogCode.RENDER_OK, LogCode.RENDER_SKIP)
-REBASE = TraceSpec(LogCode.RENDER_START, LogCode.REBASE_SUCCESS, LogCode.RENDER_SKIP)
-POP = TraceSpec(LogCode.RENDER_START, LogCode.POP_SUCCESS, LogCode.RENDER_SKIP)
+def _render_spec(success: LogCode) -> TraceSpec:
+    """Create a trace specification with render start and skip fallback."""
+
+    return TraceSpec(LogCode.RENDER_START, success, LogCode.RENDER_SKIP)
+
+
+APPEND = _render_spec(LogCode.RENDER_OK)
+REPLACE = _render_spec(LogCode.RENDER_OK)
+SET = _render_spec(LogCode.RENDER_OK)
+BACK = _render_spec(LogCode.RENDER_OK)
+REBASE = _render_spec(LogCode.REBASE_SUCCESS)
+POP = _render_spec(LogCode.POP_SUCCESS)
 
 __all__ = [
     "TraceSpec",


### PR DESCRIPTION
## Summary
- streamline telemetry tracing by introducing a reusable TraceContext helper
- simplify trace specification construction and album diffing utilities for clearer data flow
- refactor view restoration, execution, and state setting logic to emphasize modular responsibilities

## Testing
- python -m compileall app/log/aspect.py app/log/events.py app/service/view/album.py app/service/view/executor.py app/service/view/planner.py app/service/view/policy.py app/service/view/restorer.py app/usecase/set.py

------
https://chatgpt.com/codex/tasks/task_e_68d5194c42588330931ce353c16b6b00