### PR TITLE
Refactor replace and rewind workflows

### DIFF
--- a/app/service/store.py
+++ b/app/service/store.py
@@ -61,6 +61,111 @@ def _latest_marker(history: Sequence[Entry]) -> int | None:
     return messages[0].id
 
 
+class HistoryTrimmer:
+    """Trim history snapshots according to the configured policy."""
+
+    def __init__(
+            self,
+            policy: Callable[[list[Entry], int], list[Entry]],
+            limit: int,
+            channel: TelemetryChannel | None,
+    ) -> None:
+        self._policy = policy
+        self._limit = limit
+        self._channel = channel
+
+    def apply(self, history: Sequence[Entry], *, operation: str) -> list[Entry]:
+        """Return trimmed history while emitting telemetry when truncation occurs."""
+
+        snapshot = list(history)
+        trimmed = self._policy(snapshot, self._limit)
+        if len(trimmed) != len(snapshot):
+            _emit(
+                self._channel,
+                logging.DEBUG,
+                LogCode.HISTORY_TRIM,
+                op=operation,
+                history={"before": len(snapshot), "after": len(trimmed)},
+            )
+        return trimmed
+
+
+class HistoryArchiver:
+    """Persist history snapshots into the archive repository."""
+
+    def __init__(
+            self,
+            archive: HistoryRepository,
+            channel: TelemetryChannel | None,
+    ) -> None:
+        self._archive = archive
+        self._channel = channel
+
+    async def save(self, history: Sequence[Entry], *, operation: str) -> None:
+        """Archive ``history`` while reporting telemetry."""
+
+        snapshot = list(history)
+        await self._archive.archive(snapshot)
+        _emit(
+            self._channel,
+            logging.DEBUG,
+            LogCode.HISTORY_SAVE,
+            op=operation,
+            history={"len": len(snapshot)},
+        )
+
+
+class LatestMarkerUpdater:
+    """Refresh the latest message marker after persisting history."""
+
+    def __init__(
+            self,
+            ledger: LatestRepository,
+            channel: TelemetryChannel | None,
+    ) -> None:
+        self._ledger = ledger
+        self._channel = channel
+
+    async def update(self, history: Sequence[Entry], *, operation: str) -> None:
+        """Update the last message marker and emit telemetry."""
+
+        marker = _latest_marker(history)
+        if marker is None:
+            return
+        await self._ledger.mark(marker)
+        _emit(
+            self._channel,
+            logging.INFO,
+            LogCode.LAST_SET,
+            op=operation,
+            message={"id": marker},
+        )
+
+
+class HistoryPersistencePipeline:
+    """Coordinate history trimming, archiving, and marker updates."""
+
+    def __init__(
+            self,
+            archive: HistoryRepository,
+            ledger: LatestRepository,
+            prune_history: Callable[[list[Entry], int], list[Entry]],
+            limit: int,
+            telemetry: Telemetry | None = None,
+    ) -> None:
+        channel = _channel_for(telemetry)
+        self._trimmer = HistoryTrimmer(prune_history, limit, channel)
+        self._archiver = HistoryArchiver(archive, channel)
+        self._marker = LatestMarkerUpdater(ledger, channel)
+
+    async def persist(self, history: Sequence[Entry], *, operation: str) -> None:
+        """Persist ``history`` while delegating to pipeline components."""
+
+        trimmed = self._trimmer.apply(history, operation=operation)
+        await self._archiver.save(trimmed, operation=operation)
+        await self._marker.update(trimmed, operation=operation)
+
+
 async def persist(
         archive: HistoryRepository,
         ledger: LatestRepository,
@@ -73,36 +178,11 @@ async def persist(
 ) -> None:
     """Persist the supplied ``history`` snapshot and update ``ledger``."""
 
-    channel = _channel_for(telemetry)
-    snapshot = list(history)
-    trimmed = prune_history(snapshot, limit)
-    if len(trimmed) != len(snapshot):
-        _emit(
-            channel,
-            logging.DEBUG,
-            LogCode.HISTORY_TRIM,
-            op=operation,
-            history={"before": len(snapshot), "after": len(trimmed)},
-        )
-
-    await archive.archive(trimmed)
-    _emit(
-        channel,
-        logging.DEBUG,
-        LogCode.HISTORY_SAVE,
-        op=operation,
-        history={"len": len(trimmed)},
+    pipeline = HistoryPersistencePipeline(
+        archive=archive,
+        ledger=ledger,
+        prune_history=prune_history,
+        limit=limit,
+        telemetry=telemetry,
     )
-
-    marker = _latest_marker(trimmed)
-    if marker is None:
-        return
-
-    await ledger.mark(marker)
-    _emit(
-        channel,
-        logging.INFO,
-        LogCode.LAST_SET,
-        op=operation,
-        message={"id": marker},
-    )
+    await pipeline.persist(history, operation=operation)

--- a/app/usecase/back.py
+++ b/app/usecase/back.py
@@ -6,8 +6,6 @@ from typing import Any, Dict
 
 from ..log import events
 from ..log.aspect import TraceAspect
-from ..service.view.planner import ViewPlanner
-from ..service.view.restorer import ViewRestorer
 from ...core.telemetry import Telemetry
 from ...core.value.content import normalize
 from ...core.value.message import Scope
@@ -24,21 +22,16 @@ class Rewinder:
 
     def __init__(
             self,
-            ledger,
-            status,
-            restorer: ViewRestorer,
-            planner: ViewPlanner,
-            latest,
+            history: RewindHistoryAccess,
+            renderer: RewindRenderer,
+            mutator: RewindMutator,
             telemetry: Telemetry,
-            history: RewindHistoryAccess | None = None,
-            renderer: RewindRenderer | None = None,
-            mutator: RewindMutator | None = None,
             finalizer: RewindFinalizer | None = None,
     ) -> None:
-        self._history = history or RewindHistoryAccess(ledger, status, latest, telemetry)
-        self._renderer = renderer or RewindRenderer(restorer, planner)
-        mutator = mutator or RewindMutator()
-        self._finalizer = finalizer or RewindFinalizer(self._history, mutator, telemetry)
+        self._history = history
+        self._renderer = renderer
+        self._mutator = mutator
+        self._finalizer = finalizer or RewindFinalizer(self._history, self._mutator, telemetry)
         self._trace = TraceAspect(telemetry)
 
     async def execute(self, scope: Scope, context: Dict[str, Any]) -> None:

--- a/app/usecase/replace.py
+++ b/app/usecase/replace.py
@@ -7,18 +7,15 @@ from typing import List
 
 from ..log import events
 from ..log.aspect import TraceAspect
-from ..map.entry import EntryMapper, Outcome
-from ..service.store import persist
 from ..service.view.planner import ViewPlanner
-from ..service.view.policy import adapt
-from ...core.entity.history import Entry
-from ...core.port.history import HistoryRepository
-from ...core.port.last import LatestRepository
-from ...core.port.state import StateRepository
-from ...core.service.history.policy import prune as prune_history
 from ...core.telemetry import LogCode, Telemetry, TelemetryChannel
-from ...core.value.content import Payload, normalize
+from ...core.value.content import Payload
 from ...core.value.message import Scope
+from .replace_components import (
+    ReplaceHistoryAccess,
+    ReplaceHistoryWriter,
+    ReplacePreparation,
+)
 
 
 class Swapper:
@@ -26,21 +23,14 @@ class Swapper:
 
     def __init__(
             self,
-            archive: HistoryRepository,
-            state: StateRepository,
-            tail: LatestRepository,
-            planner: ViewPlanner,
-            mapper: EntryMapper,
-            limit: int,
+            history: ReplaceHistoryAccess,
+            preparation: ReplacePreparation,
+            writer: ReplaceHistoryWriter,
             telemetry: Telemetry,
     ):
-        self._archive = archive
-        self._state = state
-        self._tail = tail
-        self._planner = planner
-        self._mapper = mapper
-        self._limit = limit
-        self._telemetry = telemetry
+        self._history = history
+        self._prepare = preparation
+        self._writer = writer
         self._channel: TelemetryChannel = telemetry.channel(__name__)
         self._trace = TraceAspect(telemetry)
 
@@ -50,85 +40,16 @@ class Swapper:
         await self._trace.run(events.REPLACE, self._perform, scope, bundle)
 
     async def _perform(self, scope: Scope, bundle: List[Payload]) -> None:
-        adjusted = self._normalize_bundle(scope, bundle)
-        records = await self._load_history()
+        adjusted = self._prepare.normalize(scope, bundle)
+        records = await self._history.snapshot()
         trail = records[-1] if records else None
-        render = await self._planner.render(
-            scope,
-            adjusted,
-            trail,
-            inline=bool(scope.inline),
-        )
+        render = await self._prepare.plan(scope, adjusted, trail)
 
         if not render or not render.ids or not render.changed:
             self._channel.emit(logging.INFO, LogCode.RENDER_SKIP, op="replace")
             return
-        status = await self._state.status()
+        status = await self._history.status()
 
-        entry = self._build_entry(trail, adjusted, render, status)
-        timeline = self._timeline(records, entry)
-        await self._persist(timeline)
-
-    def _normalize_bundle(self, scope: Scope, bundle: List[Payload]) -> List[Payload]:
-        """Return payloads adapted to ``scope`` expectations."""
-
-        return [adapt(scope, normalize(payload)) for payload in bundle]
-
-    async def _load_history(self) -> List[Entry]:
-        """Load current history records and report telemetry."""
-
-        records = await self._archive.recall()
-        self._channel.emit(
-            logging.DEBUG,
-            LogCode.HISTORY_LOAD,
-            op="replace",
-            history={"len": len(records)},
-        )
-        return records
-
-    def _build_entry(
-            self,
-            trail: Entry | None,
-            adjusted: List[Payload],
-            render: object,
-            state: str | None,
-    ) -> Entry:
-        """Map ``render`` outcome to a persisted history entry."""
-
-        identifiers = getattr(render, "ids", None) or []
-        usable = adjusted[:len(identifiers)]
-        outcome = Outcome(
-            identifiers,
-            getattr(render, "extras", None),
-            getattr(render, "metas", []),
-        )
-        view = trail.view if trail else None
-        root = bool(trail.root) if trail else False
-        return self._mapper.convert(
-            outcome,
-            usable,
-            state,
-            view,
-            root,
-            base=trail,
-        )
-
-    def _timeline(self, records: List[Entry], entry: Entry) -> List[Entry]:
-        """Return a history timeline with ``entry`` as the newest snapshot."""
-
-        if not records:
-            return [entry]
-        return [*records[:-1], entry]
-
-    async def _persist(self, timeline: List[Entry]) -> None:
-        """Persist ``timeline`` updates and latest marker."""
-
-        await persist(
-            self._archive,
-            self._tail,
-            prune_history,
-            self._limit,
-            timeline,
-            operation="replace",
-            telemetry=self._telemetry,
-        )
+        entry = self._prepare.entry(trail, adjusted, render, status)
+        timeline = self._prepare.timeline(records, entry)
+        await self._writer.persist(timeline)

--- a/app/usecase/replace_components.py
+++ b/app/usecase/replace_components.py
@@ -1,0 +1,147 @@
+"""Support collaborators for the ``replace`` use case."""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Optional, Sequence
+
+from navigator.app.map.entry import EntryMapper, Outcome
+from navigator.app.service.store import HistoryPersistencePipeline
+from navigator.app.service.view.planner import ViewPlanner
+from navigator.app.service.view.policy import adapt
+from navigator.core.entity.history import Entry
+from navigator.core.port.history import HistoryRepository
+from navigator.core.port.last import LatestRepository
+from navigator.core.port.state import StateRepository
+from navigator.core.service.history.policy import prune as prune_history
+from navigator.core.telemetry import LogCode, Telemetry, TelemetryChannel
+from navigator.core.value.content import Payload, normalize
+from navigator.core.value.message import Scope
+
+
+class ReplaceHistoryAccess:
+    """Provide history and state access for replace operations."""
+
+    def __init__(
+            self,
+            archive: HistoryRepository,
+            state: StateRepository,
+            telemetry: Telemetry,
+    ) -> None:
+        self._archive = archive
+        self._state = state
+        self._channel: TelemetryChannel = telemetry.channel(f"{__name__}.history")
+
+    async def snapshot(self) -> List[Entry]:
+        """Load the current history snapshot with telemetry reporting."""
+
+        records = await self._archive.recall()
+        self._channel.emit(
+            logging.DEBUG,
+            LogCode.HISTORY_LOAD,
+            op="replace",
+            history={"len": len(records)},
+        )
+        return records
+
+    async def status(self) -> Optional[str]:
+        """Return the persisted conversation state."""
+
+        return await self._state.status()
+
+
+class ReplacePreparation:
+    """Prepare payload bundles and entries for history replacement."""
+
+    def __init__(self, planner: ViewPlanner, mapper: EntryMapper) -> None:
+        self._planner = planner
+        self._mapper = mapper
+
+    def normalize(self, scope: Scope, bundle: Sequence[Payload]) -> List[Payload]:
+        """Normalize incoming payloads against ``scope`` expectations."""
+
+        return [adapt(scope, normalize(payload)) for payload in bundle]
+
+    async def plan(
+            self,
+            scope: Scope,
+            payloads: Sequence[Payload],
+            trail: Entry | None,
+    ) -> object:
+        """Plan rendering operations for ``payloads`` within ``scope``."""
+
+        return await self._planner.render(
+            scope,
+            payloads,
+            trail,
+            inline=bool(scope.inline),
+        )
+
+    def entry(
+            self,
+            trail: Entry | None,
+            adjusted: List[Payload],
+            render: object,
+            state: Optional[str],
+    ) -> Entry:
+        """Convert ``render`` outcome to a persisted history entry."""
+
+        identifiers = getattr(render, "ids", None) or []
+        usable = adjusted[:len(identifiers)]
+        outcome = Outcome(
+            identifiers,
+            getattr(render, "extras", None),
+            getattr(render, "metas", []),
+        )
+        view = trail.view if trail else None
+        root = bool(trail.root) if trail else False
+        return self._mapper.convert(
+            outcome,
+            usable,
+            state,
+            view,
+            root,
+            base=trail,
+        )
+
+    @staticmethod
+    def timeline(records: List[Entry], entry: Entry) -> List[Entry]:
+        """Return a new timeline with ``entry`` replacing the latest snapshot."""
+
+        if not records:
+            return [entry]
+        return [*records[:-1], entry]
+
+
+class ReplaceHistoryWriter:
+    """Persist replace outcomes using the history persistence pipeline."""
+
+    def __init__(
+            self,
+            archive: HistoryRepository,
+            tail: LatestRepository,
+            limit: int,
+            telemetry: Telemetry,
+            *,
+            pipeline: HistoryPersistencePipeline | None = None,
+    ) -> None:
+        self._pipeline = pipeline or HistoryPersistencePipeline(
+            archive=archive,
+            ledger=tail,
+            prune_history=prune_history,
+            limit=limit,
+            telemetry=telemetry,
+        )
+
+    async def persist(self, timeline: Sequence[Entry]) -> None:
+        """Persist ``timeline`` updates with replace telemetry."""
+
+        await self._pipeline.persist(timeline, operation="replace")
+
+
+__all__ = [
+    "ReplaceHistoryAccess",
+    "ReplacePreparation",
+    "ReplaceHistoryWriter",
+]
+

--- a/trial.py
+++ b/trial.py
@@ -5,8 +5,10 @@ from navigator.adapters.telegram.errors import dismissible
 from navigator.adapters.telegram.gateway import TelegramGateway
 from navigator.adapters.telegram.gateway.purge import PurgeTask
 from navigator.adapters.telegram.serializer.screen import SignatureScreen
+from navigator.app.internal.policy import shield
 from navigator.app.service import TailHistoryAccess, TailHistoryMutator
-from navigator.app.service.view.planner import ViewPlanner
+from navigator.app.service.view.planner import RenderPreparer, ViewPlanner
+from navigator.app.service.view.policy import adapt
 from navigator.app.service.view.restorer import ViewRestorer
 from navigator.app.usecase.alarm import Alarm
 from navigator.app.usecase.last import Tailer
@@ -199,7 +201,8 @@ def surface() -> None:
 
 def rebuff() -> None:
     scope = Scope(chat=7, lang="en", inline="token")
-    planner = ViewPlanner(inline=_InlineStub(), regular=_RegularStub())
+    preparer = RenderPreparer(adapter=adapt, shielder=shield)
+    planner = ViewPlanner(inline=_InlineStub(), regular=_RegularStub(), preparer=preparer)
 
     try:
         asyncio.run(
@@ -218,7 +221,8 @@ def rebuff() -> None:
 
 def refuse() -> None:
     scope = Scope(chat=8, lang="en", inline="token")
-    planner = ViewPlanner(inline=_InlineStub(), regular=_RegularStub())
+    preparer = RenderPreparer(adapter=adapt, shielder=shield)
+    planner = ViewPlanner(inline=_InlineStub(), regular=_RegularStub(), preparer=preparer)
     album = [
         MediaItem(type=MediaType.PHOTO, path="file-a", caption="a"),
         MediaItem(type=MediaType.PHOTO, path="file-b", caption="b"),


### PR DESCRIPTION
## Summary
- introduce a history persistence pipeline and dedicated replace components to decouple the replace use case
- add a render preparer collaborator for view planning and inject it through the DI container
- require rewind use cases to receive explicit collaborators instead of constructing them internally

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5622edfcc83309d4b3d7749be4a2f