### PR TITLE
Refactor Telegram view orchestration components

### DIFF
--- a/infra/di/container/usecases.py
+++ b/infra/di/container/usecases.py
@@ -9,6 +9,7 @@ from navigator.app.internal.policy import shield as inline_shield
 from navigator.app.service import TailHistoryAccess, TailHistoryMutator
 from navigator.app.service.navigator_runtime import NavigatorUseCases
 from navigator.app.service.view.planner import (
+    HeadAlignment,
     InlineRenderPlanner,
     RegularRenderPlanner,
     RenderPreparer,
@@ -94,12 +95,12 @@ class UseCaseContainer(containers.DeclarativeContainer):
         rendering=core.rendering,
     )
     inline_planner = providers.Factory(InlineRenderPlanner, synchronizer=render_synchronizer)
+    head_alignment = providers.Factory(HeadAlignment, album=view.album, telemetry=telemetry)
     regular_planner = providers.Factory(
         RegularRenderPlanner,
-        album=view.album,
+        head=head_alignment,
         synchronizer=render_synchronizer,
         tails=tail_operations,
-        telemetry=telemetry,
     )
     render_preparer = providers.Factory(
         RenderPreparer,

--- a/presentation/telegram/back.py
+++ b/presentation/telegram/back.py
@@ -28,55 +28,61 @@ class RetreatOutcome:
     show_alert: bool = False
 
 
-class RetreatHandler:
-    """Coordinate navigator back operations with telemetry and localization."""
+class RetreatTelemetry:
+    """Isolate telemetry emission for retreat lifecycle events."""
 
-    def __init__(self, telemetry: Telemetry, translator: Translator) -> None:
+    def __init__(self, telemetry: Telemetry) -> None:
         self._channel: TelemetryChannel = telemetry.channel(__name__)
-        self._translate = translator
 
-    async def __call__(
-        self,
-        cb: CallbackQuery,
-        navigator: NavigatorBack,
-        payload: dict[str, Any],
-    ) -> RetreatOutcome:
-        scope = {
+    def scope(self, cb: CallbackQuery) -> dict[str, object]:
+        return {
             "chat": cb.message.chat.id if cb.message else 0,
             "inline": bool(cb.inline_message_id),
         }
+
+    def entered(self, scope: dict[str, object]) -> None:
         self._channel.emit(
             logging.INFO,
             LogCode.ROUTER_BACK_ENTER,
             kind="callback",
             scope=scope,
         )
-        try:
-            context = {**payload, "event": cb}
-            await navigator.back(context=context)
-        except HistoryEmpty:
-            return self._fail("history_empty", cb)
-        except StateNotFound:
-            return self._fail("state_not_found", cb)
-        except InlineUnsupported:
-            return self._fail("barred", cb)
-        except Exception:  # pragma: no cover - defensive net for logging
-            return self._fail("generic", cb)
+
+    def completed(self, scope: dict[str, object]) -> None:
         self._channel.emit(
             logging.INFO,
             LogCode.ROUTER_BACK_DONE,
             kind="callback",
             scope=scope,
         )
-        return RetreatOutcome()
 
-    def _fail(self, note: str, cb: CallbackQuery) -> RetreatOutcome:
+    def failed(self, note: str, scope: dict[str, object]) -> None:
         self._channel.emit(
             logging.WARNING,
             LogCode.ROUTER_BACK_FAIL,
             kind="callback",
             note=note,
+            scope=scope,
         )
+
+
+class RetreatContextBuilder:
+    """Create navigator context payloads for retreat execution."""
+
+    def build(self, cb: CallbackQuery, payload: dict[str, Any]) -> dict[str, Any]:
+        return {**payload, "event": cb}
+
+
+class RetreatOutcomeFactory:
+    """Convert retreat results into Telegram-friendly outcomes."""
+
+    def __init__(self, translator: Translator) -> None:
+        self._translate = translator
+
+    def success(self) -> RetreatOutcome:
+        return RetreatOutcome()
+
+    def failure(self, note: str, cb: CallbackQuery) -> RetreatOutcome:
         tongue = self._tongue(cb)
         key = "barred" if note == "barred" else "missing"
         return RetreatOutcome(text=self._translate(key, tongue), show_alert=True)
@@ -86,6 +92,54 @@ class RetreatHandler:
         user = getattr(obj, "from_user", None)
         code = getattr(user, "language_code", None)
         return (code or "en").split("-")[0].lower()
+
+
+class RetreatHandler:
+    """Coordinate navigator back operations with delegated collaborators."""
+
+    def __init__(
+        self,
+        telemetry: Telemetry,
+        translator: Translator,
+        *,
+        instrumentation: RetreatTelemetry | None = None,
+        context: RetreatContextBuilder | None = None,
+        outcomes: RetreatOutcomeFactory | None = None,
+    ) -> None:
+        self._telemetry = instrumentation or RetreatTelemetry(telemetry)
+        self._context = context or RetreatContextBuilder()
+        self._outcomes = outcomes or RetreatOutcomeFactory(translator)
+
+    async def __call__(
+        self,
+        cb: CallbackQuery,
+        navigator: NavigatorBack,
+        payload: dict[str, Any],
+    ) -> RetreatOutcome:
+        scope = self._telemetry.scope(cb)
+        self._telemetry.entered(scope)
+        try:
+            context = self._context.build(cb, payload)
+            await navigator.back(context=context)
+        except HistoryEmpty:
+            return self._fail("history_empty", cb, scope)
+        except StateNotFound:
+            return self._fail("state_not_found", cb, scope)
+        except InlineUnsupported:
+            return self._fail("barred", cb, scope)
+        except Exception:  # pragma: no cover - defensive net for logging
+            return self._fail("generic", cb, scope)
+        self._telemetry.completed(scope)
+        return self._outcomes.success()
+
+    def _fail(
+        self,
+        note: str,
+        cb: CallbackQuery,
+        scope: dict[str, object],
+    ) -> RetreatOutcome:
+        self._telemetry.failed(note, scope)
+        return self._outcomes.failure(note, cb)
 
 
 __all__ = ["NavigatorBack", "RetreatHandler", "RetreatOutcome"]


### PR DESCRIPTION
## Summary
- split edit gateway responsibilities by introducing dedicated cleanup wiring in `EditExecutor`
- refactor Telegram media helpers with reusable composer, validator, and telemetry collaborators
- extract retreat telemetry and handler provisioning helpers and add a head-alignment service to the regular render planner

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5fa92987483308984857a6eebeae9