### PR TITLE
Refine navigator bootstrap wiring and retreat handler injection

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Any, Iterable, cast
 
 from .contracts import NavigatorLike, ScopeDTO, ViewLedgerDTO
+from ..app.service.navigator_runtime import MissingAlert
 from ..bootstrap.navigator import NavigatorAssembler, assemble as _bootstrap
 
 
@@ -13,6 +14,8 @@ async def assemble(
         ledger: ViewLedgerDTO,
         scope: ScopeDTO,
         instrumentation: Iterable[NavigatorAssembler.Instrument] | None = None,
+        *,
+        missing_alert: MissingAlert | None = None,
 ) -> NavigatorLike:
     """Assemble and return a Navigator facade instance."""
 
@@ -22,6 +25,7 @@ async def assemble(
         ledger=ledger,
         scope=scope,
         instrumentation=instrumentation,
+        missing_alert=missing_alert,
     )
     return cast(NavigatorLike, navigator)
 

--- a/bootstrap/navigator/assembly.py
+++ b/bootstrap/navigator/assembly.py
@@ -5,6 +5,7 @@ from collections.abc import Iterable, Sequence
 from typing import Protocol
 
 from navigator.api.contracts import ScopeDTO, ViewLedgerDTO
+from navigator.app.service.navigator_runtime import MissingAlert
 from navigator.presentation.navigator import Navigator
 
 from .context import BootstrapContext
@@ -42,10 +43,17 @@ async def assemble(
     ledger: ViewLedgerDTO,
     scope: ScopeDTO,
     instrumentation: Iterable[NavigatorAssembler.Instrument] | None = None,
+    missing_alert: MissingAlert | None = None,
 ) -> Navigator:
     """Construct a Navigator instance from entrypoint payloads."""
 
-    context = BootstrapContext(event=event, state=state, ledger=ledger, scope=scope)
+    context = BootstrapContext(
+        event=event,
+        state=state,
+        ledger=ledger,
+        scope=scope,
+        missing_alert=missing_alert,
+    )
     instruments: Sequence[NavigatorAssembler.Instrument]
     if instrumentation:
         instruments = tuple(instrumentation)

--- a/bootstrap/navigator/container.py
+++ b/bootstrap/navigator/container.py
@@ -1,9 +1,9 @@
 """Factories assembling the dependency injection container for the runtime."""
 from __future__ import annotations
 
+from navigator.app.service.navigator_runtime import MissingAlert
 from navigator.core.telemetry import Telemetry
 from navigator.infra.di.container import AppContainer
-from navigator.presentation.alerts import missing
 
 from .adapter import LedgerAdapter
 from .context import BootstrapContext
@@ -12,15 +12,22 @@ from .context import BootstrapContext
 class ContainerFactory:
     """Construct application containers for the navigator runtime."""
 
-    def __init__(self, telemetry: Telemetry) -> None:
+    def __init__(
+        self,
+        telemetry: Telemetry,
+        *,
+        alert: MissingAlert | None = None,
+    ) -> None:
         self._telemetry = telemetry
+        self._alert = alert or (lambda scope: "")
 
     def create(self, context: BootstrapContext) -> AppContainer:
+        alert = context.missing_alert or self._alert
         return AppContainer(
             event=context.event,
             state=context.state,
             ledger=LedgerAdapter(context.ledger),
-            alert=missing,
+            alert=alert,
             telemetry=self._telemetry,
         )
 

--- a/bootstrap/navigator/context.py
+++ b/bootstrap/navigator/context.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from navigator.api.contracts import ScopeDTO, ViewLedgerDTO
+from navigator.app.service.navigator_runtime import MissingAlert
 from navigator.core.value.message import Scope
 
 
@@ -29,6 +30,7 @@ class BootstrapContext:
     state: object
     ledger: ViewLedgerDTO
     scope: ScopeDTO
+    missing_alert: MissingAlert | None = None
 
 
 __all__ = ["BootstrapContext", "scope_from_dto"]

--- a/bootstrap/navigator/telemetry.py
+++ b/bootstrap/navigator/telemetry.py
@@ -13,12 +13,10 @@ class TelemetryFactory:
         return Telemetry(port)
 
 
-def calibrate_telemetry(telemetry: Telemetry, container: "AppContainer") -> None:
-    """Apply container-level telemetry configuration before runtime assembly."""
+def calibrate_telemetry(telemetry: Telemetry, redaction: str | None) -> None:
+    """Apply telemetry configuration derived from bootstrap settings."""
 
-    settings = container.core().settings()
-    mode = getattr(settings, "redaction", "")
-    telemetry.calibrate(mode)
+    telemetry.calibrate(redaction or "")
 
 
 __all__ = ["TelemetryFactory", "calibrate_telemetry"]

--- a/entrypoints/telegram/assemble.py
+++ b/entrypoints/telegram/assemble.py
@@ -6,6 +6,7 @@ from typing import Any, TYPE_CHECKING
 
 from .scope import outline
 from navigator.presentation.telegram import instrument
+from navigator.presentation.alerts import missing
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from navigator.presentation.navigator import Navigator
@@ -19,6 +20,7 @@ async def assemble(event: Any, state: Any, ledger: ViewLedger) -> "Navigator":
         ledger=ledger,
         scope=scope,
         instrumentation=(instrument,),
+        missing_alert=missing,
     )
 
 

--- a/infra/di/container/telegram.py
+++ b/infra/di/container/telegram.py
@@ -47,7 +47,7 @@ class TelegramContainer(containers.DeclarativeContainer):
         editor=scribe,
         telemetry=telemetry,
     )
-    executor = providers.Factory(EditExecutor, gateway=gateway, telemetry=telemetry)
+    executor = providers.Factory(EditExecutor.create, gateway=gateway, telemetry=telemetry)
     album = providers.Factory(
         AlbumService,
         executor=executor,

--- a/presentation/bootstrap/navigator.py
+++ b/presentation/bootstrap/navigator.py
@@ -5,10 +5,9 @@ from typing import Protocol
 
 from navigator.app.locks.guard import Guardian
 from navigator.app.service import build_navigator_runtime
-from navigator.app.service.navigator_runtime import NavigatorUseCases
+from navigator.app.service.navigator_runtime import MissingAlert, NavigatorUseCases
 from navigator.core.telemetry import Telemetry
 from navigator.core.value.message import Scope
-from navigator.presentation.alerts import missing
 from navigator.presentation.navigator import Navigator
 
 
@@ -33,6 +32,7 @@ def compose(
     scope: Scope,
     *,
     guard: Guardian | None = None,
+    missing_alert: MissingAlert | None = None,
 ) -> Navigator:
     """Construct a Navigator facade from a DI container."""
 
@@ -44,7 +44,7 @@ def compose(
         scope=scope,
         guard=sentinel,
         telemetry=core.telemetry(),
-        missing_alert=missing,
+        missing_alert=missing_alert or core.alert(),
     )
     return Navigator(runtime)
 

--- a/presentation/telegram/__init__.py
+++ b/presentation/telegram/__init__.py
@@ -5,19 +5,21 @@ from .middleware import NavigatorMiddleware
 from .router import (
     BACK_CALLBACK_DATA,
     NavigatorBack,
+    RetreatCallback,
     RetreatDependencies,
+    build_retreat_handler,
     configure_retreat,
-    retreat,
     router,
 )
 from .scope import outline
 
 __all__ = [
     "router",
-    "retreat",
     "NavigatorBack",
     "BACK_CALLBACK_DATA",
+    "RetreatCallback",
     "RetreatDependencies",
+    "build_retreat_handler",
     "configure_retreat",
     "instrument",
     "NavigatorMiddleware",


### PR DESCRIPTION
## Summary
- replace the Telegram retreat handler singleton with explicit handler builders and router registration
- decouple missing-state alert wiring from bootstrap assembly and expose configuration hooks through the API
- extract dedicated collaborators for missing-state alarms and edit executor assembly to reduce responsibility overload

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5fe0f7a5083309835e646f0ab4fd8