### PR TITLE
Refactor messaging gateway and storage orchestration

### DIFF
--- a/adapters/storage/fsm/chronicle.py
+++ b/adapters/storage/fsm/chronicle.py
@@ -4,7 +4,7 @@ import logging
 from aiogram.fsm.context import FSMContext
 from navigator.core.entity.history import Entry, Message
 from navigator.core.telemetry import LogCode, Telemetry, TelemetryChannel
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from .keys import FSM_HISTORY_FIELD, FSM_NAMESPACE_KEY
 from ..codec import GroupCodec, MediaCodec, PreviewCodec, ReplyCodec, TimeCodec
@@ -13,128 +13,75 @@ from ..codec import GroupCodec, MediaCodec, PreviewCodec, ReplyCodec, TimeCodec
 class Chronicle:
     def __init__(self, state: FSMContext, telemetry: Telemetry | None = None):
         self._state = state
-        self._channel: TelemetryChannel | None = (
-            telemetry.channel(__name__) if telemetry else None
-        )
-        self._time = TimeCodec(telemetry)
-
-    def _emit(self, level: int, code: LogCode, /, **fields: Any) -> None:
-        if self._channel:
-            self._channel.emit(level, code, **fields)
+        self._telemetry = _TelemetryEmitter(telemetry)
+        self._serializer = _HistorySerializer(telemetry)
 
     async def recall(self) -> List[Entry]:
         data = await self._state.get_data()
-        namespace = data.get(FSM_NAMESPACE_KEY) or {}
-        raw = namespace.get(FSM_HISTORY_FIELD, []) if isinstance(namespace, dict) else []
-        self._emit(logging.DEBUG, LogCode.HISTORY_LOAD, history={"len": len(raw)})
-        return [self._load(record) for record in raw]
+        namespace = self._namespace(data)
+        raw = namespace.get(FSM_HISTORY_FIELD, [])
+        self._telemetry.loaded(len(raw))
+        return [
+            self._serializer.load(record, self._telemetry)
+            for record in raw
+            if isinstance(record, dict)
+        ]
 
     async def archive(self, history: List[Entry]) -> None:
-        payload = [self._dump(entry) for entry in history]
+        payload = [self._serializer.dump(entry) for entry in history]
         data = await self._state.get_data()
-        namespace = dict(data.get(FSM_NAMESPACE_KEY) or {})
+        namespace = dict(self._namespace(data))
         namespace[FSM_HISTORY_FIELD] = payload
         await self._state.update_data({FSM_NAMESPACE_KEY: namespace})
-        self._emit(logging.DEBUG, LogCode.HISTORY_SAVE, history={"len": len(payload)})
+        self._telemetry.saved(len(payload))
 
-    def _dump(self, entry: Entry) -> Dict[str, Any]:
+    @staticmethod
+    def _namespace(data: Dict[str, Any]) -> Dict[str, Any]:
+        namespace = data.get(FSM_NAMESPACE_KEY)
+        return namespace if isinstance(namespace, dict) else {}
+
+
+class _TelemetryEmitter:
+    def __init__(self, telemetry: Telemetry | None) -> None:
+        self._channel: TelemetryChannel | None = (
+            telemetry.channel(__name__) if telemetry else None
+        )
+
+    def emit(self, level: int, code: LogCode, /, **fields: Any) -> None:
+        if self._channel:
+            self._channel.emit(level, code, **fields)
+
+    def loaded(self, length: int) -> None:
+        self.emit(logging.DEBUG, LogCode.HISTORY_LOAD, history={"len": length})
+
+    def saved(self, length: int) -> None:
+        self.emit(logging.DEBUG, LogCode.HISTORY_SAVE, history={"len": length})
+
+    def error(self, note: str, **fields: Any) -> None:
+        self.emit(logging.ERROR, LogCode.HISTORY_LOAD, note=note, **fields)
+
+
+class _HistorySerializer:
+    def __init__(self, telemetry: Telemetry | None) -> None:
+        self._time = TimeCodec(telemetry)
+
+    def dump(self, entry: Entry) -> Dict[str, Any]:
         return {
             "state": entry.state,
             "view": entry.view,
             "root": bool(getattr(entry, "root", False)),
-            "messages": [
-                {
-                    "id": message.id,
-                    "text": message.text,
-                    "media": MediaCodec.pack(message.media),
-                    "group": GroupCodec.pack(message.group),
-                    "markup": ReplyCodec.pack(message.markup),
-                    "preview": PreviewCodec.pack(message.preview),
-                    "extra": message.extra,
-                    "extras": list(message.extras),
-                    "inline": message.inline,
-                    "automated": message.automated,
-                    "ts": TimeCodec.pack(message.ts),
-                }
-                for message in entry.messages
-            ],
+            "messages": [self._dump_message(message) for message in entry.messages],
         }
 
-    def _load(self, data: Dict[str, Any]) -> Entry:
+    def load(self, data: Dict[str, Any], telemetry: _TelemetryEmitter) -> Entry:
         items = data.get("messages")
         rootmark = bool(data.get("root", False))
-        if isinstance(items, list) and not items:
-            return Entry(
-                state=data.get("state"),
-                view=data.get("view"),
-                messages=[],
-                root=rootmark,
-            )
         if isinstance(items, list):
-            messages: List[Message] = []
-            for record in items:
-                if not isinstance(record, Dict):
-                    continue
-
-                if "automated" not in record:
-                    self._emit(
-                        logging.ERROR,
-                        LogCode.HISTORY_LOAD,
-                        note="history_message_missing_automated",
-                    )
-                    raise ValueError("History message payload missing required 'automated' flag")
-
-                if "id" not in record:
-                    self._emit(
-                        logging.ERROR,
-                        LogCode.HISTORY_LOAD,
-                        note="history_message_missing_id",
-                    )
-                    raise ValueError("History message payload missing required 'id'")
-
-                raw = record.get("id")
-                try:
-                    ident = int(raw)
-                except (TypeError, ValueError):
-                    self._emit(
-                        logging.ERROR,
-                        LogCode.HISTORY_LOAD,
-                        note="history_message_invalid_id",
-                        raw=raw,
-                    )
-                    raise ValueError(f"History message payload has invalid 'id': {raw!r}")
-
-                source = record.get("extras") or []
-                extras: List[int] = []
-                for value in source:
-                    if not isinstance(value, int):
-                        self._emit(
-                            logging.ERROR,
-                            LogCode.HISTORY_LOAD,
-                            note="history_message_invalid_extra",
-                            raw=value,
-                        )
-                        raise ValueError(
-                            "History message payload has non-integer 'extras' entry: "
-                            f"{value!r} (type {type(value).__name__})"
-                        )
-                    extras.append(value)
-
-                messages.append(
-                    Message(
-                        id=ident,
-                        text=record.get("text"),
-                        media=MediaCodec.unpack(record.get("media")),
-                        group=GroupCodec.unpack(record.get("group")),
-                        markup=ReplyCodec.unpack(record.get("markup")),
-                        preview=PreviewCodec.unpack(record.get("preview")),
-                        extra=record.get("extra"),
-                        extras=extras,
-                        inline=record.get("inline"),
-                        automated=bool(record.get("automated")),
-                        ts=self._time.unpack(record.get("ts")),
-                    )
-                )
+            messages = [
+                self._load_message(record, telemetry)
+                for record in items
+                if isinstance(record, dict)
+            ]
             return Entry(
                 state=data.get("state"),
                 view=data.get("view"),
@@ -147,6 +94,80 @@ class Chronicle:
             messages=[],
             root=rootmark,
         )
+
+    def _dump_message(self, message: Message) -> Dict[str, Any]:
+        return {
+            "id": message.id,
+            "text": message.text,
+            "media": MediaCodec.pack(message.media),
+            "group": GroupCodec.pack(message.group),
+            "markup": ReplyCodec.pack(message.markup),
+            "preview": PreviewCodec.pack(message.preview),
+            "extra": message.extra,
+            "extras": list(message.extras),
+            "inline": message.inline,
+            "automated": message.automated,
+            "ts": TimeCodec.pack(message.ts),
+        }
+
+    def _load_message(self, record: Dict[str, Any], telemetry: _TelemetryEmitter) -> Message:
+        automated = self._require(
+            record,
+            "automated",
+            telemetry,
+            "history_message_missing_automated",
+            message="History message payload missing required 'automated' flag",
+        )
+        raw_id = self._require(record, "id", telemetry, "history_message_missing_id")
+        ident = self._parse_identifier(raw_id, telemetry)
+        extras = self._parse_extras(record.get("extras"), telemetry)
+        return Message(
+            id=ident,
+            text=record.get("text"),
+            media=MediaCodec.unpack(record.get("media")),
+            group=GroupCodec.unpack(record.get("group")),
+            markup=ReplyCodec.unpack(record.get("markup")),
+            preview=PreviewCodec.unpack(record.get("preview")),
+            extra=record.get("extra"),
+            extras=extras,
+            inline=record.get("inline"),
+            automated=bool(automated),
+            ts=self._time.unpack(record.get("ts")),
+        )
+
+    def _require(
+            self,
+            record: Dict[str, Any],
+            key: str,
+            telemetry: _TelemetryEmitter,
+            note: str,
+            *,
+            message: str | None = None,
+    ) -> Any:
+        if key not in record:
+            telemetry.error(note)
+            detail = message or f"History message payload missing required '{key}'"
+            raise ValueError(detail)
+        return record.get(key)
+
+    def _parse_identifier(self, raw: Any, telemetry: _TelemetryEmitter) -> int:
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            telemetry.error("history_message_invalid_id", raw=raw)
+            raise ValueError(f"History message payload has invalid 'id': {raw!r}")
+
+    def _parse_extras(self, values: Any, telemetry: _TelemetryEmitter) -> List[int]:
+        extras: List[int] = []
+        for value in values or []:
+            if not isinstance(value, int):
+                telemetry.error("history_message_invalid_extra", raw=value)
+                raise ValueError(
+                    "History message payload has non-integer 'extras' entry: "
+                    f"{value!r} (type {type(value).__name__})"
+                )
+            extras.append(value)
+        return extras
 
 
 __all__ = ["Chronicle"]


### PR DESCRIPTION
## Summary
- refactor the Telegram send gateway into focused helpers for text, media, and group delivery with unified telemetry handling
- isolate entry mapping into a dedicated message composer to clarify metadata and extra sanitation responsibilities
- introduce explicit append dependencies with updated DI wiring and modularize container runtime and FSM chronicle serialization/telemetry coordination

## Testing
- python -m compileall adapters app bootstrap infra

------
https://chatgpt.com/codex/tasks/task_e_68d603792f688330914cd9e4ca129360