### PR TITLE
Refactor runtime assembly responsibilities

### DIFF
--- a/app/service/__init__.py
+++ b/app/service/__init__.py
@@ -1,6 +1,10 @@
 """Application service layer."""
 
-from .history_access import TailHistoryAccess
+from .history_access import (
+    TailHistoryAccess,
+    TailHistoryJournal,
+    TailHistoryScopeFormatter,
+)
 from .history_mutation import TailHistoryMutator
 from .navigator_runtime import (
     NavigatorHistoryService,
@@ -13,6 +17,8 @@ from .navigator_runtime import (
 
 __all__ = [
     "TailHistoryAccess",
+    "TailHistoryJournal",
+    "TailHistoryScopeFormatter",
     "TailHistoryMutator",
     "NavigatorRuntime",
     "NavigatorHistoryService",

--- a/app/service/history_access.py
+++ b/app/service/history_access.py
@@ -12,51 +12,115 @@ from navigator.core.telemetry import LogCode, Telemetry, TelemetryChannel
 from navigator.core.value.message import Scope
 
 
+class TailHistoryScopeFormatter:
+    """Convert scope objects into telemetry-friendly payloads."""
+
+    def describe(self, scope: Scope | None) -> dict[str, object] | None:
+        if scope is None:
+            return None
+        return {
+            "chat": getattr(scope, "chat", None),
+            "inline": bool(getattr(scope, "inline", None)),
+            "business": bool(getattr(scope, "business", None)),
+        }
+
+
+class TailHistoryJournal:
+    """Publish telemetry events produced by history operations."""
+
+    def __init__(
+        self,
+        channel: TelemetryChannel | None,
+        *,
+        formatter: TailHistoryScopeFormatter | None = None,
+    ) -> None:
+        self._channel = channel
+        self._formatter = formatter or TailHistoryScopeFormatter()
+
+    @classmethod
+    def from_telemetry(
+        cls,
+        telemetry: Telemetry | None,
+        *,
+        formatter: TailHistoryScopeFormatter | None = None,
+    ) -> "TailHistoryJournal":
+        channel = telemetry.channel(__name__) if telemetry else None
+        return cls(channel, formatter=formatter)
+
+    def record_marker_peek(self, marker: int | None) -> None:
+        if self._channel is None:
+            return
+        self._channel.emit(logging.INFO, LogCode.LAST_GET, message={"id": marker})
+
+    def record_history_load(
+        self, history: Sequence[Entry], scope: Scope | None = None
+    ) -> None:
+        if self._channel is None:
+            return
+        payload: dict[str, object] = {"len": len(history)}
+        described = self._formatter.describe(scope)
+        kwargs: dict[str, object] = {"history": payload}
+        if described is not None:
+            kwargs["scope"] = described
+        self._channel.emit(logging.DEBUG, LogCode.HISTORY_LOAD, **kwargs)
+
+    def record_history_save(self, history: Sequence[Entry], *, op: str) -> None:
+        if self._channel is None:
+            return
+        self._channel.emit(
+            logging.DEBUG,
+            LogCode.HISTORY_SAVE,
+            op=op,
+            history={"len": len(history)},
+        )
+
+    def record_marker_mark(
+        self, marker: int | None, *, op: str, scope: Scope | None = None
+    ) -> None:
+        if self._channel is None:
+            return
+        code = LogCode.LAST_SET if marker is not None else LogCode.LAST_DELETE
+        payload: dict[str, object] = {"id": marker}
+        described = self._formatter.describe(scope)
+        if described is not None:
+            payload = {"id": marker, "scope": described}
+        self._channel.emit(logging.INFO, code, op=op, message=payload)
+
+
 class TailHistoryAccess:
     """Encapsulate history persistence operations for tail flows."""
 
     def __init__(
-            self,
-            ledger: HistoryRepository,
-            latest: LatestRepository,
-            telemetry: Telemetry | None = None,
+        self,
+        ledger: HistoryRepository,
+        latest: LatestRepository,
+        *,
+        journal: TailHistoryJournal,
     ) -> None:
         self._ledger = ledger
         self._latest = latest
-        self._channel: TelemetryChannel | None = (
-            telemetry.channel(__name__) if telemetry else None
-        )
+        self._journal = journal
 
     async def peek(self) -> int | None:
         """Return the most recent marker identifier."""
 
         marker = await self._latest.peek()
-        self._emit(logging.INFO, LogCode.LAST_GET, message={"id": marker})
+        self._journal.record_marker_peek(marker)
         return marker
 
     async def load(self, scope: Scope | None = None) -> list[Entry]:
         """Load the persisted history snapshot."""
 
-        history = list(await self._ledger.recall())
-        self._emit(
-            logging.DEBUG,
-            LogCode.HISTORY_LOAD,
-            scope=self._describe_scope(scope),
-            history={"len": len(history)},
-        )
-        return history
+        snapshot = list(await self._ledger.recall())
+        self._journal.record_history_load(snapshot, scope)
+        return snapshot
 
     async def save(self, history: Sequence[Entry], *, op: str) -> None:
         """Persist ``history`` snapshot and emit telemetry."""
 
         snapshot = list(history)
         await self._ledger.archive(snapshot)
-        self._emit(
-            logging.DEBUG,
-            LogCode.HISTORY_SAVE,
-            op=op,
-            history={"len": len(snapshot)},
-        )
+        self._journal.record_history_save(snapshot, op=op)
 
     async def mark(
             self, marker: int | None, *, op: str, scope: Scope | None = None
@@ -64,12 +128,7 @@ class TailHistoryAccess:
         """Update the last marker and emit telemetry."""
 
         await self._latest.mark(marker)
-        code = LogCode.LAST_SET if marker is not None else LogCode.LAST_DELETE
-        payload: dict[str, object] = {"id": marker}
-        described = self._describe_scope(scope)
-        if described is not None:
-            payload = {"id": marker, "scope": described}
-        self._emit(logging.INFO, code, op=op, message=payload)
+        self._journal.record_marker_mark(marker, op=op, scope=scope)
 
     async def trim_inline(
             self, history: Sequence[Entry], scope: Scope, *, op: str
@@ -82,17 +141,6 @@ class TailHistoryAccess:
         await self.mark(marker, op=op, scope=scope)
         return trimmed
 
-    def _emit(
-            self,
-            level: int,
-            code: LogCode,
-            /,
-            **payload: object,
-    ) -> None:
-        if self._channel is None:
-            return
-        self._channel.emit(level, code, **payload)
-
     @staticmethod
     def _latest_marker(history: Sequence[Entry]) -> int | None:
         if not history:
@@ -102,15 +150,4 @@ class TailHistoryAccess:
             return None
         return int(tail.messages[0].id)
 
-    @staticmethod
-    def _describe_scope(scope: Scope | None) -> dict[str, object] | None:
-        if scope is None:
-            return None
-        return {
-            "chat": getattr(scope, "chat", None),
-            "inline": bool(getattr(scope, "inline", None)),
-            "business": bool(getattr(scope, "business", None)),
-        }
-
-
-__all__ = ["TailHistoryAccess"]
+__all__ = ["TailHistoryAccess", "TailHistoryJournal", "TailHistoryScopeFormatter"]

--- a/infra/di/container/usecases/history.py
+++ b/infra/di/container/usecases/history.py
@@ -173,7 +173,7 @@ class StateUseCaseContainer(containers.DeclarativeContainer):
         restorer=view_support.restorer,
     )
     reconciler = providers.Factory(
-        HistoryReconciler,
+        HistoryReconciler.from_components,
         ledger=storage.chronicle,
         latest=storage.latest,
         telemetry=telemetry,

--- a/infra/di/container/usecases/tail.py
+++ b/infra/di/container/usecases/tail.py
@@ -3,7 +3,11 @@ from __future__ import annotations
 
 from dependency_injector import containers, providers
 
-from navigator.app.service import TailHistoryAccess, TailHistoryMutator
+from navigator.app.service import (
+    TailHistoryAccess,
+    TailHistoryJournal,
+    TailHistoryMutator,
+)
 from navigator.app.usecase.last import Tailer
 from navigator.app.usecase.last.context import TailDecisionService, TailTelemetry
 from navigator.app.usecase.last.inline import InlineEditCoordinator
@@ -19,11 +23,15 @@ class TailUseCaseContainer(containers.DeclarativeContainer):
     view = providers.DependenciesContainer()
     telemetry = providers.Dependency(instance_of=Telemetry)
 
+    tail_history_journal = providers.Factory(
+        TailHistoryJournal.from_telemetry,
+        telemetry=telemetry,
+    )
     tail_history = providers.Factory(
         TailHistoryAccess,
         ledger=storage.chronicle,
         latest=storage.latest,
-        telemetry=telemetry,
+        journal=tail_history_journal,
     )
     tail_mutator = providers.Factory(TailHistoryMutator)
     tail_decision = providers.Factory(TailDecisionService, rendering=core.rendering)

--- a/presentation/telegram/assembly.py
+++ b/presentation/telegram/assembly.py
@@ -1,0 +1,37 @@
+"""Assemblers bridging Telegram events with navigator runtime."""
+from __future__ import annotations
+
+from typing import Protocol
+
+from aiogram.fsm.context import FSMContext
+from aiogram.types import TelegramObject
+
+from navigator.api import assemble as assemble_navigator
+from navigator.core.port.factory import ViewLedger
+from navigator.presentation.navigator import Navigator
+
+from .scope import outline
+
+
+class NavigatorAssembler(Protocol):
+    """Protocol describing navigator assembly for presentation layer."""
+
+    async def assemble(self, event: TelegramObject, state: FSMContext) -> Navigator: ...
+
+
+class TelegramNavigatorAssembler:
+    """Concrete assembler translating Telegram primitives for navigator API."""
+
+    def __init__(self, ledger: ViewLedger) -> None:
+        self._ledger = ledger
+
+    async def assemble(self, event: TelegramObject, state: FSMContext) -> Navigator:
+        return await assemble_navigator(
+            event=event,
+            state=state,
+            ledger=self._ledger,
+            scope=outline(event),
+        )
+
+
+__all__ = ["NavigatorAssembler", "TelegramNavigatorAssembler"]

--- a/trial.py
+++ b/trial.py
@@ -6,7 +6,11 @@ from navigator.adapters.telegram.gateway import TelegramGateway
 from navigator.adapters.telegram.gateway.purge import PurgeTask
 from navigator.adapters.telegram.serializer.screen import SignatureScreen
 from navigator.app.internal.policy import shield
-from navigator.app.service import TailHistoryAccess, TailHistoryMutator
+from navigator.app.service import (
+    TailHistoryAccess,
+    TailHistoryJournal,
+    TailHistoryMutator,
+)
 from navigator.app.service.view.planner import RenderPreparer, ViewPlanner
 from navigator.app.service.view.policy import adapt
 from navigator.app.service.view.restorer import ViewRestorer
@@ -103,7 +107,11 @@ def absence() -> None:
     telemetry = monitor()
     state = StateSynchronizer(state=status, telemetry=telemetry)
     reviver = PayloadReviver(state, restorer)
-    reconciliation = HistoryReconciler(ledger=ledger, latest=latest, telemetry=telemetry)
+    reconciliation = HistoryReconciler.from_components(
+        ledger=ledger,
+        latest=latest,
+        telemetry=telemetry,
+    )
     plan_builder = HistoryRestorationPlanner(ledger=ledger, telemetry=telemetry)
     setter = Setter(
         planner=plan_builder,
@@ -184,7 +192,11 @@ def surface() -> None:
     telemetry = monitor()
     state = StateSynchronizer(state=status, telemetry=telemetry)
     reviver = PayloadReviver(state, restorer)
-    reconciliation = HistoryReconciler(ledger=ledger, latest=latest, telemetry=telemetry)
+    reconciliation = HistoryReconciler.from_components(
+        ledger=ledger,
+        latest=latest,
+        telemetry=telemetry,
+    )
     plan_builder = HistoryRestorationPlanner(ledger=ledger, telemetry=telemetry)
     setter = Setter(
         planner=plan_builder,
@@ -262,7 +274,8 @@ def decline() -> None:
     )
     inline = SimpleNamespace(handle=AsyncMock())
     telemetry = monitor()
-    history = TailHistoryAccess(ledger=ledger, latest=latest, telemetry=telemetry)
+    journal = TailHistoryJournal.from_telemetry(telemetry)
+    history = TailHistoryAccess(ledger=ledger, latest=latest, journal=journal)
     mutator = TailHistoryMutator()
     decision = TailDecisionService(rendering=RenderingConfig())
     inline_coord = InlineEditCoordinator(


### PR DESCRIPTION
## Summary
- extract a dedicated telemetry journal for tail history access and wire it through the DI container and samples
- restructure history reconciliation and navigator runtime builders into smaller assemblers to reduce coupling
- add explicit runtime provision and telegram navigator assembler layers for clearer orchestration boundaries

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d61eef3c588330bd9a59453dfa4701