### PR TITLE
Decouple retreat assembly and reorganize album refresh orchestration

### DIFF
--- a/presentation/telegram/back/context.py
+++ b/presentation/telegram/back/context.py
@@ -2,16 +2,96 @@
 
 from __future__ import annotations
 
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, Mapping, MutableMapping
 
-from aiogram.types import CallbackQuery
+from aiogram.types import CallbackQuery, Message, User
+
+
+@dataclass(frozen=True, slots=True)
+class RetreatEvent:
+    """Lightweight representation of callback events required by rewind."""
+
+    id: str
+    data: str | None
+    inline_message_id: str | None
+    chat_instance: str | None
+    message_id: int | None
+    message_chat_id: int | None
+    message_thread_id: int | None
+    message_chat_type: str | None
+    user_id: int | None
+    user_language: str | None
+    user_username: str | None
+    user_first_name: str | None
+    user_last_name: str | None
 
 
 class RetreatContextBuilder:
     """Create navigator context payloads for retreat execution."""
 
-    def build(self, cb: CallbackQuery, payload: dict[str, Any]) -> dict[str, Any]:
-        return {**payload, "event": cb}
+    def build(self, cb: CallbackQuery, payload: Mapping[str, Any]) -> dict[str, Any]:
+        """Return a copy of ``payload`` augmented with sanitized event data."""
+
+        context: MutableMapping[str, Any] = dict(payload)
+        context["event"] = self._event(cb)
+        return dict(context)
+
+    def _event(self, cb: CallbackQuery) -> RetreatEvent:
+        return RetreatEvent(
+            id=cb.id,
+            data=cb.data,
+            inline_message_id=cb.inline_message_id,
+            chat_instance=cb.chat_instance,
+            message_id=self._message_id(cb.message),
+            message_chat_id=self._message_chat(cb.message),
+            message_thread_id=self._message_thread(cb.message),
+            message_chat_type=self._message_chat_type(cb.message),
+            user_id=self._user_id(cb.from_user),
+            user_language=self._user_language(cb.from_user),
+            user_username=self._user_username(cb.from_user),
+            user_first_name=self._user_first_name(cb.from_user),
+            user_last_name=self._user_last_name(cb.from_user),
+        )
+
+    @staticmethod
+    def _message_id(message: Message | None) -> int | None:
+        return getattr(message, "message_id", None)
+
+    @staticmethod
+    def _message_chat(message: Message | None) -> int | None:
+        chat = getattr(message, "chat", None)
+        return getattr(chat, "id", None)
+
+    @staticmethod
+    def _message_thread(message: Message | None) -> int | None:
+        return getattr(message, "message_thread_id", None)
+
+    @staticmethod
+    def _message_chat_type(message: Message | None) -> str | None:
+        chat = getattr(message, "chat", None)
+        return getattr(chat, "type", None)
+
+    @staticmethod
+    def _user_id(user: User | None) -> int | None:
+        return getattr(user, "id", None)
+
+    @staticmethod
+    def _user_language(user: User | None) -> str | None:
+        code = getattr(user, "language_code", None)
+        return str(code) if code is not None else None
+
+    @staticmethod
+    def _user_username(user: User | None) -> str | None:
+        return getattr(user, "username", None)
+
+    @staticmethod
+    def _user_first_name(user: User | None) -> str | None:
+        return getattr(user, "first_name", None)
+
+    @staticmethod
+    def _user_last_name(user: User | None) -> str | None:
+        return getattr(user, "last_name", None)
 
 
 __all__ = ["RetreatContextBuilder"]

--- a/presentation/telegram/back/handler.py
+++ b/presentation/telegram/back/handler.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Any
+
 from aiogram.types import CallbackQuery
 
 from navigator.app.service.retreat_failure import RetreatFailureResolver
@@ -30,22 +33,62 @@ class RetreatHandler:
         self,
         cb: CallbackQuery,
         navigator: NavigatorBack,
-        payload: dict[str, object],
+        payload: dict[str, Any],
     ) -> RetreatOutcome:
         result = await self._orchestrator.execute(cb, navigator, payload)
         return self._outcomes.render(result, cb)
 
 
-def create_retreat_handler(telemetry: Telemetry, translator: Translator) -> RetreatHandler:
-    """Return a retreat handler with default orchestration components."""
+@dataclass(slots=True)
+class RetreatHandlerBuilder:
+    """Assemble retreat handlers while allowing dependency overrides."""
 
-    instrumentation = RetreatTelemetry(telemetry)
-    context = RetreatContextBuilder()
-    failures = RetreatFailureResolver()
-    workflow = RetreatWorkflow(context=context, failures=failures)
-    orchestrator = RetreatOrchestrator(telemetry=instrumentation, workflow=workflow)
-    outcomes = RetreatOutcomeFactory(translator)
-    return RetreatHandler(orchestrator=orchestrator, outcomes=outcomes)
+    telemetry: Telemetry
+    translator: Translator
+    context: RetreatContextBuilder | None = None
+    failures: RetreatFailureResolver | None = None
+    workflow: RetreatWorkflow | None = None
+    orchestrator: RetreatOrchestrator | None = None
+    outcomes: RetreatOutcomeFactory | None = None
+    instrumentation: RetreatTelemetry | None = None
+
+    def build(self) -> RetreatHandler:
+        context = self.context or RetreatContextBuilder()
+        failures = self.failures or RetreatFailureResolver()
+        workflow = self.workflow or RetreatWorkflow(context=context, failures=failures)
+        instrumentation = self.instrumentation or RetreatTelemetry(self.telemetry)
+        orchestrator = self.orchestrator or RetreatOrchestrator(
+            telemetry=instrumentation,
+            workflow=workflow,
+        )
+        outcomes = self.outcomes or RetreatOutcomeFactory(self.translator)
+        return RetreatHandler(orchestrator=orchestrator, outcomes=outcomes)
+
+
+def create_retreat_handler(
+    telemetry: Telemetry,
+    translator: Translator,
+    *,
+    context: RetreatContextBuilder | None = None,
+    failures: RetreatFailureResolver | None = None,
+    workflow: RetreatWorkflow | None = None,
+    orchestrator: RetreatOrchestrator | None = None,
+    outcomes: RetreatOutcomeFactory | None = None,
+    instrumentation: RetreatTelemetry | None = None,
+) -> RetreatHandler:
+    """Return a retreat handler built from configurable components."""
+
+    builder = RetreatHandlerBuilder(
+        telemetry=telemetry,
+        translator=translator,
+        context=context,
+        failures=failures,
+        workflow=workflow,
+        orchestrator=orchestrator,
+        outcomes=outcomes,
+        instrumentation=instrumentation,
+    )
+    return builder.build()
 
 
 __all__ = ["RetreatHandler", "create_retreat_handler"]


### PR DESCRIPTION
## Summary
- serialize Telegram callback data before passing it into the rewind workflow and expose a configurable retreat handler builder
- extract album refresh planning and execution helpers so orchestration, mutations, and telemetry are separated
- let the Telegram navigator assembler accept custom instrumentation and alert factories instead of hardcoding defaults

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'manual')*

------
https://chatgpt.com/codex/tasks/task_e_68d66223fa248330bbb6ad784efc5f7d