### PR TITLE
Decouple telemetry context and clock dependencies

### DIFF
--- a/app/internal/policy/__init__.py
+++ b/app/internal/policy/__init__.py
@@ -1,6 +1,6 @@
 """Internal policy helpers grouped by concern."""
 
-from .prime import prime
+from .prime import PrimeEntryFactory, prime
 from .shield import shield
 
-__all__ = ["prime", "shield"]
+__all__ = ["PrimeEntryFactory", "prime", "shield"]

--- a/app/internal/policy/prime.py
+++ b/app/internal/policy/prime.py
@@ -1,51 +1,66 @@
-"""Helpers for constructing history entries from payload snapshots."""
-
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from dataclasses import dataclass
 
 from navigator.core.entity.history import Entry, Message
 from navigator.core.entity.media import MediaItem
+from navigator.core.port.clock import Clock
 from navigator.core.service.history.extra import cleanse
 from navigator.core.value.content import Payload, caption
 
 
-def prime(identifier: int, payload: Payload) -> Entry:
-    media = None
-    if payload.media:
-        media = MediaItem(
-            type=payload.media.type,
-            path=payload.media.path,
-            caption=caption(payload),
+@dataclass(slots=True)
+class PrimeEntryFactory:
+    """Build lightweight history entries for tail editing workflows."""
+
+    clock: Clock
+
+    def create(self, identifier: int, payload: Payload) -> Entry:
+        media = None
+        if payload.media:
+            media = MediaItem(
+                type=payload.media.type,
+                path=payload.media.path,
+                caption=caption(payload),
+            )
+
+        length = _content_length(payload)
+        extra = cleanse(payload.extra, length=length)
+        message = Message(
+            id=identifier,
+            text=None if (payload.media or payload.group) else payload.text,
+            media=media,
+            group=payload.group,
+            markup=None,
+            preview=payload.preview,
+            extra=extra,
+            automated=True,
+            ts=self.clock.now(),
         )
+        return Entry(
+            state=None,
+            view=None,
+            messages=[message],
+        )
+
+
+def _content_length(payload: Payload) -> int:
+    """Return the effective caption length for ``payload`` metadata."""
 
     if payload.group:
         first = payload.group[0] if payload.group else None
-        length = len((getattr(first, "caption", None) or ""))
-    elif payload.media:
-        length = len((caption(payload) or ""))
-    elif isinstance(payload.text, str):
-        length = len(payload.text)
-    else:
-        length = 0
-
-    extra = cleanse(payload.extra, length=length)
-    message = Message(
-        id=identifier,
-        text=None if (payload.media or payload.group) else payload.text,
-        media=media,
-        group=payload.group,
-        markup=None,
-        preview=payload.preview,
-        extra=extra,
-        automated=True,
-        ts=datetime.now(timezone.utc),
-    )
-    return Entry(
-        state=None,
-        view=None,
-        messages=[message],
-    )
+        return len((getattr(first, "caption", None) or "")) if first else 0
+    if payload.media:
+        return len(caption(payload) or "")
+    if isinstance(payload.text, str):
+        return len(payload.text)
+    return 0
 
 
-__all__ = ["prime"]
+def prime(identifier: int, payload: Payload, *, clock: Clock) -> Entry:
+    """Compatibility wrapper around :class:`PrimeEntryFactory`."""
+
+    return PrimeEntryFactory(clock).create(identifier, payload)
+
+
+__all__ = ["PrimeEntryFactory", "prime"]

--- a/app/map/entry.py
+++ b/app/map/entry.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any, Iterable, List, Optional, Sequence, Tuple
 
 from ...core.entity.history import Entry, Message
@@ -13,6 +13,7 @@ from ...core.error import (
     MetadataKindUnsupported,
     MetadataMediumMissing,
 )
+from ...core.port.clock import Clock
 from ...core.port.factory import ViewLedger
 from ...core.service.history.extra import cleanse
 from ...core.typing.result import GroupMeta, MediaMeta, Meta, TextMeta
@@ -130,8 +131,9 @@ def _view_if_known(ledger: ViewLedger, view: Optional[str]) -> Optional[str]:
 class EntryMapper:
     """Translate rendering outcomes into persisted history entries."""
 
-    def __init__(self, ledger: ViewLedger):
+    def __init__(self, ledger: ViewLedger, clock: Clock):
         self._ledger = ledger
+        self._clock = clock
 
     def convert(
             self,
@@ -159,7 +161,7 @@ class EntryMapper:
             payloads: Sequence[Payload],
             base: Optional[Entry],
     ) -> List[Message]:
-        timestamp = datetime.now(timezone.utc)
+        timestamp = self._clock.now()
         composer = _MessageComposer(outcome=outcome, base=base, timestamp=timestamp)
         return [composer.build(index, payload) for index, payload in enumerate(payloads)]
 

--- a/app/usecase/last/context.py
+++ b/app/usecase/last/context.py
@@ -6,7 +6,7 @@ import logging
 from dataclasses import dataclass
 from typing import Optional
 
-from ...internal.policy import prime, shield
+from ...internal.policy import PrimeEntryFactory, shield
 from ....core.entity.history import Entry, Message
 from ....core.service.rendering import decision
 from ....core.service.rendering.config import RenderingConfig
@@ -85,8 +85,9 @@ class TailResolution:
 class TailDecisionService:
     """Resolve reconciliation strategy for the tail flow."""
 
-    def __init__(self, rendering: RenderingConfig) -> None:
+    def __init__(self, rendering: RenderingConfig, prime: PrimeEntryFactory) -> None:
         self._rendering = rendering
+        self._prime = prime
 
     def resolve(
             self, scope: Scope, payload: Payload, snapshot: TailSnapshot
@@ -113,7 +114,7 @@ class TailDecisionService:
         if snapshot.marker is None:
             return None
 
-        base = anchor if anchor is not None else prime(snapshot.marker, normal)
+        base = anchor if anchor is not None else self._prime.create(snapshot.marker, normal)
         return TailResolution(decision=choice, payload=normal, base=base)
 
 

--- a/infra/di/container/storage.py
+++ b/infra/di/container/storage.py
@@ -13,7 +13,7 @@ class StorageContainer(containers.DeclarativeContainer):
     chronicle = providers.Factory(Chronicle, state=core.state, telemetry=telemetry)
     status = providers.Factory(Status, state=core.state, telemetry=telemetry)
     latest = providers.Factory(Latest, state=core.state, telemetry=telemetry)
-    mapper = providers.Factory(EntryMapper, ledger=core.ledger)
+    mapper = providers.Factory(EntryMapper, ledger=core.ledger, clock=core.clock)
 
 
 __all__ = ["StorageContainer"]

--- a/infra/di/container/usecases/history/append.py
+++ b/infra/di/container/usecases/history/append.py
@@ -5,10 +5,12 @@ from dependency_injector import containers, providers
 
 from navigator.app.usecase.add import AppendDependencies, Appender
 from navigator.app.usecase.add_components import (
+    AppendEntryAssembler,
     AppendHistoryAccess,
     AppendHistoryJournal,
     AppendHistoryWriter,
-    AppendPreparation,
+    AppendPayloadAdapter,
+    AppendRenderPlanner,
 )
 from navigator.core.telemetry import Telemetry
 
@@ -28,11 +30,9 @@ class AppendUseCaseContainer(containers.DeclarativeContainer):
         state=storage.status,
         observer=journal,
     )
-    preparation = providers.Factory(
-        AppendPreparation,
-        planner=view_support.planner,
-        mapper=storage.mapper,
-    )
+    payloads = providers.Factory(AppendPayloadAdapter)
+    planner = providers.Factory(AppendRenderPlanner, planner=view_support.planner)
+    assembler = providers.Factory(AppendEntryAssembler, mapper=storage.mapper)
     writer = providers.Factory(
         AppendHistoryWriter,
         archive=storage.chronicle,
@@ -43,7 +43,9 @@ class AppendUseCaseContainer(containers.DeclarativeContainer):
     bundle = providers.Factory(
         AppendDependencies,
         history=history,
-        preparation=preparation,
+        payloads=payloads,
+        planner=planner,
+        assembler=assembler,
         writer=writer,
     )
     usecase = providers.Factory(

--- a/infra/di/container/usecases/tail.py
+++ b/infra/di/container/usecases/tail.py
@@ -11,6 +11,7 @@ from navigator.app.service import (
 )
 from navigator.app.usecase.last import Tailer
 from navigator.app.usecase.last.context import TailDecisionService, TailTelemetry
+from navigator.app.internal.policy import PrimeEntryFactory
 from navigator.app.usecase.last.delete import TailDeleteWorkflow
 from navigator.app.usecase.last.edit import TailEditWorkflow
 from navigator.app.usecase.last.inline import InlineEditCoordinator
@@ -41,7 +42,12 @@ class TailUseCaseContainer(containers.DeclarativeContainer):
         journal=tail_history_journal,
     )
     tail_mutator = providers.Factory(TailHistoryMutator)
-    tail_decision = providers.Factory(TailDecisionService, rendering=core.rendering)
+    tail_prime = providers.Factory(PrimeEntryFactory, clock=core.clock)
+    tail_decision = providers.Factory(
+        TailDecisionService,
+        rendering=core.rendering,
+        prime=tail_prime,
+    )
     tail_inline = providers.Factory(
         InlineEditCoordinator,
         handler=view.inline,

--- a/manual/tail.py
+++ b/manual/tail.py
@@ -11,6 +11,7 @@ from navigator.app.service import (
     TailHistoryMutator,
     TailHistoryTracker,
 )
+from navigator.app.internal.policy import PrimeEntryFactory
 from navigator.app.usecase.last import Tailer
 from navigator.app.usecase.last.context import TailDecisionService, TailTelemetry
 from navigator.app.usecase.last.delete import TailDeleteWorkflow
@@ -23,6 +24,7 @@ from navigator.core.service.rendering.config import RenderingConfig
 from navigator.core.typing.result import TextMeta
 from navigator.core.value.content import Payload
 from navigator.core.value.message import Scope
+from navigator.infra.clock.system import SystemClock
 
 from .common import monitor
 
@@ -45,7 +47,10 @@ def decline() -> None:
     access = TailHistoryAccess(ledger=ledger, latest=latest)
     history = TailHistoryTracker(access=access, journal=journal)
     mutator = TailHistoryMutator()
-    decision = TailDecisionService(rendering=RenderingConfig())
+    decision = TailDecisionService(
+        rendering=RenderingConfig(),
+        prime=PrimeEntryFactory(clock=SystemClock()),
+    )
     inline_coord = InlineEditCoordinator(
         handler=inline,
         executor=executor,


### PR DESCRIPTION
## Summary
- derive trace scope and payload metadata from argument types instead of positional names
- route entry creation and tail policies through injected clock-aware factories and updated DI wiring
- split append preparation responsibilities into dedicated payload, planning, and assembly helpers
- formalize dynamic view forge supply declarations and expose retreat handler wiring through overridable factories

## Testing
- pytest *(fails: AttributeError: 'NoneType' object has no attribute 'core' during dependency injector setup in trial.py collection)*

------
https://chatgpt.com/codex/tasks/task_e_68d671a779d0833094ab9893b37388c6