### PR TITLE
Refactor messaging pipeline and runtime assembly

### DIFF
--- a/app/service/navigator_runtime/__init__.py
+++ b/app/service/navigator_runtime/__init__.py
@@ -1,7 +1,13 @@
 """Navigator runtime package exposing orchestration helpers."""
 from __future__ import annotations
 
-from .builder import build_navigator_runtime
+from .builder import (
+    HistoryContracts,
+    NavigatorRuntimeContracts,
+    StateContracts,
+    TailContracts,
+    build_navigator_runtime,
+)
 from .bundler import PayloadBundler
 from .facade import NavigatorFacade
 from .history import (
@@ -27,6 +33,7 @@ __all__ = [
     "HistoryRebaseOperation",
     "HistoryReplaceOperation",
     "HistoryTrimOperation",
+    "HistoryContracts",
     "MissingAlert",
     "NavigatorFacade",
     "MissingStateAlarm",
@@ -34,9 +41,12 @@ __all__ = [
     "NavigatorReporter",
     "NavigatorRuntime",
     "NavigatorRuntimeSnapshot",
+    "NavigatorRuntimeContracts",
     "NavigatorStateService",
     "NavigatorTail",
     "NavigatorUseCases",
     "PayloadBundler",
+    "StateContracts",
     "StateDescriptor",
+    "TailContracts",
 ]

--- a/app/service/view/__init__.py
+++ b/app/service/view/__init__.py
@@ -1,3 +1,17 @@
 """Rendering orchestration for application views."""
 
-__all__ = []
+from .dynamic import DynamicPayloadNormaliser, DynamicViewRestorer
+from .forge import ForgeInvoker, ForgeResolver, ForgeSuppliesExtractor, forge_supplies
+from .restorer import ViewRestorer
+from .static import StaticPayloadFactory
+
+__all__ = [
+    "DynamicPayloadNormaliser",
+    "DynamicViewRestorer",
+    "ForgeInvoker",
+    "ForgeResolver",
+    "ForgeSuppliesExtractor",
+    "StaticPayloadFactory",
+    "ViewRestorer",
+    "forge_supplies",
+]

--- a/app/service/view/dynamic.py
+++ b/app/service/view/dynamic.py
@@ -1,0 +1,74 @@
+"""Dynamic view restoration workflow."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any, List, Optional
+
+from ....core.entity.history import Entry
+from ....core.error import InlineUnsupported
+from ....core.port.factory import ViewLedger
+from ....core.telemetry import LogCode, TelemetryChannel
+from ....core.value.content import Payload
+
+from .forge import ForgeInvoker, ForgeResolver
+
+
+class DynamicPayloadNormaliser:
+    """Ensure dynamic payload output respects inline constraints."""
+
+    def normalize(
+        self,
+        content: Optional[Payload | List[Payload]],
+        *,
+        inline: bool,
+    ) -> Optional[List[Payload]]:
+        if not content:
+            return None
+        if isinstance(content, list):
+            if inline and len(content) > 1:
+                raise InlineUnsupported("inline_dynamic_multi_payload")
+            return content
+        return [content]
+
+
+class DynamicViewRestorer:
+    """Coordinate the dynamic restoration pipeline."""
+
+    def __init__(
+        self,
+        *,
+        channel: TelemetryChannel,
+        ledger: ViewLedger,
+        resolver: ForgeResolver | None = None,
+        invoker: ForgeInvoker | None = None,
+        normaliser: DynamicPayloadNormaliser | None = None,
+    ) -> None:
+        self._channel = channel
+        self._resolver = resolver or ForgeResolver(ledger, channel)
+        self._invoker = invoker or ForgeInvoker(channel)
+        self._normaliser = normaliser or DynamicPayloadNormaliser()
+
+    async def restore(
+        self,
+        entry: Entry,
+        context: Mapping[str, Any],
+        *,
+        inline: bool,
+    ) -> Optional[List[Payload]]:
+        if not entry.view:
+            return None
+
+        self._channel.emit(logging.INFO, LogCode.RESTORE_DYNAMIC, forge=entry.view)
+        forge = self._resolver.resolve(entry.view)
+        if forge is None:
+            return None
+        content = await self._invoker.invoke(entry.view, forge, context)
+        return self._normaliser.normalize(content, inline=inline)
+
+
+__all__ = [
+    "DynamicPayloadNormaliser",
+    "DynamicViewRestorer",
+]

--- a/app/service/view/forge.py
+++ b/app/service/view/forge.py
@@ -1,0 +1,126 @@
+"""Utilities for resolving and invoking view forges."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable, Iterable, Mapping
+from typing import Any, Dict, List, Optional, Tuple
+
+from ....core.port.factory import ViewLedger
+from ....core.telemetry import LogCode, TelemetryChannel
+from ....core.value.content import Payload
+
+_Forge = Callable[..., Awaitable[Optional[Payload | List[Payload]]]]
+_SUPPLIES_ATTR = "__navigator_supplies__"
+
+
+def forge_supplies(*names: str) -> Callable[[_Forge], _Forge]:
+    """Annotate ``forge`` with the context keys it expects."""
+
+    required = _normalize_supplies(names)
+
+    def decorator(forge: _Forge) -> _Forge:
+        setattr(forge, _SUPPLIES_ATTR, required)
+        return forge
+
+    return decorator
+
+
+def _normalize_supplies(names: Iterable[str]) -> Tuple[str, ...]:
+    """Return stable, de-duplicated supply names."""
+
+    unique: Dict[str, None] = {}
+    for name in names:
+        unique[str(name)] = None
+    return tuple(unique.keys())
+
+
+def _declared_supplies(forge: _Forge) -> Tuple[str, ...]:
+    """Fetch the supply declaration attached to ``forge`` if present."""
+
+    declared = getattr(forge, _SUPPLIES_ATTR, ())
+    if isinstance(declared, str):
+        return (declared,)
+    if isinstance(declared, Iterable):
+        return _normalize_supplies(declared)
+    return ()
+
+
+class ForgeResolver:
+    """Resolve view forges from the configured ledger."""
+
+    def __init__(self, ledger: ViewLedger, channel: TelemetryChannel) -> None:
+        self._ledger = ledger
+        self._channel = channel
+
+    def resolve(self, key: str) -> Optional[_Forge]:
+        try:
+            return self._ledger.get(key)
+        except KeyError:
+            self._channel.emit(
+                logging.WARNING,
+                LogCode.RESTORE_DYNAMIC_FALLBACK,
+                forge=key,
+                note="factory_not_found",
+            )
+            return None
+
+
+class ForgeSuppliesExtractor:
+    """Derive forge arguments from the provided context mapping."""
+
+    def extract(self, forge: _Forge, context: Mapping[str, Any]) -> Dict[str, Any]:
+        required = _declared_supplies(forge)
+        if not required:
+            return {}
+        supplies: Dict[str, Any] = {}
+        missing: list[str] = []
+        for name in required:
+            if name in context:
+                supplies[name] = context[name]
+            else:
+                missing.append(name)
+        if missing:
+            raise KeyError(f"missing_supplies:{','.join(sorted(missing))}")
+        return supplies
+
+
+class ForgeInvoker:
+    """Invoke dynamic forges while reporting telemetry on failures."""
+
+    def __init__(
+        self,
+        channel: TelemetryChannel,
+        extractor: ForgeSuppliesExtractor | None = None,
+    ) -> None:
+        self._channel = channel
+        self._extractor = extractor or ForgeSuppliesExtractor()
+
+    async def invoke(
+        self,
+        key: str,
+        forge: _Forge,
+        context: Mapping[str, Any],
+    ) -> Optional[Payload | List[Payload]]:
+        try:
+            supplies = self._extractor.extract(forge, context)
+            return await forge(**supplies)
+        except Exception as exc:  # pragma: no cover - defensive
+            self._channel.emit(
+                logging.WARNING,
+                LogCode.RESTORE_DYNAMIC_FALLBACK,
+                forge=key,
+                note=type(exc).__name__,
+                exc_info=True,
+                error={"type": type(exc).__name__},
+            )
+            return None
+
+
+__all__ = [
+    "ForgeInvoker",
+    "ForgeResolver",
+    "ForgeSuppliesExtractor",
+    "_Forge",
+    "forge_supplies",
+]

--- a/app/service/view/restorer.py
+++ b/app/service/view/restorer.py
@@ -2,199 +2,16 @@
 
 from __future__ import annotations
 
-import logging
-from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List
 
-from ....core.entity.history import Entry, Message
-from ....core.error import InlineUnsupported
+from ....core.entity.history import Entry
 from ....core.port.factory import ViewLedger
-from ....core.telemetry import LogCode, Telemetry, TelemetryChannel
+from ....core.telemetry import Telemetry, TelemetryChannel
 from ....core.value.content import Payload
 
-_Forge = Callable[..., Awaitable[Optional[Payload | List[Payload]]]]
-_SUPPLIES_ATTR = "__navigator_supplies__"
-
-
-def forge_supplies(*names: str) -> Callable[[_Forge], _Forge]:
-    """Annotate ``forge`` with the context keys it expects."""
-
-    required = _normalize_supplies(names)
-
-    def decorator(forge: _Forge) -> _Forge:
-        setattr(forge, _SUPPLIES_ATTR, required)
-        return forge
-
-    return decorator
-
-
-def _normalize_supplies(names: Iterable[str]) -> Tuple[str, ...]:
-    """Return stable, de-duplicated supply names."""
-
-    unique: Dict[str, None] = {}
-    for name in names:
-        unique[str(name)] = None
-    return tuple(unique.keys())
-
-
-def _declared_supplies(forge: _Forge) -> Tuple[str, ...]:
-    """Fetch the supply declaration attached to ``forge`` if present."""
-
-    declared = getattr(forge, _SUPPLIES_ATTR, ())
-    if isinstance(declared, str):
-        return (declared,)
-    if isinstance(declared, Iterable):
-        return _normalize_supplies(declared)
-    return ()
-
-
-class StaticPayloadFactory:
-    """Transform stored messages into payload shells."""
-
-    def build_many(self, messages: Sequence[Message]) -> List[Payload]:
-        return [self.build(message) for message in messages]
-
-    def build(self, message: Message) -> Payload:
-        text = getattr(message, "text", None)
-        media = getattr(message, "media", None)
-
-        if text is None and media is not None:
-            caption = getattr(media, "caption", None)
-            if isinstance(caption, str) and caption:
-                text = caption
-
-        return Payload(
-            text=text,
-            media=media,
-            group=message.group,
-            reply=message.markup,
-            preview=message.preview,
-            extra=message.extra,
-        )
-
-
-class ForgeResolver:
-    """Resolve view forges from the configured ledger."""
-
-    def __init__(self, ledger: ViewLedger, channel: TelemetryChannel) -> None:
-        self._ledger = ledger
-        self._channel = channel
-
-    def resolve(self, key: str) -> Optional[_Forge]:
-        try:
-            return self._ledger.get(key)
-        except KeyError:
-            self._channel.emit(
-                logging.WARNING,
-                LogCode.RESTORE_DYNAMIC_FALLBACK,
-                forge=key,
-                note="factory_not_found",
-            )
-            return None
-
-
-class ForgeSuppliesExtractor:
-    """Derive forge arguments from the provided context mapping."""
-
-    def extract(self, forge: _Forge, context: Mapping[str, Any]) -> Dict[str, Any]:
-        required = _declared_supplies(forge)
-        if not required:
-            return {}
-        supplies: Dict[str, Any] = {}
-        missing: list[str] = []
-        for name in required:
-            if name in context:
-                supplies[name] = context[name]
-            else:
-                missing.append(name)
-        if missing:
-            raise KeyError(f"missing_supplies:{','.join(sorted(missing))}")
-        return supplies
-
-
-class ForgeInvoker:
-    """Invoke dynamic forges while reporting telemetry on failures."""
-
-    def __init__(
-        self,
-        channel: TelemetryChannel,
-        extractor: ForgeSuppliesExtractor | None = None,
-    ) -> None:
-        self._channel = channel
-        self._extractor = extractor or ForgeSuppliesExtractor()
-
-    async def invoke(
-        self,
-        key: str,
-        forge: _Forge,
-        context: Mapping[str, Any],
-    ) -> Optional[Payload | List[Payload]]:
-        try:
-            supplies = self._extractor.extract(forge, context)
-            return await forge(**supplies)
-        except Exception as exc:  # pragma: no cover - defensive
-            self._channel.emit(
-                logging.WARNING,
-                LogCode.RESTORE_DYNAMIC_FALLBACK,
-                forge=key,
-                note=type(exc).__name__,
-                exc_info=True,
-                error={"type": type(exc).__name__},
-            )
-            return None
-
-
-class DynamicPayloadNormaliser:
-    """Ensure dynamic payload output respects inline constraints."""
-
-    def normalize(
-        self,
-        content: Optional[Payload | List[Payload]],
-        *,
-        inline: bool,
-    ) -> Optional[List[Payload]]:
-        if not content:
-            return None
-        if isinstance(content, list):
-            if inline and len(content) > 1:
-                raise InlineUnsupported("inline_dynamic_multi_payload")
-            return content
-        return [content]
-
-
-class DynamicViewRestorer:
-    """Coordinate the dynamic restoration pipeline."""
-
-    def __init__(
-        self,
-        *,
-        channel: TelemetryChannel,
-        ledger: ViewLedger,
-        resolver: ForgeResolver | None = None,
-        invoker: ForgeInvoker | None = None,
-        normaliser: DynamicPayloadNormaliser | None = None,
-    ) -> None:
-        self._channel = channel
-        self._resolver = resolver or ForgeResolver(ledger, channel)
-        self._invoker = invoker or ForgeInvoker(channel)
-        self._normaliser = normaliser or DynamicPayloadNormaliser()
-
-    async def restore(
-        self,
-        entry: Entry,
-        context: Mapping[str, Any],
-        *,
-        inline: bool,
-    ) -> Optional[List[Payload]]:
-        if not entry.view:
-            return None
-
-        self._channel.emit(logging.INFO, LogCode.RESTORE_DYNAMIC, forge=entry.view)
-        forge = self._resolver.resolve(entry.view)
-        if forge is None:
-            return None
-        content = await self._invoker.invoke(entry.view, forge, context)
-        return self._normaliser.normalize(content, inline=inline)
+from .dynamic import DynamicPayloadNormaliser, DynamicViewRestorer
+from .forge import ForgeInvoker, ForgeResolver, ForgeSuppliesExtractor, forge_supplies
+from .static import StaticPayloadFactory
 
 
 class ViewRestorer:
@@ -225,3 +42,15 @@ class ViewRestorer:
         if dynamic is not None:
             return dynamic
         return self._static.build_many(entry.messages)
+
+
+__all__ = [
+    "DynamicViewRestorer",
+    "DynamicPayloadNormaliser",
+    "ForgeInvoker",
+    "ForgeResolver",
+    "ForgeSuppliesExtractor",
+    "StaticPayloadFactory",
+    "ViewRestorer",
+    "forge_supplies",
+]

--- a/app/service/view/static.py
+++ b/app/service/view/static.py
@@ -1,0 +1,36 @@
+"""Static payload reconstruction helpers."""
+
+from __future__ import annotations
+
+from typing import List, Sequence
+
+from ....core.entity.history import Message
+from ....core.value.content import Payload
+
+
+class StaticPayloadFactory:
+    """Transform stored messages into payload shells."""
+
+    def build_many(self, messages: Sequence[Message]) -> List[Payload]:
+        return [self.build(message) for message in messages]
+
+    def build(self, message: Message) -> Payload:
+        text = getattr(message, "text", None)
+        media = getattr(message, "media", None)
+
+        if text is None and media is not None:
+            caption = getattr(media, "caption", None)
+            if isinstance(caption, str) and caption:
+                text = caption
+
+        return Payload(
+            text=text,
+            media=media,
+            group=message.group,
+            reply=message.markup,
+            preview=message.preview,
+            extra=message.extra,
+        )
+
+
+__all__ = ["StaticPayloadFactory"]


### PR DESCRIPTION
## Summary
- encapsulate Telegram send gateway preparation and dispatch to isolate validation, telemetry, and strategy selection
- introduce explicit navigator runtime contracts to decouple builder assembly from raw use-case bundles
- split the view restorer utilities into cohesive modules and restructure the append workflow into dedicated preparation, rendering, and persistence collaborators

## Testing
- pytest *(fails: dependency injector bootstrap requires configured core container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6769fa3a88330ad2c3e30486d685e