### PR TITLE
Refine navigator instrumentation and Telegram transport

### DIFF
--- a/adapters/telegram/gateway/__init__.py
+++ b/adapters/telegram/gateway/__init__.py
@@ -19,12 +19,62 @@ from navigator.core.value.message import Scope
 from . import util
 from .edit import recast, remap, retitle, rewrite
 from .purge import PurgeTask
-from .send import send
+from .send import SendContextFactory, SendDispatcher
 from ..serializer.screen import SignatureScreen
 
 
-class TelegramMessageTransport:
-    """Handle Telegram message send and edit operations."""
+def _message_result(
+    outcome: object,
+    identifier: int,
+    payload: Payload,
+    scope: Scope,
+) -> Result:
+    meta = util.extract(outcome, payload, scope)
+    result_id = getattr(outcome, "message_id", identifier)
+    return Result(id=result_id, extra=[], meta=meta)
+
+
+class TelegramMessageSender:
+    """Coordinate Telegram send operations for navigator payloads."""
+
+    def __init__(
+        self,
+        bot: Bot,
+        *,
+        codec: MarkupCodec,
+        limits: Limits,
+        schema: ExtraSchema,
+        policy: MediaPathPolicy,
+        screen: SignatureScreen,
+        preview: LinkPreviewCodec | None,
+        truncate: bool,
+        telemetry: Telemetry,
+    ) -> None:
+        self._dispatcher = SendDispatcher(
+            bot,
+            schema=schema,
+            screen=screen,
+            policy=policy,
+            limits=limits,
+            telemetry=telemetry,
+        )
+        self._context_factory = SendContextFactory(codec=codec, preview=preview)
+        self._truncate = truncate
+        self._channel: TelemetryChannel = telemetry.channel(__name__)
+
+    async def send(self, scope: Scope, payload: Payload) -> Result:
+        context = self._context_factory.build(scope=scope, payload=payload, channel=self._channel)
+        message, extras, meta = await self._dispatcher.dispatch(
+            payload,
+            scope=scope,
+            context=context,
+            truncate=self._truncate,
+        )
+        return Result(id=message.message_id, extra=extras, meta=meta)
+
+
+class TelegramMessageEditor:
+    """Handle Telegram edit operations using dedicated helpers."""
 
     def __init__(
         self,
@@ -47,25 +97,7 @@ class TelegramMessageTransport:
         self._screen = screen
         self._preview = preview
         self._truncate = truncate
-        self._telemetry = telemetry
         self._channel: TelemetryChannel = telemetry.channel(__name__)
-
-    async def send(self, scope: Scope, payload: Payload) -> Result:
-        message, extras, meta = await send(
-            self._bot,
-            codec=self._codec,
-            schema=self._schema,
-            screen=self._screen,
-            policy=self._policy,
-            limits=self._limits,
-            preview=self._preview,
-            scope=scope,
-            payload=payload,
-            truncate=self._truncate,
-            channel=self._channel,
-            telemetry=self._telemetry,
-        )
-        return Result(id=message.message_id, extra=extras, meta=meta)
 
     async def rewrite(self, scope: Scope, identifier: int, payload: Payload) -> Result:
         outcome = await rewrite(
@@ -81,9 +113,7 @@ class TelegramMessageTransport:
             truncate=self._truncate,
             channel=self._channel,
         )
-        meta = util.extract(outcome, payload, scope)
-        resultid = getattr(outcome, "message_id", identifier)
-        return Result(id=resultid, extra=[], meta=meta)
+        return _message_result(outcome, identifier, payload, scope)
 
     async def recast(self, scope: Scope, identifier: int, payload: Payload) -> Result:
         outcome = await recast(
@@ -99,9 +129,7 @@ class TelegramMessageTransport:
             truncate=self._truncate,
             channel=self._channel,
         )
-        meta = util.extract(outcome, payload, scope)
-        resultid = getattr(outcome, "message_id", identifier)
-        return Result(id=resultid, extra=[], meta=meta)
+        return _message_result(outcome, identifier, payload, scope)
 
     async def retitle(self, scope: Scope, identifier: int, payload: Payload) -> Result:
         outcome = await retitle(
@@ -116,9 +144,22 @@ class TelegramMessageTransport:
             truncate=self._truncate,
             channel=self._channel,
         )
-        meta = util.extract(outcome, payload, scope)
-        resultid = getattr(outcome, "message_id", identifier)
-        return Result(id=resultid, extra=[], meta=meta)
+        return _message_result(outcome, identifier, payload, scope)
+
+
+class TelegramMarkupRefiner:
+    """Manage reply markup remapping for Telegram messages."""
+
+    def __init__(
+        self,
+        bot: Bot,
+        *,
+        codec: MarkupCodec,
+        telemetry: Telemetry,
+    ) -> None:
+        self._bot = bot
+        self._codec = codec
+        self._channel: TelemetryChannel = telemetry.channel(__name__)
 
     async def remap(self, scope: Scope, identifier: int, payload: Payload) -> Result:
         outcome = await remap(
@@ -129,9 +170,7 @@ class TelegramMessageTransport:
             payload=payload,
             channel=self._channel,
         )
-        meta = util.extract(outcome, payload, scope)
-        resultid = getattr(outcome, "message_id", identifier)
-        return Result(id=resultid, extra=[], meta=meta)
+        return _message_result(outcome, identifier, payload, scope)
 
 
 class TelegramDeletionManager:
@@ -169,28 +208,32 @@ class TelegramGateway(MessageGateway):
     def __init__(
         self,
         *,
-        transport: TelegramMessageTransport,
+        sender: TelegramMessageSender,
+        editor: TelegramMessageEditor,
+        markup: TelegramMarkupRefiner,
         deletion: TelegramDeletionManager,
         notifier: TelegramNotifier,
     ) -> None:
-        self._transport = transport
+        self._sender = sender
+        self._editor = editor
+        self._markup = markup
         self._deletion = deletion
         self._notifier = notifier
 
     async def send(self, scope: Scope, payload: Payload) -> Result:
-        return await self._transport.send(scope, payload)
+        return await self._sender.send(scope, payload)
 
     async def rewrite(self, scope: Scope, identifier: int, payload: Payload) -> Result:
-        return await self._transport.rewrite(scope, identifier, payload)
+        return await self._editor.rewrite(scope, identifier, payload)
 
     async def recast(self, scope: Scope, identifier: int, payload: Payload) -> Result:
-        return await self._transport.recast(scope, identifier, payload)
+        return await self._editor.recast(scope, identifier, payload)
 
     async def retitle(self, scope: Scope, identifier: int, payload: Payload) -> Result:
-        return await self._transport.retitle(scope, identifier, payload)
+        return await self._editor.retitle(scope, identifier, payload)
 
     async def remap(self, scope: Scope, identifier: int, payload: Payload) -> Result:
-        return await self._transport.remap(scope, identifier, payload)
+        return await self._markup.remap(scope, identifier, payload)
 
     async def delete(self, scope: Scope, identifiers: List[int]) -> None:
         await self._deletion.delete(scope, identifiers)
@@ -212,11 +255,13 @@ def create_gateway(
     truncate: bool = False,
     deletepause: float = 0.05,
     telemetry: Telemetry,
-    transport_factory: Callable[..., TelegramMessageTransport] = TelegramMessageTransport,
+    sender_factory: Callable[..., TelegramMessageSender] = TelegramMessageSender,
+    editor_factory: Callable[..., TelegramMessageEditor] = TelegramMessageEditor,
+    markup_factory: Callable[..., TelegramMarkupRefiner] = TelegramMarkupRefiner,
     deletion_factory: Callable[..., TelegramDeletionManager] = TelegramDeletionManager,
     notifier_factory: Callable[..., TelegramNotifier] = TelegramNotifier,
 ) -> TelegramGateway:
-    transport = transport_factory(
+    sender = sender_factory(
         bot,
         codec=codec,
         limits=limits,
@@ -227,6 +272,22 @@ def create_gateway(
         truncate=truncate,
         telemetry=telemetry,
     )
+    editor = editor_factory(
+        bot,
+        codec=codec,
+        limits=limits,
+        schema=schema,
+        policy=policy,
+        screen=screen,
+        preview=preview,
+        truncate=truncate,
+        telemetry=telemetry,
+    )
+    markup = markup_factory(
+        bot,
+        codec=codec,
+        telemetry=telemetry,
+    )
     deletion = deletion_factory(
         bot,
         chunk=chunk,
@@ -235,10 +296,18 @@ def create_gateway(
     )
     notifier = notifier_factory(bot, telemetry=telemetry)
     return TelegramGateway(
-        transport=transport,
+        sender=sender,
+        editor=editor,
+        markup=markup,
         deletion=deletion,
         notifier=notifier,
     )
 
 
-__all__ = ["TelegramGateway", "create_gateway"]
+__all__ = [
+    "TelegramGateway",
+    "TelegramMessageEditor",
+    "TelegramMessageSender",
+    "TelegramMarkupRefiner",
+    "create_gateway",
+]

--- a/adapters/telegram/gateway/send.py
+++ b/adapters/telegram/gateway/send.py
@@ -40,25 +40,21 @@ async def send(
         channel: TelemetryChannel,
         telemetry: Telemetry,
 ) -> tuple[Message, list[int], Meta]:
-    context = _SendContext.create(
-        codec=codec,
-        scope=scope,
-        payload=payload,
-        preview=preview,
-        channel=channel,
-    )
-
-    return await _dispatch(
+    context_factory = SendContextFactory(codec=codec, preview=preview)
+    dispatcher = SendDispatcher(
         bot,
-        payload,
-        context=context,
         schema=schema,
         screen=screen,
         policy=policy,
         limits=limits,
-        truncate=truncate,
         telemetry=telemetry,
+    )
+    context = context_factory.build(scope=scope, payload=payload, channel=channel)
+    return await dispatcher.dispatch(
+        payload,
         scope=scope,
+        context=context,
+        truncate=truncate,
     )
 
 
@@ -74,13 +70,13 @@ def _preview_options(preview: LinkPreviewCodec | None, payload: Payload) -> obje
 
 
 @dataclass(frozen=True)
-class _SendContext:
+class SendContext:
     """Bundle prepared data required to send a payload."""
 
     markup: object | None
     preview: object | None
     targets: Dict[str, object]
-    reporter: "_SendTelemetry"
+    reporter: "SendTelemetry"
 
     @classmethod
     def create(
@@ -91,12 +87,12 @@ class _SendContext:
         payload: Payload,
         preview: LinkPreviewCodec | None,
         channel: TelemetryChannel,
-    ) -> "_SendContext":
+    ) -> "SendContext":
         _ensure_inline_supported(scope)
         markup = textkit.decode(codec, payload.reply)
         preview_options = _preview_options(preview, payload)
         targets = util.targets(scope)
-        reporter = _SendTelemetry(channel, scope, payload)
+        reporter = SendTelemetry(channel, scope, payload)
         return cls(
             markup=markup,
             preview=preview_options,
@@ -105,7 +101,7 @@ class _SendContext:
         )
 
 
-class _SendTelemetry:
+class SendTelemetry:
     def __init__(self, channel: TelemetryChannel, scope: Scope, payload: Payload) -> None:
         self._channel = channel
         self._scope = scope
@@ -129,159 +125,159 @@ class _SendTelemetry:
         )
 
 
-async def _send_group(
-        bot: Bot,
-        payload: Payload,
-        *,
-        context: _SendContext,
-        schema: ExtraSchema,
-        screen: SignatureScreen,
-        policy: MediaPathPolicy,
-        limits: Limits,
-        telemetry: Telemetry,
+class SendContextFactory:
+    """Construct :class:`SendContext` instances from raw payload data."""
+
+    def __init__(self, codec: MarkupCodec, preview: LinkPreviewCodec | None) -> None:
+        self._codec = codec
+        self._preview = preview
+
+    def build(
+        self,
         scope: Scope,
-) -> tuple[Message, list[int], GroupMeta]:
-    caption = captionkit.caption(payload)
-    extras = schema.send(scope, payload.extra, span=len(caption or ""), media=True)
-    bundle = assemble(
-        payload.group,
-        captionmeta=extras.get("caption", {}),
-        mediameta=extras.get("media", {}),
-        policy=policy,
-        screen=screen,
-        limits=limits,
-        native=True,
-        telemetry=telemetry,
-    )
-    effect = extras.get("effect")
-    addition: Dict[str, object] = {}
-    if effect is not None:
-        addition = screen.filter(bot.send_media_group, {"message_effect_id": effect})
-
-    messages = await bot.send_media_group(
-        media=bundle,
-        **context.targets,
-        **addition,
-    )
-    head = messages[0]
-    context.reporter.success(head.message_id, len(messages) - 1)
-    meta = GroupMeta(clusters=_group_clusters(messages, payload), inline=scope.inline)
-    extras_ids = [message.message_id for message in messages[1:]]
-    return head, extras_ids, meta
-
-
-async def _dispatch(
-        bot: Bot,
         payload: Payload,
-        *,
-        context: _SendContext,
-        schema: ExtraSchema,
-        screen: SignatureScreen,
-        policy: MediaPathPolicy,
-        limits: Limits,
-        truncate: bool,
-        telemetry: Telemetry,
-        scope: Scope,
-) -> tuple[Message, list[int], Meta]:
-    if payload.group:
-        return await _send_group(
-            bot,
-            payload,
-            context=context,
-            schema=schema,
-            screen=screen,
-            policy=policy,
-            limits=limits,
-            telemetry=telemetry,
+        channel: TelemetryChannel,
+    ) -> SendContext:
+        return SendContext.create(
+            codec=self._codec,
             scope=scope,
+            payload=payload,
+            preview=self._preview,
+            channel=channel,
         )
 
-    if payload.media:
-        return await _send_media(
-            bot,
+
+class SendDispatcher:
+    """Execute Telegram send operations using prepared context."""
+
+    def __init__(
+        self,
+        bot: Bot,
+        *,
+        schema: ExtraSchema,
+        screen: SignatureScreen,
+        policy: MediaPathPolicy,
+        limits: Limits,
+        telemetry: Telemetry,
+    ) -> None:
+        self._bot = bot
+        self._schema = schema
+        self._screen = screen
+        self._policy = policy
+        self._limits = limits
+        self._telemetry = telemetry
+
+    async def dispatch(
+        self,
+        payload: Payload,
+        *,
+        scope: Scope,
+        context: SendContext,
+        truncate: bool,
+    ) -> tuple[Message, list[int], Meta]:
+        if payload.group:
+            return await self._send_group(payload, scope=scope, context=context)
+        if payload.media:
+            return await self._send_media(
+                payload,
+                scope=scope,
+                context=context,
+                truncate=truncate,
+            )
+        return await self._send_text(
             payload,
+            scope=scope,
             context=context,
-            schema=schema,
-            screen=screen,
-            policy=policy,
-            limits=limits,
             truncate=truncate,
-            scope=scope,
         )
 
-    return await _send_text(
-        bot,
-        payload,
-        context=context,
-        schema=schema,
-        screen=screen,
-        limits=limits,
-        truncate=truncate,
-        scope=scope,
-    )
-
-
-async def _send_media(
-        bot: Bot,
+    async def _send_group(
+        self,
         payload: Payload,
         *,
-        context: _SendContext,
-        schema: ExtraSchema,
-        screen: SignatureScreen,
-        policy: MediaPathPolicy,
-        limits: Limits,
-        truncate: bool,
         scope: Scope,
-) -> tuple[Message, list[int], Meta]:
-    caption = captionkit.caption(payload)
-    caption = _enforce_caption_limit(caption, limits, truncate, context.reporter)
-    extras = schema.send(scope, payload.extra, span=len(caption or ""), media=True)
-    sender = getattr(bot, f"send_{payload.media.type.value}")
-    arguments = {
-        **context.targets,
-        payload.media.type.value: policy.adapt(payload.media.path, native=True),
-        "reply_markup": context.markup,
-    }
-    if caption is not None:
-        arguments["caption"] = caption
-    arguments.update(screen.filter(sender, extras.get("caption", {})))
-    arguments.update(screen.filter(sender, extras.get("media", {})))
-    message = await sender(**arguments)
-    context.reporter.success(message.message_id, 0)
-    meta = util.extract(message, payload, scope)
-    return message, [], meta
+        context: SendContext,
+    ) -> tuple[Message, list[int], GroupMeta]:
+        caption = captionkit.caption(payload)
+        extras = self._schema.send(scope, payload.extra, span=len(caption or ""), media=True)
+        bundle = assemble(
+            payload.group,
+            captionmeta=extras.get("caption", {}),
+            mediameta=extras.get("media", {}),
+            policy=self._policy,
+            screen=self._screen,
+            limits=self._limits,
+            native=True,
+            telemetry=self._telemetry,
+        )
+        effect = extras.get("effect")
+        addition: Dict[str, object] = {}
+        if effect is not None:
+            addition = self._screen.filter(self._bot.send_media_group, {"message_effect_id": effect})
 
+        messages = await self._bot.send_media_group(
+            media=bundle,
+            **context.targets,
+            **addition,
+        )
+        head = messages[0]
+        context.reporter.success(head.message_id, len(messages) - 1)
+        meta = GroupMeta(clusters=_group_clusters(messages, payload), inline=scope.inline)
+        extras_ids = [message.message_id for message in messages[1:]]
+        return head, extras_ids, meta
 
-async def _send_text(
-        bot: Bot,
+    async def _send_media(
+        self,
         payload: Payload,
         *,
-        context: _SendContext,
-        schema: ExtraSchema,
-        screen: SignatureScreen,
-        limits: Limits,
-        truncate: bool,
         scope: Scope,
-) -> tuple[Message, list[int], Meta]:
-    text = _normalise_text(payload.text, limits, truncate, context.reporter)
-    extras = schema.send(scope, payload.extra, span=len(text), media=False)
-    message = await bot.send_message(
-        **context.targets,
-        text=text,
-        reply_markup=context.markup,
-        link_preview_options=context.preview,
-        **screen.filter(bot.send_message, extras.get("text", {})),
-    )
-    context.reporter.success(message.message_id, 0)
-    meta = util.extract(message, payload, scope)
-    return message, [], meta
+        context: SendContext,
+        truncate: bool,
+    ) -> tuple[Message, list[int], Meta]:
+        caption = captionkit.caption(payload)
+        caption = _enforce_caption_limit(caption, self._limits, truncate, context.reporter)
+        extras = self._schema.send(scope, payload.extra, span=len(caption or ""), media=True)
+        sender = getattr(self._bot, f"send_{payload.media.type.value}")
+        arguments = {
+            **context.targets,
+            payload.media.type.value: self._policy.adapt(payload.media.path, native=True),
+            "reply_markup": context.markup,
+        }
+        if caption is not None:
+            arguments["caption"] = caption
+        arguments.update(self._screen.filter(sender, extras.get("caption", {})))
+        arguments.update(self._screen.filter(sender, extras.get("media", {})))
+        message = await sender(**arguments)
+        context.reporter.success(message.message_id, 0)
+        meta = util.extract(message, payload, scope)
+        return message, [], meta
 
+    async def _send_text(
+        self,
+        payload: Payload,
+        *,
+        scope: Scope,
+        context: SendContext,
+        truncate: bool,
+    ) -> tuple[Message, list[int], Meta]:
+        text = _normalise_text(payload.text, self._limits, truncate, context.reporter)
+        extras = self._schema.send(scope, payload.extra, span=len(text), media=False)
+        message = await self._bot.send_message(
+            **context.targets,
+            text=text,
+            reply_markup=context.markup,
+            link_preview_options=context.preview,
+            **self._screen.filter(self._bot.send_message, extras.get("text", {})),
+        )
+        context.reporter.success(message.message_id, 0)
+        meta = util.extract(message, payload, scope)
+        return message, [], meta
 
 def _enforce_caption_limit(
-        caption: str | None,
-        limits: Limits,
-        truncate: bool,
-        reporter: _SendTelemetry,
+    caption: str | None,
+    limits: Limits,
+    truncate: bool,
+    reporter: SendTelemetry,
 ) -> str | None:
     if caption is None or len(caption) <= limits.captionlimit():
         return caption
@@ -295,7 +291,7 @@ def _normalise_text(
         text: str | None,
         limits: Limits,
         truncate: bool,
-        reporter: _SendTelemetry,
+        reporter: SendTelemetry,
 ) -> str:
     value = text or ""
     if not value.strip():
@@ -357,4 +353,4 @@ def _group_member_tokens(message: Message, member) -> tuple[str | None, str | No
     return medium, filetoken
 
 
-__all__ = ["send"]
+__all__ = ["SendContextFactory", "SendDispatcher", "send"]

--- a/api/__init__.py
+++ b/api/__init__.py
@@ -3,10 +3,15 @@ from __future__ import annotations
 
 from typing import Any, Iterable, cast
 
-from .contracts import NavigatorLike, ScopeDTO, ViewLedgerDTO
+from .contracts import (
+    NavigatorLike,
+    NavigatorRuntimeInstrument,
+    ScopeDTO,
+    ViewLedgerDTO,
+)
 from ..app.service.navigator_runtime import MissingAlert
 from ..app.service.navigator_runtime.facade import NavigatorFacade
-from ..bootstrap.navigator import NavigatorAssembler, assemble as _bootstrap
+from ..bootstrap.navigator import assemble as _bootstrap
 
 
 async def assemble(
@@ -14,7 +19,7 @@ async def assemble(
         state: Any,
         ledger: ViewLedgerDTO,
         scope: ScopeDTO,
-        instrumentation: Iterable[NavigatorAssembler.Instrument] | None = None,
+        instrumentation: Iterable[NavigatorRuntimeInstrument] | None = None,
         *,
         missing_alert: MissingAlert | None = None,
 ) -> NavigatorLike:

--- a/api/contracts.py
+++ b/api/contracts.py
@@ -34,4 +34,25 @@ class NavigatorLike(Protocol):
     async def add(self, *args: Any, **kwargs: Any) -> Any: ...
 
 
-__all__ = ["ScopeDTO", "ViewLedgerDTO", "NavigatorLike"]
+@runtime_checkable
+class NavigatorRuntimeBundleLike(Protocol):
+    """Structural contract describing runtime bundles exposed to the API."""
+
+    telemetry: Any
+    container: Any
+    runtime: Any
+
+
+class NavigatorRuntimeInstrument(Protocol):
+    """Protocol describing runtime instrumentation hooks accepted by the API."""
+
+    def __call__(self, bundle: NavigatorRuntimeBundleLike) -> None: ...
+
+
+__all__ = [
+    "NavigatorLike",
+    "NavigatorRuntimeBundleLike",
+    "NavigatorRuntimeInstrument",
+    "ScopeDTO",
+    "ViewLedgerDTO",
+]

--- a/app/service/navigator_runtime/__init__.py
+++ b/app/service/navigator_runtime/__init__.py
@@ -1,6 +1,7 @@
 """Navigator runtime package exposing orchestration helpers."""
 from __future__ import annotations
 
+from .assembly import build_runtime_from_dependencies
 from .builder import (
     HistoryContracts,
     NavigatorRuntimeContracts,
@@ -29,6 +30,7 @@ from .usecases import NavigatorUseCases
 
 __all__ = [
     "build_navigator_runtime",
+    "build_runtime_from_dependencies",
     "HistoryAddOperation",
     "HistoryBackOperation",
     "HistoryRebaseOperation",

--- a/app/service/navigator_runtime/assembly.py
+++ b/app/service/navigator_runtime/assembly.py
@@ -1,0 +1,31 @@
+"""High level helpers to build navigator runtime instances."""
+from __future__ import annotations
+
+from navigator.app.locks.guard import Guardian
+from navigator.core.value.message import Scope
+
+from .builder import build_navigator_runtime
+from .dependencies import NavigatorDependencies
+from .runtime import NavigatorRuntime
+from .types import MissingAlert
+
+
+def build_runtime_from_dependencies(
+    dependencies: NavigatorDependencies,
+    scope: Scope,
+    *,
+    guard: Guardian | None = None,
+    missing_alert: MissingAlert | None = None,
+) -> NavigatorRuntime:
+    """Compose a :class:`NavigatorRuntime` from resolved dependencies."""
+
+    return build_navigator_runtime(
+        usecases=dependencies.usecases,
+        scope=scope,
+        guard=guard or dependencies.guard,
+        telemetry=dependencies.telemetry,
+        missing_alert=missing_alert or dependencies.missing_alert,
+    )
+
+
+__all__ = ["build_runtime_from_dependencies"]

--- a/bootstrap/navigator/assembly.py
+++ b/bootstrap/navigator/assembly.py
@@ -2,9 +2,12 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
-from typing import Protocol
 
-from navigator.api.contracts import ScopeDTO, ViewLedgerDTO
+from navigator.api.contracts import (
+    NavigatorRuntimeInstrument,
+    ScopeDTO,
+    ViewLedgerDTO,
+)
 from navigator.app.service.navigator_runtime import MissingAlert
 from .context import BootstrapContext
 from .runtime import ContainerRuntimeFactory, NavigatorFactory, NavigatorRuntimeBundle
@@ -13,13 +16,10 @@ from .runtime import ContainerRuntimeFactory, NavigatorFactory, NavigatorRuntime
 class NavigatorAssembler:
     """Compose navigator runtime bundles from bootstrap context."""
 
-    class Instrument(Protocol):
-        def __call__(self, bundle: NavigatorRuntimeBundle) -> None: ...
-
     def __init__(
         self,
         runtime_factory: NavigatorFactory | None = None,
-        instrumentation: Sequence[Instrument] | None = None,
+        instrumentation: Sequence[NavigatorRuntimeInstrument] | None = None,
     ) -> None:
         self._runtime_factory = runtime_factory or ContainerRuntimeFactory()
         if instrumentation:
@@ -40,7 +40,7 @@ async def assemble(
     state: object,
     ledger: ViewLedgerDTO,
     scope: ScopeDTO,
-    instrumentation: Iterable[NavigatorAssembler.Instrument] | None = None,
+    instrumentation: Iterable[NavigatorRuntimeInstrument] | None = None,
     missing_alert: MissingAlert | None = None,
 ) -> NavigatorRuntimeBundle:
     """Construct a navigator runtime bundle from entrypoint payloads."""
@@ -52,7 +52,7 @@ async def assemble(
         scope=scope,
         missing_alert=missing_alert,
     )
-    instruments: Sequence[NavigatorAssembler.Instrument]
+    instruments: Sequence[NavigatorRuntimeInstrument]
     if instrumentation:
         instruments = tuple(instrumentation)
     else:

--- a/bootstrap/navigator/runtime/composition.py
+++ b/bootstrap/navigator/runtime/composition.py
@@ -1,8 +1,10 @@
 """Compose navigator runtime services from provisioned artifacts."""
 from __future__ import annotations
 
-from navigator.app.service import build_navigator_runtime
-from navigator.app.service.navigator_runtime import NavigatorRuntime
+from navigator.app.service.navigator_runtime import (
+    NavigatorRuntime,
+    build_runtime_from_dependencies,
+)
 from navigator.app.service.navigator_runtime.dependencies import NavigatorDependencies
 from navigator.app.service.navigator_runtime.snapshot import NavigatorRuntimeSnapshot
 from navigator.core.telemetry import Telemetry
@@ -29,11 +31,10 @@ class NavigatorRuntimeComposer:
         dependencies: NavigatorDependencies = snapshot.dependencies
         scope = scope_from_dto(context.scope)
         missing_alert = context.missing_alert or dependencies.missing_alert
-        return build_navigator_runtime(
-            usecases=dependencies.usecases,
-            scope=scope,
+        return build_runtime_from_dependencies(
+            dependencies,
+            scope,
             guard=dependencies.guard,
-            telemetry=dependencies.telemetry,
             missing_alert=missing_alert,
         )
 

--- a/infra/di/container/__init__.py
+++ b/infra/di/container/__init__.py
@@ -11,6 +11,7 @@ from .storage import StorageContainer
 from .telegram import TelegramContainer
 from .runtime import NavigatorRuntimeContainer
 from .usecases import UseCaseContainer
+from .usecases.view import ViewSupportContainer
 
 
 class CoreBindings(containers.DeclarativeContainer):
@@ -48,6 +49,12 @@ class IntegrationBindings(containers.DeclarativeContainer):
         core=core.provided.core,
         telemetry=telemetry,
     )
+    view_support = providers.Container(
+        ViewSupportContainer,
+        core=core.provided.core,
+        view=view,
+        telemetry=telemetry,
+    )
 
 
 class UseCaseBindings(containers.DeclarativeContainer):
@@ -61,7 +68,7 @@ class UseCaseBindings(containers.DeclarativeContainer):
         UseCaseContainer,
         core=core.provided.core,
         storage=integration.provided.storage,
-        view=integration.provided.view,
+        view_support=integration.provided.view_support,
         telemetry=telemetry,
     )
 

--- a/infra/di/container/usecases/__init__.py
+++ b/infra/di/container/usecases/__init__.py
@@ -9,7 +9,6 @@ from navigator.core.telemetry import Telemetry
 
 from .history import HistoryUseCaseContainer
 from .tail import TailUseCaseContainer
-from .view import ViewSupportContainer
 
 
 class UseCaseContainer(containers.DeclarativeContainer):
@@ -17,15 +16,9 @@ class UseCaseContainer(containers.DeclarativeContainer):
 
     core = providers.DependenciesContainer()
     storage = providers.DependenciesContainer()
-    view = providers.DependenciesContainer()
+    view_support = providers.DependenciesContainer()
     telemetry = providers.Dependency(instance_of=Telemetry)
 
-    view_support = providers.Container(
-        ViewSupportContainer,
-        core=core,
-        view=view,
-        telemetry=telemetry,
-    )
     history = providers.Container(
         HistoryUseCaseContainer,
         core=core,
@@ -37,10 +30,15 @@ class UseCaseContainer(containers.DeclarativeContainer):
         TailUseCaseContainer,
         core=core,
         storage=storage,
-        view=view,
+        view_support=view_support,
         telemetry=telemetry,
     )
-    alarm = providers.Factory(Alarm, gateway=view.gateway, alert=core.alert, telemetry=telemetry)
+    alarm = providers.Factory(
+        Alarm,
+        gateway=view_support.gateway,
+        alert=core.alert,
+        telemetry=telemetry,
+    )
     navigator = providers.Factory(
         NavigatorUseCases,
         appender=history.provided.appender,

--- a/infra/di/container/usecases/tail.py
+++ b/infra/di/container/usecases/tail.py
@@ -24,7 +24,7 @@ class TailUseCaseContainer(containers.DeclarativeContainer):
 
     core = providers.DependenciesContainer()
     storage = providers.DependenciesContainer()
-    view = providers.DependenciesContainer()
+    view_support = providers.DependenciesContainer()
     telemetry = providers.Dependency(instance_of=Telemetry)
 
     tail_history_journal = providers.Factory(
@@ -50,13 +50,13 @@ class TailUseCaseContainer(containers.DeclarativeContainer):
     )
     tail_inline = providers.Factory(
         InlineEditCoordinator,
-        handler=view.inline,
-        executor=view.executor,
+        handler=view_support.inline,
+        executor=view_support.executor,
         rendering=core.rendering,
     )
     tail_mutation = providers.Factory(
         MessageEditCoordinator,
-        executor=view.executor,
+        executor=view_support.executor,
         history=tail_history,
         mutator=tail_mutator,
     )

--- a/infra/di/container/usecases/view.py
+++ b/infra/di/container/usecases/view.py
@@ -25,19 +25,24 @@ class ViewSupportContainer(containers.DeclarativeContainer):
     view = providers.DependenciesContainer()
     telemetry = providers.Dependency(instance_of=Telemetry)
 
+    gateway = providers.Delegate(view.gateway)
+    executor = providers.Delegate(view.executor)
+    inline = providers.Delegate(view.inline)
+    album = providers.Delegate(view.album)
+
     render_synchronizer = providers.Factory(
         RenderSynchronizer,
-        executor=view.executor,
-        inline=view.inline,
+        executor=executor,
+        inline=inline,
         rendering=core.rendering,
     )
     tail_operations = providers.Factory(
         TailOperations,
-        executor=view.executor,
+        executor=executor,
         rendering=core.rendering,
     )
     inline_planner = providers.Factory(InlineRenderPlanner, synchronizer=render_synchronizer)
-    head_alignment = providers.Factory(HeadAlignment, album=view.album, telemetry=telemetry)
+    head_alignment = providers.Factory(HeadAlignment, album=album, telemetry=telemetry)
     regular_planner = providers.Factory(
         RegularRenderPlanner,
         head=head_alignment,

--- a/presentation/bootstrap/navigator.py
+++ b/presentation/bootstrap/navigator.py
@@ -2,8 +2,11 @@
 from __future__ import annotations
 
 from navigator.app.locks.guard import Guardian
-from navigator.app.service import build_navigator_runtime
-from navigator.app.service.navigator_runtime import MissingAlert, NavigatorRuntime
+from navigator.app.service.navigator_runtime import (
+    MissingAlert,
+    NavigatorRuntime,
+    build_runtime_from_dependencies,
+)
 from navigator.app.service.navigator_runtime.dependencies import NavigatorDependencies
 from navigator.core.value.message import Scope
 from navigator.presentation.navigator import Navigator
@@ -18,12 +21,11 @@ def build_runtime(
 ) -> NavigatorRuntime:
     """Construct a navigator runtime from resolved dependencies."""
 
-    return build_navigator_runtime(
-        usecases=dependencies.usecases,
-        scope=scope,
-        guard=guard or dependencies.guard,
-        telemetry=dependencies.telemetry,
-        missing_alert=missing_alert or dependencies.missing_alert,
+    return build_runtime_from_dependencies(
+        dependencies,
+        scope,
+        guard=guard,
+        missing_alert=missing_alert,
     )
 
 

--- a/presentation/telegram/assembly.py
+++ b/presentation/telegram/assembly.py
@@ -8,7 +8,7 @@ from aiogram.fsm.context import FSMContext
 from aiogram.types import TelegramObject
 
 from navigator.api import assemble as assemble_navigator
-from navigator.bootstrap.navigator.runtime import NavigatorRuntimeBundle
+from navigator.api.contracts import NavigatorRuntimeInstrument
 from navigator.app.service.navigator_runtime import MissingAlert
 from navigator.core.port.factory import ViewLedger
 from navigator.presentation.navigator import Navigator
@@ -24,12 +24,6 @@ class NavigatorAssembler(Protocol):
     async def assemble(self, event: TelegramObject, state: FSMContext) -> Navigator: ...
 
 
-class NavigatorInstrument(Protocol):
-    """Protocol describing presentation-friendly runtime instrumentation."""
-
-    def __call__(self, bundle: NavigatorRuntimeBundle) -> None: ...
-
-
 class TelegramNavigatorAssembler:
     """Concrete assembler translating Telegram primitives for navigator API."""
 
@@ -37,11 +31,11 @@ class TelegramNavigatorAssembler:
         self,
         ledger: ViewLedger,
         *,
-        instrumentation: Iterable[NavigatorInstrument] | None = None,
+        instrumentation: Iterable[NavigatorRuntimeInstrument] | None = None,
         missing_alert: MissingAlert | None = None,
     ) -> None:
         self._ledger = ledger
-        self._instrumentation: Sequence[NavigatorInstrument] | None = (
+        self._instrumentation: Sequence[NavigatorRuntimeInstrument] | None = (
             tuple(instrumentation) if instrumentation is not None else None
         )
         self._missing_alert = missing_alert or missing
@@ -57,6 +51,9 @@ class TelegramNavigatorAssembler:
             missing_alert=self._missing_alert,
         )
         return navigator
+
+
+NavigatorInstrument = NavigatorRuntimeInstrument
 
 
 __all__ = ["NavigatorAssembler", "NavigatorInstrument", "TelegramNavigatorAssembler"]

--- a/presentation/telegram/instrumentation.py
+++ b/presentation/telegram/instrumentation.py
@@ -3,17 +3,17 @@ from __future__ import annotations
 
 from typing import Callable
 
-from navigator.bootstrap.navigator.runtime import NavigatorRuntimeBundle
+from navigator.api.contracts import NavigatorRuntimeBundleLike
 
 from .router import RetreatDependencies, RetreatRouterConfigurator, retreat_configurator
 
 
 def build_retreat_instrument(
     configurator: RetreatRouterConfigurator,
-) -> Callable[[NavigatorRuntimeBundle], None]:
+) -> Callable[[NavigatorRuntimeBundleLike], None]:
     """Return an instrumentation hook bound to ``configurator`` router."""
 
-    def _instrument(bundle: NavigatorRuntimeBundle) -> None:
+    def _instrument(bundle: NavigatorRuntimeBundleLike) -> None:
         dependencies = RetreatDependencies(telemetry=bundle.telemetry)
         callback = configurator.build(dependencies)
         configurator.register(callback)

--- a/presentation/telegram/middleware.py
+++ b/presentation/telegram/middleware.py
@@ -8,6 +8,7 @@ from aiogram import BaseMiddleware
 from aiogram.fsm.context import FSMContext
 from aiogram.types import TelegramObject
 
+from navigator.api.contracts import NavigatorRuntimeInstrument
 from navigator.bootstrap.navigator import NavigatorAssembler as BootstrapNavigatorAssembler
 from navigator.core.port.factory import ViewLedger
 
@@ -27,7 +28,7 @@ class NavigatorMiddleware(BaseMiddleware):
         cls,
         ledger: ViewLedger,
         *,
-        instrumentation: Iterable[BootstrapNavigatorAssembler.Instrument] | None = None,
+        instrumentation: Iterable[NavigatorRuntimeInstrument] | None = None,
     ) -> "NavigatorMiddleware":
         """Provide a convenient constructor for the default assembler."""
 


### PR DESCRIPTION
## Summary
- expose runtime bundle and instrumentation protocols from the public API to decouple consumers from bootstrap details
- add a shared runtime builder helper and reuse it from presentation and bootstrap flows to remove duplicated assembly logic
- restructure Telegram DI bindings to consume a generic view support container and split the gateway into dedicated sender/editor/remapper collaborators, including cohesive send pipeline utilities

## Testing
- python -m compileall adapters/ api/ app/ bootstrap/ infra/ presentation/

------
https://chatgpt.com/codex/tasks/task_e_68d68438c59c83309115cae5934d6bb0