### PR TITLE
Decouple telemetry and presentation dependencies

### DIFF
--- a/app/usecase/add.py
+++ b/app/usecase/add.py
@@ -20,6 +20,7 @@ from .add_components import (
     AppendPayloadAdapter,
     AppendRenderPlanner,
 )
+from .render_contract import RenderOutcome
 
 
 @dataclass(frozen=True)
@@ -98,9 +99,9 @@ class AppendRendering:
         self,
         scope: Scope,
         prepared: AppendPreparationResult,
-    ) -> object | None:
+    ) -> RenderOutcome | None:
         render = await self._planner.plan(scope, prepared.adjusted, prepared.trail)
-        if not render or not getattr(render, "ids", None) or not getattr(render, "changed", False):
+        if not render or not render.ids or not render.changed:
             self._channel.emit(logging.INFO, LogCode.RENDER_SKIP, op="add")
             return None
         return render
@@ -122,7 +123,7 @@ class AppendPersistence:
     async def persist(
         self,
         prepared: AppendPreparationResult,
-        render: object,
+        render: RenderOutcome,
         view: Optional[str],
         *,
         root: bool = False,

--- a/app/usecase/add_components.py
+++ b/app/usecase/add_components.py
@@ -18,6 +18,7 @@ from navigator.core.service.scope import profile
 from navigator.core.telemetry import LogCode, Telemetry, TelemetryChannel
 from navigator.core.value.content import Payload, normalize
 from navigator.core.value.message import Scope
+from .render_contract import RenderOutcome
 
 
 class AppendHistoryObserver(Protocol):
@@ -146,20 +147,16 @@ class AppendEntryAssembler:
     def build_entry(
             self,
             adjusted: List[Payload],
-            render: object,
+            render: RenderOutcome,
             state: Optional[str],
             view: Optional[str],
             root: bool,
             *,
             base: Optional[Entry] = None,
     ) -> Entry:
-        identifiers = getattr(render, "ids", None) or []
+        identifiers = list(render.ids)
         usable = adjusted[:len(identifiers)]
-        outcome = Outcome(
-            identifiers,
-            getattr(render, "extras", None),
-            getattr(render, "metas", []),
-        )
+        outcome = Outcome(identifiers, list(render.extras), list(render.metas))
         return self._mapper.convert(
             outcome,
             usable,

--- a/app/usecase/pop_instrumentation.py
+++ b/app/usecase/pop_instrumentation.py
@@ -1,0 +1,78 @@
+"""Telemetry helpers coordinating history pop instrumentation."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+
+from ..log import events
+from ..log.aspect import TraceAspect
+from ...core.telemetry import LogCode, Telemetry, TelemetryChannel
+
+PerformTrim = Callable[[int], Awaitable[None]]
+
+
+class PopInstrumentation:
+    """Provide tracing and logging facilities for pop operations."""
+
+    def __init__(self, telemetry: Telemetry, *, topic: str | None = None) -> None:
+        channel_name = topic or "navigator.app.usecase.pop"
+        self._channel: TelemetryChannel = telemetry.channel(channel_name)
+        self._trace = TraceAspect(telemetry)
+
+    async def traced(self, count: int, action: PerformTrim) -> None:
+        """Execute ``action`` within the pop trace scope."""
+
+        await self._trace.run(events.POP, action, count)
+
+    def history_loaded(self, length: int) -> None:
+        """Report history recall events."""
+
+        self._channel.emit(
+            logging.DEBUG,
+            LogCode.HISTORY_LOAD,
+            op="pop",
+            history={"len": length},
+        )
+
+    def history_saved(self, length: int) -> None:
+        """Report history persistence events."""
+
+        self._channel.emit(
+            logging.DEBUG,
+            LogCode.HISTORY_SAVE,
+            op="pop",
+            history={"len": length},
+        )
+
+    def marker_updated(self, marker: int | None) -> None:
+        """Emit telemetry for latest marker updates."""
+
+        code = LogCode.LAST_SET if marker is not None else LogCode.LAST_DELETE
+        message = {"id": marker} if marker is not None else {"id": None}
+        self._channel.emit(
+            logging.INFO,
+            code,
+            op="pop",
+            message=message,
+        )
+
+    def completed(self, deletions: int, remaining: int) -> None:
+        """Emit telemetry for successful pop operations."""
+
+        self._channel.emit(
+            logging.INFO,
+            LogCode.POP_SUCCESS,
+            op="pop",
+            history={"len": remaining},
+            note=f"deleted:{deletions}",
+        )
+
+    def skipped(self, note: str) -> None:
+        """Record pop skip decisions."""
+
+        self._channel.emit(logging.INFO, LogCode.RENDER_SKIP, op="pop", note=note)
+
+
+__all__ = ["PopInstrumentation"]
+

--- a/app/usecase/render_contract.py
+++ b/app/usecase/render_contract.py
@@ -1,0 +1,21 @@
+"""Protocols describing renderer outcomes expected by use cases."""
+
+from __future__ import annotations
+
+from typing import Protocol, Sequence, runtime_checkable
+
+from navigator.core.typing.result import Meta
+
+
+@runtime_checkable
+class RenderOutcome(Protocol):
+    """Structural contract produced by view planners."""
+
+    ids: Sequence[int]
+    extras: Sequence[Sequence[int]]
+    metas: Sequence[Meta]
+    changed: bool
+
+
+__all__ = ["RenderOutcome"]
+

--- a/app/usecase/replace.py
+++ b/app/usecase/replace.py
@@ -2,13 +2,8 @@
 
 from __future__ import annotations
 
-import logging
 from typing import List
 
-from ..log import events
-from ..log.aspect import TraceAspect
-from ..service.view.planner import ViewPlanner
-from ...core.telemetry import LogCode, Telemetry, TelemetryChannel
 from ...core.value.content import Payload
 from ...core.value.message import Scope
 from .replace_components import (
@@ -16,6 +11,7 @@ from .replace_components import (
     ReplaceHistoryWriter,
     ReplacePreparation,
 )
+from .replace_instrumentation import ReplaceInstrumentation
 
 
 class Swapper:
@@ -26,18 +22,17 @@ class Swapper:
             history: ReplaceHistoryAccess,
             preparation: ReplacePreparation,
             writer: ReplaceHistoryWriter,
-            telemetry: Telemetry,
+            instrumentation: ReplaceInstrumentation,
     ):
         self._history = history
         self._prepare = preparation
         self._writer = writer
-        self._channel: TelemetryChannel = telemetry.channel(__name__)
-        self._trace = TraceAspect(telemetry)
+        self._instrumentation = instrumentation
 
     async def execute(self, scope: Scope, bundle: List[Payload]) -> None:
         """Replace history entry within ``scope`` using ``bundle`` payloads."""
 
-        await self._trace.run(events.REPLACE, self._perform, scope, bundle)
+        await self._instrumentation.traced(scope, bundle, self._perform)
 
     async def _perform(self, scope: Scope, bundle: List[Payload]) -> None:
         adjusted = self._prepare.normalize(scope, bundle)
@@ -46,7 +41,7 @@ class Swapper:
         render = await self._prepare.plan(scope, adjusted, trail)
 
         if not render or not render.ids or not render.changed:
-            self._channel.emit(logging.INFO, LogCode.RENDER_SKIP, op="replace")
+            self._instrumentation.render_skipped()
             return
         status = await self._history.status()
 

--- a/app/usecase/replace_instrumentation.py
+++ b/app/usecase/replace_instrumentation.py
@@ -1,0 +1,37 @@
+"""Instrumentation helpers dedicated to the replace workflow."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Awaitable, Callable
+
+from ..log import events
+from ..log.aspect import TraceAspect
+from ...core.telemetry import LogCode, Telemetry, TelemetryChannel
+from ...core.value.content import Payload
+from ...core.value.message import Scope
+
+PerformReplace = Callable[[Scope, list[Payload]], Awaitable[None]]
+
+
+class ReplaceInstrumentation:
+    """Coordinate tracing and telemetry for replace operations."""
+
+    def __init__(self, telemetry: Telemetry, *, topic: str | None = None) -> None:
+        channel_name = topic or "navigator.app.usecase.replace"
+        self._channel: TelemetryChannel = telemetry.channel(channel_name)
+        self._trace = TraceAspect(telemetry)
+
+    async def traced(self, scope: Scope, bundle: list[Payload], action: PerformReplace) -> None:
+        """Execute ``action`` within the replace trace scope."""
+
+        await self._trace.run(events.REPLACE, action, scope, bundle)
+
+    def render_skipped(self) -> None:
+        """Emit telemetry whenever rendering is skipped."""
+
+        self._channel.emit(logging.INFO, LogCode.RENDER_SKIP, op="replace")
+
+
+__all__ = ["ReplaceInstrumentation"]
+

--- a/bootstrap/navigator/container.py
+++ b/bootstrap/navigator/container.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 
 from navigator.app.service.navigator_runtime import MissingAlert
 from navigator.core.telemetry import Telemetry
-from navigator.infra.di.container import AppContainer
+from typing import TYPE_CHECKING
 
 from .adapter import LedgerAdapter
 from .context import BootstrapContext, ViewContainerFactory
+
+if TYPE_CHECKING:
+    from navigator.infra.di.container import AppContainer
 
 
 class ContainerFactory:
@@ -23,11 +26,13 @@ class ContainerFactory:
         self._alert = alert or (lambda scope: "")
         self._view_container = view_container
 
-    def create(self, context: BootstrapContext) -> AppContainer:
+    def create(self, context: BootstrapContext) -> "AppContainer":
         alert = context.missing_alert or self._alert
         view_container = context.view_container or self._view_container
         if view_container is None:
             raise ValueError("view_container must be provided to ContainerFactory")
+        from navigator.infra.di.container import AppContainer  # local import
+
         return AppContainer(
             event=context.event,
             state=context.state,

--- a/bootstrap/navigator/inspection.py
+++ b/bootstrap/navigator/inspection.py
@@ -2,10 +2,13 @@
 from __future__ import annotations
 
 from navigator.app.service.navigator_runtime.snapshot import NavigatorRuntimeSnapshot
-from navigator.infra.di.container import AppContainer
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from navigator.infra.di.container import AppContainer
 
 
-def inspect_container(container: AppContainer) -> NavigatorRuntimeSnapshot:
+def inspect_container(container: "AppContainer") -> NavigatorRuntimeSnapshot:
     """Collect runtime dependencies and configuration from the container."""
 
     runtime = container.runtime()

--- a/bootstrap/navigator/runtime/bundle.py
+++ b/bootstrap/navigator/runtime/bundle.py
@@ -2,10 +2,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from navigator.app.service.navigator_runtime import NavigatorRuntime
 from navigator.core.telemetry import Telemetry
-from navigator.infra.di.container import AppContainer
+
+if TYPE_CHECKING:
+    from navigator.infra.di.container import AppContainer
 
 
 @dataclass(frozen=True)
@@ -13,7 +16,7 @@ class NavigatorRuntimeBundle:
     """Aggregate runtime services exposed to bootstrap instrumentation."""
 
     telemetry: Telemetry
-    container: AppContainer
+    container: "AppContainer"
     runtime: NavigatorRuntime
 
 

--- a/bootstrap/navigator/runtime/provision.py
+++ b/bootstrap/navigator/runtime/provision.py
@@ -6,7 +6,10 @@ from dataclasses import dataclass
 from navigator.app.service.navigator_runtime import MissingAlert
 from navigator.app.service.navigator_runtime.snapshot import NavigatorRuntimeSnapshot
 from navigator.core.telemetry import Telemetry
-from navigator.infra.di.container import AppContainer
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from navigator.infra.di.container import AppContainer
 
 from ..context import BootstrapContext, ViewContainerFactory
 from ..container import ContainerFactory
@@ -19,7 +22,7 @@ class RuntimeProvision:
     """Capture the intermediate components produced during bootstrap."""
 
     telemetry: Telemetry
-    container: AppContainer
+    container: "AppContainer"
     snapshot: NavigatorRuntimeSnapshot
 
 

--- a/infra/di/container/usecases/history/maintenance.py
+++ b/infra/di/container/usecases/history/maintenance.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from dependency_injector import containers, providers
 
 from navigator.app.usecase.pop import Trimmer
+from navigator.app.usecase.pop_instrumentation import PopInstrumentation
 from navigator.app.usecase.rebase import Shifter
 from navigator.app.usecase.rebase_instrumentation import RebaseInstrumentation
 from navigator.core.telemetry import Telemetry
@@ -15,11 +16,15 @@ class MaintenanceUseCaseContainer(containers.DeclarativeContainer):
     storage = providers.DependenciesContainer()
     telemetry = providers.Dependency(instance_of=Telemetry)
 
+    pop_instrumentation = providers.Factory(
+        PopInstrumentation,
+        telemetry=telemetry,
+    )
     trimmer = providers.Factory(
         Trimmer,
         ledger=storage.chronicle,
         latest=storage.latest,
-        telemetry=telemetry,
+        instrumentation=pop_instrumentation,
     )
     rebase_instrumentation = providers.Factory(
         RebaseInstrumentation,

--- a/infra/di/container/usecases/history/replace.py
+++ b/infra/di/container/usecases/history/replace.py
@@ -8,7 +8,9 @@ from navigator.app.usecase.replace_components import (
     ReplaceHistoryAccess,
     ReplaceHistoryWriter,
     ReplacePreparation,
+    ReplaceHistoryJournal,
 )
+from navigator.app.usecase.replace_instrumentation import ReplaceInstrumentation
 from navigator.core.telemetry import Telemetry
 
 
@@ -20,11 +22,15 @@ class ReplaceUseCaseContainer(containers.DeclarativeContainer):
     view_support = providers.DependenciesContainer()
     history_limit = providers.Dependency()
 
+    history_observer = providers.Factory(
+        ReplaceHistoryJournal,
+        telemetry=telemetry,
+    )
     history = providers.Factory(
         ReplaceHistoryAccess,
         archive=storage.chronicle,
         state=storage.status,
-        telemetry=telemetry,
+        observer=history_observer,
     )
     preparation = providers.Factory(
         ReplacePreparation,
@@ -38,12 +44,16 @@ class ReplaceUseCaseContainer(containers.DeclarativeContainer):
         limit=history_limit,
         telemetry=telemetry,
     )
+    instrumentation = providers.Factory(
+        ReplaceInstrumentation,
+        telemetry=telemetry,
+    )
     usecase = providers.Factory(
         Swapper,
         history=history,
         preparation=preparation,
         writer=writer,
-        telemetry=telemetry,
+        instrumentation=instrumentation,
     )
 
 

--- a/presentation/telegram/assembly.py
+++ b/presentation/telegram/assembly.py
@@ -11,7 +11,6 @@ from navigator.api import assemble as assemble_navigator
 from navigator.api.contracts import NavigatorRuntimeInstrument
 from navigator.app.service.navigator_runtime import MissingAlert
 from navigator.core.port.factory import ViewLedger
-from navigator.infra.di.container.telegram import TelegramContainer
 from navigator.presentation.navigator import Navigator
 from navigator.bootstrap.navigator.context import ViewContainerFactory
 
@@ -35,7 +34,7 @@ class TelegramNavigatorAssembler:
         *,
         instrumentation: Iterable[NavigatorRuntimeInstrument] | None = None,
         missing_alert: MissingAlert | None = None,
-        view_container: ViewContainerFactory = TelegramContainer,
+        view_container: ViewContainerFactory | None = None,
     ) -> None:
         self._ledger = ledger
         self._instrumentation: Sequence[NavigatorRuntimeInstrument] | None = (


### PR DESCRIPTION
## Summary
- extract dedicated instrumentation for replace/pop workflows and introduce an explicit render outcome contract
- update DI wiring and presentation layer defaults to remove direct dependencies on telemetry and storage implementations
- defer heavy DI imports in bootstrap runtime to lower coupling and ease testing

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'manual')*

------
https://chatgpt.com/codex/tasks/task_e_68d6bca0abc88330ba9ac5078a45e56c