### PR TITLE
Refactor album orchestration and decouple presentation factories

### DIFF
--- a/app/log/aspect.py
+++ b/app/log/aspect.py
@@ -24,97 +24,100 @@ class TraceContext:
     payload: Optional[dict]
 
 
-def _capture_context(
+class TraceContextExtractor:
+    """Derive telemetry context from function call arguments."""
+
+    def extract(
+        self,
         fn: Callable[..., Any],
         args: Tuple[Any, ...],
         kwargs: Dict[str, Any],
-) -> TraceContext:
-    """Extract stable telemetry context from ``fn`` call arguments."""
+    ) -> TraceContext:
+        del fn  # function identity is irrelevant for structural context capture
+        values = list(args) + list(kwargs.values())
+        scope = self._extract_scope(values)
+        payload = self._extract_payload(values)
+        scoped = profile(scope) if scope is not None else None
+        classified = self._classify_payload(payload) if payload is not None else None
+        return TraceContext(scope=scoped, payload=classified)
 
-    del fn  # function identity is irrelevant for structural context capture
-    values = list(args) + list(kwargs.values())
-    scope = _extract_scope(values)
-    payload = _extract_payload(values)
-    scoped = profile(scope) if scope is not None else None
-    classified = _classify_payload(payload) if payload is not None else None
-    return TraceContext(scope=scoped, payload=classified)
+    @staticmethod
+    def _extract_scope(values: Sequence[Any]) -> Scope | None:
+        for value in values:
+            if isinstance(value, Scope):
+                return value
+        return None
 
+    @staticmethod
+    def _extract_payload(values: Sequence[Any]) -> Payload | Sequence[Payload] | None:
+        for value in values:
+            if isinstance(value, Payload):
+                return value
+            if TraceContextExtractor._is_payload_sequence(value):
+                return value
+        return None
 
-def _extract_scope(values: Sequence[Any]) -> Scope | None:
-    """Return the first :class:`Scope` instance from ``values`` if any."""
-
-    for value in values:
-        if isinstance(value, Scope):
-            return value
-    return None
-
-
-def _extract_payload(values: Sequence[Any]) -> Payload | Sequence[Payload] | None:
-    """Return payload artefacts discovered inside ``values``."""
-
-    for value in values:
-        if isinstance(value, Payload):
-            return value
-        if _is_payload_sequence(value):
-            return value
-    return None
-
-
-def _is_payload_sequence(candidate: Any) -> bool:
-    """Check whether ``candidate`` looks like a payload sequence."""
-
-    if isinstance(candidate, (str, bytes)):
+    @staticmethod
+    def _is_payload_sequence(candidate: Any) -> bool:
+        if isinstance(candidate, (str, bytes)):
+            return False
+        if isinstance(candidate, Sequence):
+            return any(isinstance(item, Payload) for item in candidate)
         return False
-    if isinstance(candidate, Sequence):
-        return any(isinstance(item, Payload) for item in candidate)
-    return False
+
+    @staticmethod
+    def _classify_payload(payload: Payload | Sequence[Payload]) -> Optional[dict]:
+        if isinstance(payload, Payload):
+            return classify(payload)
+        items = [item for item in payload if isinstance(item, Payload)]
+        if not items:
+            return None
+        if len(items) == 1:
+            return classify(items[0])
+        families: Dict[str, int] = {}
+        for item in items:
+            kind = classify(item).get("kind", "unknown")
+            families[kind] = families.get(kind, 0) + 1
+        return {"kind": "bundle", "size": len(items), "families": families}
 
 
-def _classify_payload(payload: Payload | Sequence[Payload]) -> Optional[dict]:
-    """Convert payload artefacts into lightweight telemetry metadata."""
+class TraceResultInspector:
+    """Derive telemetry annotations from executed call results."""
 
-    if isinstance(payload, Payload):
-        return classify(payload)
-    items = [item for item in payload if isinstance(item, Payload)]
-    if not items:
-        return None
-    if len(items) == 1:
-        return classify(items[0])
-    families: Dict[str, int] = {}
-    for item in items:
-        kind = classify(item).get("kind", "unknown")
-        families[kind] = families.get(kind, 0) + 1
-    return {"kind": "bundle", "size": len(items), "families": families}
-
-
-def _snapshot(result: Any) -> Optional[dict]:
-    """Return lightweight telemetry metadata extracted from ``result``."""
-
-    identifier = getattr(result, "id", None)
-    extra = getattr(result, "extra", None)
-    if identifier is None and extra is None:
-        return None
-    return {"id": identifier, "extra_len": len(extra) if isinstance(extra, list) else 0}
+    def inspect(self, result: Any) -> Optional[dict]:
+        identifier = getattr(result, "id", None)
+        extra = getattr(result, "extra", None)
+        if identifier is None and extra is None:
+            return None
+        return {"id": identifier, "extra_len": len(extra) if isinstance(extra, list) else 0}
 
 
 class TraceAspect:
     """Coordinate begin/success/failure telemetry around async calls."""
 
-    def __init__(self, telemetry: Telemetry) -> None:
+    def __init__(
+        self,
+        telemetry: Telemetry,
+        *,
+        context: TraceContextExtractor | None = None,
+        inspector: TraceResultInspector | None = None,
+    ) -> None:
         self._telemetry = telemetry
+        self._context = context or TraceContextExtractor()
+        self._inspector = inspector or TraceResultInspector()
 
     async def run(
-            self,
-            spec: TraceSpec,
-            call: Callable[..., Awaitable[Any]],
-            *args: Any,
-            augment: Callable[[Any], Optional[dict]] | None = None,
-            **kwargs: Any,
+        self,
+        spec: TraceSpec,
+        call: Callable[..., Awaitable[Any]],
+        *args: Any,
+        augment: Callable[[Any], Optional[dict]] | None = None,
+        **kwargs: Any,
     ) -> Any:
         """Run ``call`` while reporting progress through ``spec`` telemetry."""
 
         channel = self._telemetry.channel(call.__module__)
-        context = _capture_context(call, args, kwargs)
+        context = self._context.extract(call, args, kwargs)
         channel.emit(logging.INFO, spec.begin, scope=context.scope, payload=context.payload)
         started = time.monotonic()
         try:
@@ -129,7 +132,7 @@ class TraceAspect:
             )
             raise
         elapsed = time.monotonic() - started
-        meta = augment(result) if augment else _snapshot(result)
+        meta = augment(result) if augment else self._inspector.inspect(result)
         channel.emit(
             logging.INFO,
             spec.success,
@@ -141,4 +144,4 @@ class TraceAspect:
         return result
 
 
-__all__ = ["TraceAspect"]
+__all__ = ["TraceAspect", "TraceContext", "TraceContextExtractor", "TraceResultInspector"]

--- a/app/service/view/__init__.py
+++ b/app/service/view/__init__.py
@@ -1,13 +1,20 @@
 """Rendering orchestration for application views."""
 
-from .dynamic import DynamicPayloadNormaliser, DynamicViewRestorer
+from .dynamic import (
+    DynamicPayloadNormaliser,
+    DynamicRestorationFactory,
+    DynamicViewRestorer,
+    create_dynamic_view_restorer,
+)
 from .forge import ForgeInvoker, ForgeResolver, ForgeSuppliesExtractor, forge_supplies
 from .restorer import ViewRestorer
 from .static import StaticPayloadFactory
 
 __all__ = [
     "DynamicPayloadNormaliser",
+    "DynamicRestorationFactory",
     "DynamicViewRestorer",
+    "create_dynamic_view_restorer",
     "ForgeInvoker",
     "ForgeResolver",
     "ForgeSuppliesExtractor",

--- a/app/service/view/album/__init__.py
+++ b/app/service/view/album/__init__.py
@@ -1,0 +1,13 @@
+"""Album refresh orchestration primitives."""
+
+from .mutations import AlbumMutationExecutor
+from .planner import AlbumMutation, AlbumRefreshPlan, AlbumRefreshPlanner
+from .service import AlbumService
+
+__all__ = [
+    "AlbumMutation",
+    "AlbumMutationExecutor",
+    "AlbumRefreshPlan",
+    "AlbumRefreshPlanner",
+    "AlbumService",
+]

--- a/app/service/view/album/mutations.py
+++ b/app/service/view/album/mutations.py
@@ -1,0 +1,32 @@
+"""Execute planned album mutations."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from navigator.core.value.message import Scope
+
+from ..executor import EditExecutor
+from .planner import AlbumMutation
+
+
+class AlbumMutationExecutor:
+    """Execute album mutations with shared edit executor."""
+
+    def __init__(self, executor: EditExecutor) -> None:
+        self._executor = executor
+
+    async def apply(self, scope: Scope, mutations: Iterable[AlbumMutation]) -> bool:
+        mutated = False
+        for mutation in mutations:
+            execution = await self._executor.execute(
+                scope,
+                mutation.decision,
+                mutation.payload,
+                mutation.reference,
+            )
+            mutated = mutated or bool(execution)
+        return mutated
+
+
+__all__ = ["AlbumMutationExecutor"]

--- a/app/service/view/album/service.py
+++ b/app/service/view/album/service.py
@@ -1,0 +1,58 @@
+"""Album reconciliation service wiring planner and mutation executor."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from navigator.core.entity.history import Message
+from navigator.core.port.limits import Limits
+from navigator.core.telemetry import LogCode, Telemetry, TelemetryChannel
+from navigator.core.typing.result import GroupMeta
+from navigator.core.value.content import Payload
+from navigator.core.value.message import Scope
+
+from ..executor import EditExecutor
+from .mutations import AlbumMutationExecutor
+from .planner import AlbumRefreshPlan, AlbumRefreshPlanner
+
+
+class AlbumService:
+    """Refresh album state and emit edits when existing nodes diverge."""
+
+    def __init__(
+        self,
+        executor: EditExecutor,
+        *,
+        limits: Limits,
+        thumbguard: bool,
+        telemetry: Telemetry,
+        planner: AlbumRefreshPlanner | None = None,
+        mutations: AlbumMutationExecutor | None = None,
+    ) -> None:
+        self._planner = planner or AlbumRefreshPlanner(limits=limits, thumbguard=thumbguard)
+        self._mutations = mutations or AlbumMutationExecutor(executor)
+        self._channel: TelemetryChannel = telemetry.channel(__name__)
+
+    async def refresh(
+        self,
+        scope: Scope,
+        former: Message,
+        latter: Payload,
+    ) -> Optional[tuple[int, list[int], GroupMeta, bool]]:
+        plan: AlbumRefreshPlan | None = self._planner.prepare(former, latter)
+        if plan is None:
+            return None
+
+        mutated = await self._mutations.apply(scope, plan.mutations)
+
+        self._channel.emit(
+            logging.INFO,
+            LogCode.ALBUM_PARTIAL_OK,
+            count=len(plan.lineup),
+        )
+
+        return plan.lineup[0], plan.extras, plan.meta, mutated
+
+
+__all__ = ["AlbumService"]

--- a/app/service/view/restorer.py
+++ b/app/service/view/restorer.py
@@ -9,7 +9,11 @@ from ....core.port.factory import ViewLedger
 from ....core.telemetry import Telemetry, TelemetryChannel
 from ....core.value.content import Payload
 
-from .dynamic import DynamicPayloadNormaliser, DynamicViewRestorer
+from .dynamic import (
+    DynamicPayloadNormaliser,
+    DynamicViewRestorer,
+    create_dynamic_view_restorer,
+)
 from .forge import ForgeInvoker, ForgeResolver, ForgeSuppliesExtractor, forge_supplies
 from .static import StaticPayloadFactory
 
@@ -26,7 +30,7 @@ class ViewRestorer:
         static_factory: StaticPayloadFactory | None = None,
     ) -> None:
         channel: TelemetryChannel = telemetry.channel(__name__)
-        self._dynamic = dynamic or DynamicViewRestorer(channel=channel, ledger=ledger)
+        self._dynamic = dynamic or create_dynamic_view_restorer(ledger, channel)
         self._static = static_factory or StaticPayloadFactory()
 
     async def revive(

--- a/bootstrap/navigator/runtime/__init__.py
+++ b/bootstrap/navigator/runtime/__init__.py
@@ -7,6 +7,7 @@ from .provision import (
     ContainerInspector,
     RuntimeProvision,
     RuntimeProvisioner,
+    RuntimeProvisionWorkflow,
     TelemetryInitializer,
 )
 
@@ -20,5 +21,6 @@ __all__ = [
     "RuntimeCalibrator",
     "RuntimeProvision",
     "RuntimeProvisioner",
+    "RuntimeProvisionWorkflow",
     "TelemetryInitializer",
 ]

--- a/presentation/telegram/back/__init__.py
+++ b/presentation/telegram/back/__init__.py
@@ -9,6 +9,7 @@ from .factory import (
 from .handler import RetreatHandler
 from .orchestrator import RetreatOrchestrator
 from .outcome import RetreatOutcome
+from .providers import default_retreat_providers
 from .protocols import NavigatorBack, Translator
 from .result import RetreatResult
 from .telemetry import RetreatTelemetry
@@ -26,5 +27,6 @@ __all__ = [
     "RetreatTelemetry",
     "RetreatWorkflow",
     "Translator",
+    "default_retreat_providers",
     "create_retreat_handler",
 ]

--- a/presentation/telegram/back/factory.py
+++ b/presentation/telegram/back/factory.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Callable
+from dataclasses import dataclass
+from typing import Callable, TYPE_CHECKING
 
-from navigator.app.service.retreat_failure import RetreatFailureResolver
 from navigator.core.telemetry import Telemetry
 
 from .context import RetreatContextBuilder
@@ -14,30 +13,22 @@ from .orchestrator import RetreatOrchestrator
 from .outcome import RetreatOutcomeFactory
 from .protocols import Translator
 from .telemetry import RetreatTelemetry
-from .workflow import RetreatWorkflow
+
+if TYPE_CHECKING:
+    from navigator.app.service.retreat_failure import RetreatFailureResolver
+    from .workflow import RetreatWorkflow
 
 
 @dataclass(frozen=True, slots=True)
 class RetreatHandlerProviders:
     """Expose hooks to lazily create retreat handler collaborators."""
 
-    context: Callable[[], RetreatContextBuilder] = RetreatContextBuilder
-    failures: Callable[[], RetreatFailureResolver] = RetreatFailureResolver
-    workflow: Callable[[RetreatContextBuilder, RetreatFailureResolver], RetreatWorkflow] = (
-        lambda context, failures: RetreatWorkflow(context=context, failures=failures)
-    )
-    instrumentation: Callable[[Telemetry], RetreatTelemetry] = (
-        lambda telemetry: RetreatTelemetry(telemetry)
-    )
-    orchestrator: Callable[[RetreatTelemetry, RetreatWorkflow], RetreatOrchestrator] = (
-        lambda instrumentation, workflow: RetreatOrchestrator(
-            telemetry=instrumentation,
-            workflow=workflow,
-        )
-    )
-    outcomes: Callable[[Translator], RetreatOutcomeFactory] = (
-        lambda translator: RetreatOutcomeFactory(translator)
-    )
+    context: Callable[[], RetreatContextBuilder]
+    failures: Callable[[], "RetreatFailureResolver"]
+    workflow: Callable[[RetreatContextBuilder, "RetreatFailureResolver"], "RetreatWorkflow"]
+    instrumentation: Callable[[Telemetry], RetreatTelemetry]
+    orchestrator: Callable[[RetreatTelemetry, "RetreatWorkflow"], RetreatOrchestrator]
+    outcomes: Callable[[Translator], RetreatOutcomeFactory]
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,8 +36,8 @@ class RetreatHandlerOverrides:
     """Optional dependencies that may replace individual collaborators."""
 
     context: RetreatContextBuilder | None = None
-    failures: RetreatFailureResolver | None = None
-    workflow: RetreatWorkflow | None = None
+    failures: "RetreatFailureResolver" | None = None
+    workflow: "RetreatWorkflow" | None = None
     instrumentation: RetreatTelemetry | None = None
     orchestrator: RetreatOrchestrator | None = None
     outcomes: RetreatOutcomeFactory | None = None
@@ -58,10 +49,12 @@ class RetreatHandlerFactory:
 
     telemetry: Telemetry
     translator: Translator
-    providers: RetreatHandlerProviders = field(default_factory=RetreatHandlerProviders)
+    providers: RetreatHandlerProviders
 
     def create(
-        self, overrides: RetreatHandlerOverrides | None = None
+        self,
+        *,
+        overrides: RetreatHandlerOverrides | None = None,
     ) -> RetreatHandler:
         options = overrides or RetreatHandlerOverrides()
         providers = self.providers
@@ -72,8 +65,7 @@ class RetreatHandlerFactory:
 
         if options.orchestrator is None:
             instrumentation = (
-                options.instrumentation
-                or providers.instrumentation(self.telemetry)
+                options.instrumentation or providers.instrumentation(self.telemetry)
             )
             orchestrator = providers.orchestrator(instrumentation, workflow)
         else:
@@ -87,17 +79,17 @@ def create_retreat_handler(
     telemetry: Telemetry,
     translator: Translator,
     *,
+    providers: RetreatHandlerProviders,
     overrides: RetreatHandlerOverrides | None = None,
-    providers: RetreatHandlerProviders | None = None,
 ) -> RetreatHandler:
     """Convenience wrapper returning an assembled retreat handler."""
 
     factory = RetreatHandlerFactory(
         telemetry=telemetry,
         translator=translator,
-        providers=providers or RetreatHandlerProviders(),
+        providers=providers,
     )
-    return factory.create(overrides)
+    return factory.create(overrides=overrides)
 
 
 __all__ = [
@@ -106,4 +98,3 @@ __all__ = [
     "RetreatHandlerProviders",
     "create_retreat_handler",
 ]
-

--- a/presentation/telegram/back/providers.py
+++ b/presentation/telegram/back/providers.py
@@ -1,0 +1,41 @@
+"""Default providers bridging presentation layer with application services."""
+
+from __future__ import annotations
+
+from navigator.app.service.retreat_failure import RetreatFailureResolver
+from .context import RetreatContextBuilder
+from .factory import RetreatHandlerProviders
+from .orchestrator import RetreatOrchestrator
+from .outcome import RetreatOutcomeFactory
+from .protocols import Translator
+from .telemetry import RetreatTelemetry
+from .workflow import RetreatWorkflow
+
+
+def default_retreat_providers() -> RetreatHandlerProviders:
+    """Return providers wiring application services for retreat handling."""
+
+    def build_workflow(
+        context: RetreatContextBuilder, failures: RetreatFailureResolver
+    ) -> RetreatWorkflow:
+        return RetreatWorkflow(context=context, failures=failures)
+
+    def build_orchestrator(
+        instrumentation: RetreatTelemetry, workflow: RetreatWorkflow
+    ) -> RetreatOrchestrator:
+        return RetreatOrchestrator(telemetry=instrumentation, workflow=workflow)
+
+    def build_outcomes(translator: Translator) -> RetreatOutcomeFactory:
+        return RetreatOutcomeFactory(translator)
+
+    return RetreatHandlerProviders(
+        context=RetreatContextBuilder,
+        failures=RetreatFailureResolver,
+        workflow=build_workflow,
+        instrumentation=lambda telemetry: RetreatTelemetry(telemetry),
+        orchestrator=build_orchestrator,
+        outcomes=build_outcomes,
+    )
+
+
+__all__ = ["default_retreat_providers"]

--- a/presentation/telegram/router.py
+++ b/presentation/telegram/router.py
@@ -14,6 +14,7 @@ from navigator.presentation.telegram.back import (
     RetreatOutcome,
     Translator,
     create_retreat_handler,
+    default_retreat_providers,
 )
 
 router = Router(name="navigator_handlers")
@@ -41,7 +42,12 @@ class RetreatCallback(Protocol):
 def build_retreat_handler(dependencies: RetreatDependencies) -> RetreatHandler:
     """Create a retreat handler with explicit dependencies."""
 
-    return create_retreat_handler(dependencies.telemetry, dependencies.translator)
+    providers = default_retreat_providers()
+    return create_retreat_handler(
+        dependencies.telemetry,
+        dependencies.translator,
+        providers=providers,
+    )
 
 
 def _retreat_callback(handler: RetreatHandler) -> RetreatCallback:


### PR DESCRIPTION
## Summary
- split the album view service into dedicated planner, mutation executor, and service modules to improve cohesion
- add factories around dynamic view restoration, trace telemetry, and runtime provisioning so orchestration happens through composable workflows
- decouple the Telegram retreat handler factory by injecting providers from a new default provider module and wiring it through the router

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'manual')*

------
https://chatgpt.com/codex/tasks/task_e_68d6c90c4b98833081a5b20bd8467411