### PR TITLE
Decouple navigator bootstrap from Telegram DI container

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Any, Iterable, cast
 
 from .contracts import (
+    NavigatorAssemblyOverrides,
     NavigatorLike,
     NavigatorRuntimeInstrument,
     ScopeDTO,
@@ -12,7 +13,6 @@ from .contracts import (
 from ..app.service.navigator_runtime import MissingAlert
 from ..app.service.navigator_runtime.facade import NavigatorFacade
 from ..bootstrap.navigator import assemble as _bootstrap
-from ..bootstrap.navigator.context import ViewContainerFactory
 
 
 async def assemble(
@@ -23,15 +23,15 @@ async def assemble(
         instrumentation: Iterable[NavigatorRuntimeInstrument] | None = None,
         *,
         missing_alert: MissingAlert | None = None,
-        view_container: ViewContainerFactory | None = None,
+        overrides: NavigatorAssemblyOverrides | None = None,
 ) -> NavigatorLike:
     """Assemble and return a Navigator facade instance."""
 
     bootstrap_kwargs = {
         "missing_alert": missing_alert,
     }
-    if view_container is not None:
-        bootstrap_kwargs["view_container"] = view_container
+    if overrides is not None and overrides.view_container is not None:
+        bootstrap_kwargs["view_container"] = overrides.view_container
     bundle = await _bootstrap(
         event=event,
         state=state,

--- a/api/contracts.py
+++ b/api/contracts.py
@@ -6,6 +6,13 @@ from typing import Any, Awaitable, Protocol, runtime_checkable
 
 
 @dataclass(slots=True)
+class NavigatorAssemblyOverrides:
+    """Configuration overrides accepted by the public API."""
+
+    view_container: Any | None = None
+
+
+@dataclass(slots=True)
 class ScopeDTO:
     """Thin DTO describing chat scope information required by the API."""
 
@@ -50,6 +57,7 @@ class NavigatorRuntimeInstrument(Protocol):
 
 
 __all__ = [
+    "NavigatorAssemblyOverrides",
     "NavigatorLike",
     "NavigatorRuntimeBundleLike",
     "NavigatorRuntimeInstrument",

--- a/bootstrap/navigator/assembly.py
+++ b/bootstrap/navigator/assembly.py
@@ -10,6 +10,7 @@ from navigator.api.contracts import (
 )
 from navigator.app.service.navigator_runtime import MissingAlert
 from .context import BootstrapContext, ViewContainerFactory
+from .container_resolution import resolve_view_container
 from .runtime import ContainerRuntimeFactory, NavigatorFactory, NavigatorRuntimeBundle
 
 
@@ -74,9 +75,7 @@ def _resolve_view_container(candidate: ViewContainerFactory | None) -> ViewConta
 
     if candidate is not None:
         return candidate
-    from navigator.infra.di.container.telegram import TelegramContainer  # local import
-
-    return TelegramContainer
+    return resolve_view_container()
 
 
 __all__ = ["NavigatorAssembler", "assemble"]

--- a/bootstrap/navigator/container_resolution.py
+++ b/bootstrap/navigator/container_resolution.py
@@ -1,0 +1,188 @@
+"""Default resolution helpers for container-related collaborators."""
+from __future__ import annotations
+
+import os
+from importlib import import_module
+from typing import Protocol, TypeVar, cast
+
+from .container_types import ContainerBuilder, ViewContainerFactory
+
+
+DEFAULT_VIEW_CONTAINER_PATH = "navigator.infra.di.container.telegram:TelegramContainer"
+DEFAULT_CONTAINER_BUILDER_PATH = "navigator.infra.di.container.builder:NavigatorContainerBuilder"
+ENV_VIEW_CONTAINER = "NAVIGATOR_VIEW_CONTAINER"
+ENV_CONTAINER_BUILDER = "NAVIGATOR_CONTAINER_BUILDER"
+
+
+T_co = TypeVar("T_co")
+
+
+class _Loader(Protocol[T_co]):
+    def __call__(self) -> T_co: ...
+
+
+class ContainerResolutionError(LookupError):
+    """Raised when default container collaborators cannot be resolved."""
+
+
+class _ResolutionState:
+    """Track overrides and cached resolution results."""
+
+    def __init__(self) -> None:
+        self._view_loader: _Loader[ViewContainerFactory] | None = None
+        self._builder_loader: _Loader[ContainerBuilder] | None = None
+        self._view_cache: ViewContainerFactory | None = None
+        self._builder_cache: ContainerBuilder | None = None
+
+    def configure_view_container(
+        self, loader: _Loader[ViewContainerFactory] | ViewContainerFactory
+    ) -> None:
+        self._view_loader = _ensure_view_loader(loader)
+        self._view_cache = None
+
+    def configure_container_builder(
+        self, loader: _Loader[ContainerBuilder] | ContainerBuilder
+    ) -> None:
+        self._builder_loader = _ensure_builder_loader(loader)
+        self._builder_cache = None
+
+    def resolve_view_container(self) -> ViewContainerFactory:
+        if self._view_cache is not None:
+            return self._view_cache
+        loader = self._view_loader or _default_view_loader
+        container = loader()
+        self._view_cache = container
+        return container
+
+    def resolve_container_builder(self) -> ContainerBuilder:
+        if self._builder_cache is not None:
+            return self._builder_cache
+        loader = self._builder_loader or _default_builder_loader
+        builder = loader()
+        if not hasattr(builder, "build"):
+            raise ContainerResolutionError(
+                "Resolved container builder does not expose a 'build' method"
+            )
+        self._builder_cache = builder
+        return builder
+
+
+_state = _ResolutionState()
+
+
+def configure_view_container(
+    factory: _Loader[ViewContainerFactory] | ViewContainerFactory,
+) -> None:
+    """Override the default view container factory resolution."""
+
+    _state.configure_view_container(factory)
+
+
+def configure_container_builder(
+    builder: _Loader[ContainerBuilder] | ContainerBuilder,
+) -> None:
+    """Override the default container builder resolution."""
+
+    _state.configure_container_builder(builder)
+
+
+def resolve_view_container() -> ViewContainerFactory:
+    """Return the default view container factory."""
+
+    try:
+        return _state.resolve_view_container()
+    except (ImportError, AttributeError) as exc:
+        raise ContainerResolutionError("Unable to resolve default view container") from exc
+
+
+def resolve_container_builder() -> ContainerBuilder:
+    """Return the default runtime container builder."""
+
+    try:
+        return _state.resolve_container_builder()
+    except (ImportError, AttributeError, TypeError) as exc:
+        raise ContainerResolutionError("Unable to resolve container builder") from exc
+
+
+def _ensure_view_loader(
+    loader: _Loader[ViewContainerFactory] | ViewContainerFactory,
+) -> _Loader[ViewContainerFactory]:
+    if callable(loader) and not isinstance(loader, type):
+        return cast(_Loader[ViewContainerFactory], loader)
+
+    def _factory() -> ViewContainerFactory:
+        if isinstance(loader, type):
+            return loader
+        return cast(ViewContainerFactory, loader)
+
+    return _factory
+
+
+def _ensure_builder_loader(
+    loader: _Loader[ContainerBuilder] | ContainerBuilder,
+) -> _Loader[ContainerBuilder]:
+    if callable(getattr(loader, "build", None)) and not isinstance(loader, type):
+        return lambda: cast(ContainerBuilder, loader)
+    if callable(loader) and not isinstance(loader, type):
+        return cast(_Loader[ContainerBuilder], loader)
+
+    def _factory() -> ContainerBuilder:
+        if isinstance(loader, type):
+            instance = loader()  # type: ignore[call-arg]
+        else:
+            instance = cast(ContainerBuilder, loader)
+        if not hasattr(instance, "build"):
+            raise ContainerResolutionError(
+                "Configured builder does not provide a 'build' method"
+            )
+        return cast(ContainerBuilder, instance)
+
+    return _factory
+
+
+def _default_view_loader() -> ViewContainerFactory:
+    path = os.getenv(ENV_VIEW_CONTAINER, DEFAULT_VIEW_CONTAINER_PATH)
+    container = _import_symbol(path)
+    if not isinstance(container, type):
+        raise ContainerResolutionError(
+            f"Default view container '{path}' is not a container class"
+        )
+    return cast(ViewContainerFactory, container)
+
+
+def _default_builder_loader() -> ContainerBuilder:
+    path = os.getenv(ENV_CONTAINER_BUILDER, DEFAULT_CONTAINER_BUILDER_PATH)
+    symbol = _import_symbol(path)
+    if isinstance(symbol, type):
+        instance = symbol()  # type: ignore[call-arg]
+    else:
+        instance = symbol
+    if not hasattr(instance, "build"):
+        raise ContainerResolutionError(
+            f"Default builder '{path}' does not implement a 'build' method"
+        )
+    return cast(ContainerBuilder, instance)
+
+
+def _import_symbol(path: str):
+    module_path, _, attribute = path.partition(":")
+    if not module_path or not attribute:
+        raise ContainerResolutionError(
+            f"Invalid module path '{path}' provided for container resolution"
+        )
+    module = import_module(module_path)
+    try:
+        return getattr(module, attribute)
+    except AttributeError as exc:
+        raise ContainerResolutionError(
+            f"Module '{module_path}' does not expose attribute '{attribute}'"
+        ) from exc
+
+
+__all__ = [
+    "ContainerResolutionError",
+    "configure_container_builder",
+    "configure_view_container",
+    "resolve_container_builder",
+    "resolve_view_container",
+]

--- a/bootstrap/navigator/container_types.py
+++ b/bootstrap/navigator/container_types.py
@@ -1,0 +1,54 @@
+"""Type contracts shared across navigator container orchestration."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dependency_injector import containers
+from typing import Protocol
+
+from navigator.app.service.navigator_runtime import MissingAlert
+from navigator.app.service.navigator_runtime.snapshot import NavigatorRuntimeSnapshot
+from navigator.core.telemetry import Telemetry
+
+from .adapter import LedgerAdapter
+
+
+ViewContainerFactory = type[containers.DeclarativeContainer]
+
+
+class RuntimeSnapshotSource(Protocol):
+    """Expose runtime snapshot creation capabilities."""
+
+    def snapshot(self) -> NavigatorRuntimeSnapshot: ...
+
+
+class RuntimeContainer(Protocol):
+    """Expose runtime bindings required by bootstrap orchestration."""
+
+    def runtime(self) -> RuntimeSnapshotSource: ...
+
+
+@dataclass(frozen=True)
+class ContainerRequest:
+    """Payload required to build the runtime container."""
+
+    event: object
+    state: object
+    ledger: LedgerAdapter
+    alert: MissingAlert
+    telemetry: Telemetry
+    view_container: ViewContainerFactory
+
+
+class ContainerBuilder(Protocol):
+    """Protocol describing builders capable of producing runtime containers."""
+
+    def build(self, request: ContainerRequest) -> RuntimeContainer: ...
+
+
+__all__ = [
+    "ContainerBuilder",
+    "ContainerRequest",
+    "RuntimeContainer",
+    "RuntimeSnapshotSource",
+    "ViewContainerFactory",
+]

--- a/bootstrap/navigator/context.py
+++ b/bootstrap/navigator/context.py
@@ -3,11 +3,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from dependency_injector import containers
-
 from navigator.api.contracts import ScopeDTO, ViewLedgerDTO
 from navigator.app.service.navigator_runtime import MissingAlert
 from navigator.core.value.message import Scope
+
+from .container_types import ViewContainerFactory
 
 
 def scope_from_dto(dto: ScopeDTO) -> Scope:
@@ -22,9 +22,6 @@ def scope_from_dto(dto: ScopeDTO) -> Scope:
         topic=getattr(dto, "topic", None),
         direct=bool(getattr(dto, "direct", False)),
     )
-
-
-ViewContainerFactory = type[containers.DeclarativeContainer]
 
 
 @dataclass(frozen=True)

--- a/bootstrap/navigator/inspection.py
+++ b/bootstrap/navigator/inspection.py
@@ -2,13 +2,11 @@
 from __future__ import annotations
 
 from navigator.app.service.navigator_runtime.snapshot import NavigatorRuntimeSnapshot
-from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:
-    from navigator.infra.di.container import AppContainer
+from .container_types import RuntimeContainer
 
 
-def inspect_container(container: "AppContainer") -> NavigatorRuntimeSnapshot:
+def inspect_container(container: RuntimeContainer) -> NavigatorRuntimeSnapshot:
     """Collect runtime dependencies and configuration from the container."""
 
     runtime = container.runtime()

--- a/bootstrap/navigator/runtime/__init__.py
+++ b/bootstrap/navigator/runtime/__init__.py
@@ -8,6 +8,7 @@ from .provision import (
     RuntimeProvision,
     RuntimeProvisioner,
     RuntimeProvisionWorkflow,
+    build_runtime_provisioner,
     TelemetryInitializer,
 )
 
@@ -22,5 +23,6 @@ __all__ = [
     "RuntimeProvision",
     "RuntimeProvisioner",
     "RuntimeProvisionWorkflow",
+    "build_runtime_provisioner",
     "TelemetryInitializer",
 ]

--- a/bootstrap/navigator/runtime/bundle.py
+++ b/bootstrap/navigator/runtime/bundle.py
@@ -2,13 +2,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
-
 from navigator.app.service.navigator_runtime import NavigatorRuntime
 from navigator.core.telemetry import Telemetry
 
-if TYPE_CHECKING:
-    from navigator.infra.di.container import AppContainer
+from ..container_types import RuntimeContainer
 
 
 @dataclass(frozen=True)
@@ -16,7 +13,7 @@ class NavigatorRuntimeBundle:
     """Aggregate runtime services exposed to bootstrap instrumentation."""
 
     telemetry: Telemetry
-    container: "AppContainer"
+    container: RuntimeContainer
     runtime: NavigatorRuntime
 
 

--- a/bootstrap/navigator/runtime/factory.py
+++ b/bootstrap/navigator/runtime/factory.py
@@ -9,7 +9,7 @@ from ..context import BootstrapContext, ViewContainerFactory
 from ..telemetry import TelemetryFactory
 from .bundle import NavigatorRuntimeBundle
 from .composition import NavigatorRuntimeComposer, RuntimeCalibrator
-from .provision import RuntimeProvisioner
+from .provision import RuntimeProvisioner, build_runtime_provisioner
 
 
 class NavigatorFactory(Protocol):
@@ -31,7 +31,7 @@ class ContainerRuntimeFactory(NavigatorFactory):
         composer: NavigatorRuntimeComposer | None = None,
     ) -> None:
         factory = telemetry_factory or TelemetryFactory()
-        self._provisioner = provisioner or RuntimeProvisioner(
+        self._provisioner = provisioner or build_runtime_provisioner(
             factory,
             missing_alert=missing_alert,
             view_container=view_container,

--- a/bootstrap/navigator/runtime/provision.py
+++ b/bootstrap/navigator/runtime/provision.py
@@ -6,13 +6,10 @@ from dataclasses import dataclass
 from navigator.app.service.navigator_runtime import MissingAlert
 from navigator.app.service.navigator_runtime.snapshot import NavigatorRuntimeSnapshot
 from navigator.core.telemetry import Telemetry
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from navigator.infra.di.container import AppContainer
 
 from ..context import BootstrapContext, ViewContainerFactory
 from ..container import ContainerFactory
+from ..container_types import ContainerBuilder, RuntimeContainer
 from ..inspection import inspect_container
 from ..telemetry import TelemetryFactory
 
@@ -22,7 +19,7 @@ class RuntimeProvision:
     """Capture the intermediate components produced during bootstrap."""
 
     telemetry: Telemetry
-    container: "AppContainer"
+    container: RuntimeContainer
     snapshot: NavigatorRuntimeSnapshot
 
 
@@ -44,15 +41,18 @@ class ContainerAssembler:
         *,
         missing_alert: MissingAlert | None = None,
         view_container: ViewContainerFactory | None = None,
+        builder: ContainerBuilder | None = None,
     ) -> None:
         self._missing_alert = missing_alert
         self._view_container = view_container
+        self._builder = builder
 
-    def assemble(self, telemetry: Telemetry, context: BootstrapContext) -> AppContainer:
+    def assemble(self, telemetry: Telemetry, context: BootstrapContext) -> RuntimeContainer:
         factory = ContainerFactory(
             telemetry,
             alert=self._missing_alert,
             view_container=self._view_container,
+            builder=self._builder,
         )
         return factory.create(context)
 
@@ -60,7 +60,7 @@ class ContainerAssembler:
 class ContainerInspector:
     """Produce container diagnostics independently from provisioning."""
 
-    def inspect(self, container: AppContainer) -> NavigatorRuntimeSnapshot:
+    def inspect(self, container: RuntimeContainer) -> NavigatorRuntimeSnapshot:
         return inspect_container(container)
 
 
@@ -82,36 +82,41 @@ class RuntimeProvisionWorkflow:
 class RuntimeProvisioner:
     """Produce the container, telemetry and inspection snapshot."""
 
-    def __init__(
-        self,
-        telemetry_factory: TelemetryFactory,
-        *,
-        missing_alert: MissingAlert | None = None,
-        view_container: ViewContainerFactory | None = None,
-        workflow: RuntimeProvisionWorkflow | None = None,
-        initializer: TelemetryInitializer | None = None,
-        assembler: ContainerAssembler | None = None,
-        inspector: ContainerInspector | None = None,
-    ) -> None:
-        base_workflow = workflow
-        if base_workflow is None:
-            init = initializer or TelemetryInitializer(telemetry_factory)
-            assemble = assembler or ContainerAssembler(
-                missing_alert=missing_alert,
-                view_container=view_container,
-            )
-            review = inspector or ContainerInspector()
-            base_workflow = RuntimeProvisionWorkflow(init, assemble, review)
-        self._workflow = base_workflow
+    def __init__(self, workflow: RuntimeProvisionWorkflow) -> None:
+        self._workflow = workflow
 
     def provision(self, context: BootstrapContext) -> RuntimeProvision:
         return self._workflow.run(context)
+
+
+def build_runtime_provisioner(
+    telemetry_factory: TelemetryFactory,
+    *,
+    missing_alert: MissingAlert | None = None,
+    view_container: ViewContainerFactory | None = None,
+    builder: ContainerBuilder | None = None,
+    initializer: TelemetryInitializer | None = None,
+    assembler: ContainerAssembler | None = None,
+    inspector: ContainerInspector | None = None,
+) -> RuntimeProvisioner:
+    """Create a provisioner backed by the default workflow collaborators."""
+
+    init = initializer or TelemetryInitializer(telemetry_factory)
+    assemble = assembler or ContainerAssembler(
+        missing_alert=missing_alert,
+        view_container=view_container,
+        builder=builder,
+    )
+    review = inspector or ContainerInspector()
+    workflow = RuntimeProvisionWorkflow(init, assemble, review)
+    return RuntimeProvisioner(workflow)
 
 
 __all__ = [
     "ContainerAssembler",
     "ContainerInspector",
     "RuntimeProvision",
+    "build_runtime_provisioner",
     "RuntimeProvisioner",
     "RuntimeProvisionWorkflow",
     "TelemetryInitializer",

--- a/infra/di/container/builder.py
+++ b/infra/di/container/builder.py
@@ -1,0 +1,43 @@
+"""Concrete container builder wiring the application composition root."""
+from __future__ import annotations
+
+from navigator.bootstrap.navigator.container_types import ContainerBuilder, ContainerRequest
+
+from . import AppContainer, CoreBindings, IntegrationBindings, RuntimeBindings, UseCaseBindings
+
+
+class NavigatorContainerBuilder(ContainerBuilder):
+    """Build navigator containers using dependency-injector bindings."""
+
+    def build(self, request: ContainerRequest) -> AppContainer:
+        core = CoreBindings(
+            event=request.event,
+            state=request.state,
+            ledger=request.ledger,
+            alert=request.alert,
+            telemetry=request.telemetry,
+        )
+        integration = IntegrationBindings(
+            core=core,
+            telemetry=request.telemetry,
+            view_container=request.view_container,
+        )
+        usecases = UseCaseBindings(
+            core=core,
+            integration=integration,
+            telemetry=request.telemetry,
+        )
+        runtime = RuntimeBindings(
+            core=core,
+            usecases=usecases,
+            telemetry=request.telemetry,
+        )
+        return AppContainer(
+            core=core,
+            integration=integration,
+            usecases=usecases,
+            runtime_bindings=runtime,
+        )
+
+
+__all__ = ["NavigatorContainerBuilder"]

--- a/presentation/telegram/assembly.py
+++ b/presentation/telegram/assembly.py
@@ -8,11 +8,13 @@ from aiogram.fsm.context import FSMContext
 from aiogram.types import TelegramObject
 
 from navigator.api import assemble as assemble_navigator
-from navigator.api.contracts import NavigatorRuntimeInstrument
+from navigator.api.contracts import (
+    NavigatorAssemblyOverrides,
+    NavigatorRuntimeInstrument,
+)
 from navigator.app.service.navigator_runtime import MissingAlert
 from navigator.core.port.factory import ViewLedger
 from navigator.presentation.navigator import Navigator
-from navigator.bootstrap.navigator.context import ViewContainerFactory
 
 from .alerts import missing
 from .instrumentation import instrument as default_instrument
@@ -34,14 +36,14 @@ class TelegramNavigatorAssembler:
         *,
         instrumentation: Iterable[NavigatorRuntimeInstrument] | None = None,
         missing_alert: MissingAlert | None = None,
-        view_container: ViewContainerFactory | None = None,
+        overrides: NavigatorAssemblyOverrides | None = None,
     ) -> None:
         self._ledger = ledger
         self._instrumentation: Sequence[NavigatorRuntimeInstrument] | None = (
             tuple(instrumentation) if instrumentation is not None else None
         )
         self._missing_alert = missing_alert or missing
-        self._view_container = view_container
+        self._overrides = overrides
 
     async def assemble(self, event: TelegramObject, state: FSMContext) -> Navigator:
         instrumentation = self._instrumentation or (default_instrument,)
@@ -52,7 +54,7 @@ class TelegramNavigatorAssembler:
             scope=outline(event),
             instrumentation=instrumentation,
             missing_alert=self._missing_alert,
-            view_container=self._view_container,
+            overrides=self._overrides,
         )
         return navigator
 


### PR DESCRIPTION
## Summary
- add container resolution utilities and a builder to decouple bootstrap from the Telegram-specific DI container
- refactor runtime provisioning to rely on the new builder and slim down the AppContainer responsibilities
- expose API overrides so the presentation layer no longer depends on bootstrap container types

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'manual')*

------
https://chatgpt.com/codex/tasks/task_e_68d7420d59708330b56e93afdab0cca2