### PR TITLE
Refactor navigator back handling and container resolution

### DIFF
--- a/api/contracts.py
+++ b/api/contracts.py
@@ -1,8 +1,12 @@
-"""Public contracts exposed by the navigator API layer."""
+"""Contracts describing navigator assembly inputs and outputs."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Awaitable, Protocol, runtime_checkable
+from typing import Any, Awaitable, Protocol, SupportsInt, runtime_checkable
+
+from ..app.service.navigator_runtime.back_context import NavigatorBackContext
+from ..app.service.navigator_runtime.types import StateLike
 
 
 @dataclass(slots=True)
@@ -35,10 +39,45 @@ class ViewLedgerDTO(Protocol):
 
 
 @runtime_checkable
+class NavigatorHistoryLike(Protocol):
+    """Protocol describing history oriented facade capabilities."""
+
+    async def add(self, *args: Any, **kwargs: Any) -> Any: ...
+
+    async def replace(self, *args: Any, **kwargs: Any) -> Any: ...
+
+    async def rebase(self, message: int | SupportsInt) -> Any: ...
+
+    async def back(self, context: NavigatorBackContext) -> Any: ...
+
+    async def pop(self, count: int = 1) -> Any: ...
+
+
+@runtime_checkable
+class NavigatorStateLike(Protocol):
+    """Protocol describing state oriented facade capabilities."""
+
+    async def set(
+        self, state: str | StateLike, context: dict[str, object] | None = None
+    ) -> Any: ...
+
+    async def alert(self) -> Any: ...
+
+
+@runtime_checkable
+class NavigatorTailLike(Protocol):
+    """Protocol describing tail oriented facade capabilities."""
+
+    async def edit_last(self, content: Any) -> Any: ...
+
+
+@runtime_checkable
 class NavigatorLike(Protocol):
     """Protocol describing the facade returned by :func:`assemble`."""
 
-    async def add(self, *args: Any, **kwargs: Any) -> Any: ...
+    history: NavigatorHistoryLike
+    state: NavigatorStateLike
+    tail: NavigatorTailLike
 
 
 @runtime_checkable
@@ -58,9 +97,12 @@ class NavigatorRuntimeInstrument(Protocol):
 
 __all__ = [
     "NavigatorAssemblyOverrides",
+    "NavigatorHistoryLike",
     "NavigatorLike",
     "NavigatorRuntimeBundleLike",
     "NavigatorRuntimeInstrument",
+    "NavigatorStateLike",
+    "NavigatorTailLike",
     "ScopeDTO",
     "ViewLedgerDTO",
 ]

--- a/app/service/navigator_runtime/__init__.py
+++ b/app/service/navigator_runtime/__init__.py
@@ -4,8 +4,14 @@ from __future__ import annotations
 from .assembly import build_runtime_from_dependencies
 from .builder import build_navigator_runtime
 from .contracts import HistoryContracts, NavigatorRuntimeContracts, StateContracts, TailContracts
+from .back_context import NavigatorBackContext, NavigatorBackEvent
 from .bundler import PayloadBundler
-from .facade import NavigatorFacade
+from .facade import (
+    NavigatorFacade,
+    NavigatorHistoryFacade,
+    NavigatorStateFacade,
+    NavigatorTailFacade,
+)
 from .history import (
     HistoryAddOperation,
     HistoryBackOperation,
@@ -24,6 +30,8 @@ from .types import MissingAlert
 from .usecases import NavigatorUseCases
 
 __all__ = [
+    "NavigatorBackContext",
+    "NavigatorBackEvent",
     "build_navigator_runtime",
     "build_runtime_from_dependencies",
     "HistoryAddOperation",
@@ -34,10 +42,13 @@ __all__ = [
     "HistoryContracts",
     "MissingAlert",
     "NavigatorFacade",
+    "NavigatorHistoryFacade",
     "MissingStateAlarm",
     "NavigatorHistoryService",
+    "NavigatorStateFacade",
     "NavigatorReporter",
     "NavigatorRuntime",
+    "NavigatorTailFacade",
     "NavigatorRuntimeSnapshot",
     "NavigatorRuntimeContracts",
     "NavigatorStateService",

--- a/app/service/navigator_runtime/back_context.py
+++ b/app/service/navigator_runtime/back_context.py
@@ -1,0 +1,71 @@
+"""Domain oriented context objects for navigator back operations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping
+
+
+@dataclass(frozen=True, slots=True)
+class NavigatorBackEvent:
+    """Structured representation of UI callback data relevant for rewind."""
+
+    id: str
+    data: str | None
+    inline_message_id: str | None
+    chat_instance: str | None
+    message_id: int | None
+    message_chat_id: int | None
+    message_thread_id: int | None
+    message_chat_type: str | None
+    user_id: int | None
+    user_language: str | None
+    user_username: str | None
+    user_first_name: str | None
+    user_last_name: str | None
+
+    def as_mapping(self) -> dict[str, Any]:
+        """Return the event fields as a plain mapping."""
+
+        return {
+            "id": self.id,
+            "data": self.data,
+            "inline_message_id": self.inline_message_id,
+            "chat_instance": self.chat_instance,
+            "message_id": self.message_id,
+            "message_chat_id": self.message_chat_id,
+            "message_thread_id": self.message_thread_id,
+            "message_chat_type": self.message_chat_type,
+            "user_id": self.user_id,
+            "user_language": self.user_language,
+            "user_username": self.user_username,
+            "user_first_name": self.user_first_name,
+            "user_last_name": self.user_last_name,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class NavigatorBackContext:
+    """Stable contract passed from the presentation layer into rewind use cases."""
+
+    payload: Mapping[str, Any]
+    event: NavigatorBackEvent | None = None
+
+    def as_mapping(self) -> dict[str, Any]:
+        """Return a mutable mapping merging payload and structured event."""
+
+        data = dict(self.payload)
+        if self.event is not None:
+            data.setdefault("event", self.event.as_mapping())
+        return data
+
+    def handler_names(self) -> Iterable[str]:
+        """Return the logical handler keys present inside the context."""
+
+        handlers = set(self.payload.keys())
+        if self.event is not None:
+            handlers.add("event")
+        return sorted(handlers)
+
+
+__all__ = ["NavigatorBackContext", "NavigatorBackEvent"]

--- a/app/service/navigator_runtime/history.py
+++ b/app/service/navigator_runtime/history.py
@@ -1,12 +1,12 @@
 """History-oriented operations orchestrated by the navigator runtime."""
 from __future__ import annotations
 
-from collections.abc import Mapping
 from typing import Any, Awaitable, Callable, SupportsInt
 
 from navigator.app.locks.guard import Guardian
 
 from .bundler import PayloadBundleSource, PayloadBundler
+from .back_context import NavigatorBackContext
 from .ports import (
     AppendHistoryUseCase,
     RebaseHistoryUseCase,
@@ -141,8 +141,8 @@ class HistoryBackOperation(_HistoryOperation):
         super().__init__(guard=guard, scope=scope, reporter=reporter)
         self._rewinder = rewinder
 
-    async def __call__(self, context: dict[str, Any]) -> None:
-        handlers = sorted(context.keys()) if isinstance(context, Mapping) else None
+    async def __call__(self, context: NavigatorBackContext) -> None:
+        handlers = list(context.handler_names())
 
         async def action() -> None:
             await self._rewinder.execute(self._scope, context)
@@ -205,7 +205,7 @@ class NavigatorHistoryService:
     async def rebase(self, message: int | SupportsInt) -> None:
         await self._rebase(message)
 
-    async def back(self, context: dict[str, Any]) -> None:
+    async def back(self, context: NavigatorBackContext) -> None:
         await self._back(context)
 
     async def pop(self, count: int = 1) -> None:

--- a/app/service/navigator_runtime/ports.py
+++ b/app/service/navigator_runtime/ports.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from typing import Any, Protocol
 
 from navigator.core.value.content import Payload
 from navigator.core.value.message import Scope
+
+from .back_context import NavigatorBackContext
 
 
 class AppendHistoryUseCase(Protocol):
@@ -40,7 +42,7 @@ class RebaseHistoryUseCase(Protocol):
 class RewindHistoryUseCase(Protocol):
     """Navigate backwards in history using optional handler context."""
 
-    async def execute(self, scope: Scope, context: Mapping[str, Any]) -> None:
+    async def execute(self, scope: Scope, context: NavigatorBackContext) -> None:
         ...
 
 

--- a/bootstrap/navigator/runtime/__init__.py
+++ b/bootstrap/navigator/runtime/__init__.py
@@ -7,9 +7,8 @@ from .provision import (
     ContainerInspector,
     RuntimeProvision,
     RuntimeProvisioner,
-    RuntimeProvisionWorkflow,
-    build_runtime_provisioner,
     TelemetryInitializer,
+    build_runtime_provisioner,
 )
 
 __all__ = [
@@ -22,7 +21,6 @@ __all__ = [
     "RuntimeCalibrator",
     "RuntimeProvision",
     "RuntimeProvisioner",
-    "RuntimeProvisionWorkflow",
     "build_runtime_provisioner",
     "TelemetryInitializer",
 ]

--- a/infra/di/container/__init__.py
+++ b/infra/di/container/__init__.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from dependency_injector import containers, providers
-from aiogram.fsm.context import FSMContext
+
+from navigator.adapters.storage.fsm.context import StateContext
 from navigator.core.port.factory import ViewLedger
 from navigator.core.telemetry import Telemetry
 
@@ -19,7 +20,7 @@ class CoreBindings(containers.DeclarativeContainer):
     """Expose base dependencies shared across modules."""
 
     event = providers.Dependency()
-    state = providers.Dependency(instance_of=FSMContext)
+    state = providers.Dependency(instance_of=StateContext)
     ledger = providers.Dependency(instance_of=ViewLedger)
     alert = providers.Dependency()
     telemetry = providers.Dependency(instance_of=Telemetry)

--- a/presentation/telegram/back/context.py
+++ b/presentation/telegram/back/context.py
@@ -2,43 +2,29 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Mapping, MutableMapping
+from typing import Mapping, MutableMapping
 
 from aiogram.types import CallbackQuery, Message, User
 
-
-@dataclass(frozen=True, slots=True)
-class RetreatEvent:
-    """Lightweight representation of callback events required by rewind."""
-
-    id: str
-    data: str | None
-    inline_message_id: str | None
-    chat_instance: str | None
-    message_id: int | None
-    message_chat_id: int | None
-    message_thread_id: int | None
-    message_chat_type: str | None
-    user_id: int | None
-    user_language: str | None
-    user_username: str | None
-    user_first_name: str | None
-    user_last_name: str | None
+from navigator.app.service.navigator_runtime.back_context import (
+    NavigatorBackContext,
+    NavigatorBackEvent,
+)
 
 
 class RetreatContextBuilder:
     """Create navigator context payloads for retreat execution."""
 
-    def build(self, cb: CallbackQuery, payload: Mapping[str, Any]) -> dict[str, Any]:
-        """Return a copy of ``payload`` augmented with sanitized event data."""
+    def build(
+        self, cb: CallbackQuery, payload: Mapping[str, object]
+    ) -> NavigatorBackContext:
+        """Return navigator back context augmented with sanitized event data."""
 
-        context: MutableMapping[str, Any] = dict(payload)
-        context["event"] = self._event(cb)
-        return dict(context)
+        context: MutableMapping[str, object] = dict(payload)
+        return NavigatorBackContext(context, self._event(cb))
 
-    def _event(self, cb: CallbackQuery) -> RetreatEvent:
-        return RetreatEvent(
+    def _event(self, cb: CallbackQuery) -> NavigatorBackEvent:
+        return NavigatorBackEvent(
             id=cb.id,
             data=cb.data,
             inline_message_id=cb.inline_message_id,

--- a/presentation/telegram/back/handler.py
+++ b/presentation/telegram/back/handler.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Mapping
 
 from aiogram.types import CallbackQuery
 
@@ -26,7 +26,7 @@ class RetreatHandler:
         self,
         cb: CallbackQuery,
         navigator: NavigatorBack,
-        payload: dict[str, Any],
+        payload: Mapping[str, object],
     ) -> RetreatOutcome:
         result = await self._orchestrator.execute(cb, navigator, payload)
         return self._outcomes.render(result, cb)

--- a/presentation/telegram/back/orchestrator.py
+++ b/presentation/telegram/back/orchestrator.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 from aiogram.types import CallbackQuery
 
 from .protocols import NavigatorBack
@@ -26,7 +28,7 @@ class RetreatOrchestrator:
         self,
         cb: CallbackQuery,
         navigator: NavigatorBack,
-        payload: dict[str, object],
+        payload: Mapping[str, object],
     ) -> RetreatResult:
         scope = self._telemetry.scope(cb)
         self._telemetry.entered(scope)

--- a/presentation/telegram/back/protocols.py
+++ b/presentation/telegram/back/protocols.py
@@ -3,14 +3,20 @@
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any, Protocol
+from typing import Protocol
+
+from navigator.app.service.navigator_runtime.back_context import NavigatorBackContext
+
+
+class RetreatHistory(Protocol):
+    async def back(self, context: NavigatorBackContext) -> None: ...
 
 
 class NavigatorBack(Protocol):
-    async def back(self, context: dict[str, Any]) -> None: ...
+    history: RetreatHistory
 
 
 Translator = Callable[[str, str], str]
 
 
-__all__ = ["NavigatorBack", "Translator"]
+__all__ = ["NavigatorBack", "RetreatHistory", "Translator"]

--- a/presentation/telegram/back/workflow.py
+++ b/presentation/telegram/back/workflow.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Mapping
 
 from aiogram.types import CallbackQuery
 
+from navigator.app.service.navigator_runtime.back_context import NavigatorBackContext
 from navigator.app.service.retreat_failure import RetreatFailureResolver
 
 from .context import RetreatContextBuilder
@@ -29,11 +30,11 @@ class RetreatWorkflow:
         self,
         cb: CallbackQuery,
         navigator: NavigatorBack,
-        payload: dict[str, Any],
+        payload: Mapping[str, object],
     ) -> RetreatResult:
         try:
-            context = self._context.build(cb, payload)
-            await navigator.back(context=context)
+            context: NavigatorBackContext = self._context.build(cb, payload)
+            await navigator.history.back(context=context)
         except Exception as error:  # pragma: no cover - mapper branch
             note = self._failures.translate(error)
             if note is None:


### PR DESCRIPTION
## Summary
- Introduce structured navigator back context objects to insulate rewind use cases from Telegram callback payloads and update the history workflow accordingly
- Split the navigator facade into history, state, and tail sub-facades while aligning public API contracts and Telegram retreat orchestration with the new shape
- Remove the shared container resolution singleton, simplify runtime provisioning, and depend on the StateContext protocol in the DI container

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'manual')*

------
https://chatgpt.com/codex/tasks/task_e_68d7468743c88330af51a525f3023ecd