### PR TITLE
Refactor navigator contracts to reduce layer coupling

### DIFF
--- a/api/contracts.py
+++ b/api/contracts.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Awaitable, Protocol, SupportsInt, runtime_checkable
 
-from ..app.service.navigator_runtime.back_context import NavigatorBackContext
-from ..app.service.navigator_runtime.types import StateLike
+from ..core.contracts.back import NavigatorBackContext
+from ..core.contracts.state import StateLike
 
 
 @dataclass(slots=True)

--- a/app/service/navigator_runtime/__init__.py
+++ b/app/service/navigator_runtime/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from .assembly import build_runtime_from_dependencies
 from .builder import build_navigator_runtime
 from .contracts import HistoryContracts, NavigatorRuntimeContracts, StateContracts, TailContracts
-from .back_context import NavigatorBackContext, NavigatorBackEvent
+from navigator.core.contracts.back import NavigatorBackContext, NavigatorBackEvent
 from .bundler import PayloadBundler
 from .facade import (
     NavigatorFacade,

--- a/app/service/navigator_runtime/contracts.py
+++ b/app/service/navigator_runtime/contracts.py
@@ -3,15 +3,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from navigator.app.usecase.alarm import Alarm
-from navigator.app.usecase.last import Tailer
-from navigator.app.usecase.set import Setter
-
 from .ports import (
+    AlarmUseCase,
     AppendHistoryUseCase,
     RebaseHistoryUseCase,
     ReplaceHistoryUseCase,
     RewindHistoryUseCase,
+    SetStateUseCase,
+    TailUseCase,
     TrimHistoryUseCase,
 )
 from .usecases import NavigatorUseCases
@@ -32,15 +31,15 @@ class HistoryContracts:
 class StateContracts:
     """Expose state-oriented use cases required by the runtime."""
 
-    setter: Setter
-    alarm: Alarm
+    setter: SetStateUseCase
+    alarm: AlarmUseCase
 
 
 @dataclass(frozen=True)
 class TailContracts:
     """Expose tail-specific collaborators required by the runtime."""
 
-    tailer: Tailer
+    tailer: TailUseCase
 
 
 @dataclass(frozen=True)

--- a/app/service/navigator_runtime/facade.py
+++ b/app/service/navigator_runtime/facade.py
@@ -6,14 +6,14 @@ from typing import Any, SupportsInt
 
 from navigator.app.dto.content import Content, Node
 
-from .back_context import NavigatorBackContext
+from navigator.core.contracts.back import NavigatorBackContext
 from .bundler import bundle_from_dto
 from .history import NavigatorHistoryService
 from .runtime import NavigatorRuntime
 from .state import NavigatorStateService
 from .tail import NavigatorTail
 from .tail_components import dto_edit_request
-from .types import StateLike
+from navigator.core.contracts.state import StateLike
 
 
 @dataclass(frozen=True)

--- a/app/service/navigator_runtime/history.py
+++ b/app/service/navigator_runtime/history.py
@@ -6,7 +6,7 @@ from typing import Any, Awaitable, Callable, SupportsInt
 from navigator.app.locks.guard import Guardian
 
 from .bundler import PayloadBundleSource, PayloadBundler
-from .back_context import NavigatorBackContext
+from navigator.core.contracts.back import NavigatorBackContext
 from .ports import (
     AppendHistoryUseCase,
     RebaseHistoryUseCase,

--- a/app/service/navigator_runtime/ports.py
+++ b/app/service/navigator_runtime/ports.py
@@ -5,10 +5,9 @@ from __future__ import annotations
 from collections.abc import Sequence
 from typing import Any, Protocol
 
+from navigator.core.contracts.back import NavigatorBackContext
 from navigator.core.value.content import Payload
 from navigator.core.value.message import Scope
-
-from .back_context import NavigatorBackContext
 
 
 class AppendHistoryUseCase(Protocol):
@@ -53,10 +52,40 @@ class TrimHistoryUseCase(Protocol):
         ...
 
 
+class SetStateUseCase(Protocol):
+    """Restore a state goal for the provided scope."""
+
+    async def execute(self, scope: Scope, goal: str, context: dict[str, Any]) -> None:
+        ...
+
+
+class AlarmUseCase(Protocol):
+    """Trigger alert notifications for the supplied scope."""
+
+    async def execute(self, scope: Scope, text: str | None = None) -> None:
+        ...
+
+
+class TailUseCase(Protocol):
+    """Coordinate tail operations for conversation history."""
+
+    async def peek(self) -> int | None:
+        ...
+
+    async def delete(self, scope: Scope) -> None:
+        ...
+
+    async def edit(self, scope: Scope, payload: Payload) -> int | None:
+        ...
+
+
 __all__ = [
     "AppendHistoryUseCase",
+    "AlarmUseCase",
     "RebaseHistoryUseCase",
     "ReplaceHistoryUseCase",
     "RewindHistoryUseCase",
+    "SetStateUseCase",
+    "TailUseCase",
     "TrimHistoryUseCase",
 ]

--- a/app/service/navigator_runtime/state.py
+++ b/app/service/navigator_runtime/state.py
@@ -4,12 +4,11 @@ from __future__ import annotations
 from typing import Any, Protocol
 
 from navigator.app.locks.guard import Guardian
-from navigator.app.usecase.alarm import Alarm
-from navigator.app.usecase.set import Setter
 from navigator.core.error import StateNotFound
 from navigator.core.value.message import Scope
 
 from .reporter import NavigatorReporter
+from .ports import AlarmUseCase, SetStateUseCase
 from .types import MissingAlert
 
 
@@ -25,7 +24,7 @@ class MissingStateAlarm:
     def __init__(
         self,
         *,
-        alarm: Alarm,
+        alarm: AlarmUseCase,
         scope: Scope,
         factory: MissingAlert | None = None,
     ) -> None:
@@ -44,7 +43,7 @@ class StateAlertManager:
     def __init__(
         self,
         *,
-        alarm: Alarm,
+        alarm: AlarmUseCase,
         scope: Scope,
         missing_alarm: MissingStateAlarm | None = None,
     ) -> None:
@@ -68,7 +67,7 @@ class StateOperationExecutor:
     def __init__(
         self,
         *,
-        setter: Setter,
+        setter: SetStateUseCase,
         guard: Guardian,
         scope: Scope,
         alerts: StateAlertManager,

--- a/app/service/navigator_runtime/tail_components/gateway.py
+++ b/app/service/navigator_runtime/tail_components/gateway.py
@@ -9,13 +9,13 @@ from navigator.app.service.navigator_runtime.tail_components.edit_request import
 from navigator.app.service.navigator_runtime.tail_components.converter import (
     TailPayloadConverter,
 )
-from navigator.app.usecase.last import Tailer
+from navigator.app.service.navigator_runtime.ports import TailUseCase
 
 
 class TailGateway:
     """Adapt navigator tail use cases for runtime consumption."""
 
-    def __init__(self, flow: Tailer, *, converter: TailPayloadConverter | None = None) -> None:
+    def __init__(self, flow: TailUseCase, *, converter: TailPayloadConverter | None = None) -> None:
         self._flow = flow
         self._converter = converter or TailPayloadConverter()
 

--- a/app/service/navigator_runtime/types.py
+++ b/app/service/navigator_runtime/types.py
@@ -1,18 +1,13 @@
 """Shared type aliases used across navigator runtime components."""
 from __future__ import annotations
 
-from typing import Callable, Protocol
+from typing import Callable
 
 from navigator.core.value.message import Scope
+from navigator.core.contracts.state import StateLike
 
 
 MissingAlert = Callable[[Scope], str]
-
-
-class StateLike(Protocol):
-    """Protocol describing objects exposing an FSM state string."""
-
-    state: str
 
 
 __all__ = ["MissingAlert", "StateLike"]

--- a/app/service/navigator_runtime/usecases.py
+++ b/app/service/navigator_runtime/usecases.py
@@ -3,15 +3,14 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from navigator.app.usecase.alarm import Alarm
-from navigator.app.usecase.last import Tailer
-from navigator.app.usecase.set import Setter
-
 from .ports import (
+    AlarmUseCase,
     AppendHistoryUseCase,
     RebaseHistoryUseCase,
     ReplaceHistoryUseCase,
     RewindHistoryUseCase,
+    SetStateUseCase,
+    TailUseCase,
     TrimHistoryUseCase,
 )
 
@@ -23,11 +22,11 @@ class NavigatorUseCases:
     appender: AppendHistoryUseCase
     swapper: ReplaceHistoryUseCase
     rewinder: RewindHistoryUseCase
-    setter: Setter
+    setter: SetStateUseCase
     trimmer: TrimHistoryUseCase
     shifter: RebaseHistoryUseCase
-    tailer: Tailer
-    alarm: Alarm
+    tailer: TailUseCase
+    alarm: AlarmUseCase
 
 
 __all__ = ["NavigatorUseCases"]

--- a/app/usecase/back.py
+++ b/app/usecase/back.py
@@ -9,7 +9,7 @@ from ...core.value.content import normalize
 from ...core.value.message import Scope
 from ..log import events
 from ..log.aspect import TraceAspect
-from ..service.navigator_runtime.back_context import NavigatorBackContext
+from ...core.contracts.back import NavigatorBackContext
 from .back_access import (
     RewindFinalizer,
     RewindHistoryReader,

--- a/app/usecase/render_contract.py
+++ b/app/usecase/render_contract.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Protocol, Sequence, runtime_checkable
+from typing import Optional, Protocol, Sequence, runtime_checkable
 
+from navigator.core.entity.history import Entry
+from navigator.core.value.content import Payload
+from navigator.core.value.message import Scope
 from navigator.core.typing.result import Meta
 
 
@@ -17,5 +20,20 @@ class RenderOutcome(Protocol):
     changed: bool
 
 
-__all__ = ["RenderOutcome"]
+@runtime_checkable
+class RenderPlanner(Protocol):
+    """Structural contract for components able to plan renders."""
+
+    async def render(
+        self,
+        scope: Scope,
+        payloads: Sequence[Payload],
+        trail: Entry | None,
+        *,
+        inline: bool,
+    ) -> Optional[RenderOutcome]:
+        ...
+
+
+__all__ = ["RenderOutcome", "RenderPlanner"]
 

--- a/app/usecase/set.py
+++ b/app/usecase/set.py
@@ -6,11 +6,11 @@ from typing import Any, Dict, Optional
 
 from ..log import events
 from ..log.aspect import TraceAspect
-from ..service.view.planner import RenderNode, ViewPlanner
 from ...core.entity.history import Entry
 from ...core.value.content import Payload
 from ...core.telemetry import Telemetry
 from ...core.value.message import Scope
+from .render_contract import RenderOutcome, RenderPlanner
 from .set_components import (
     HistoryReconciler,
     HistoryRestorationPlanner,
@@ -28,7 +28,7 @@ class Setter:
             planner: HistoryRestorationPlanner,
             state: StateSynchronizer,
             reviver: PayloadReviver,
-            renderer: ViewPlanner,
+            renderer: RenderPlanner,
             reconciler: HistoryReconciler,
             telemetry: Telemetry,
     ):
@@ -73,7 +73,7 @@ class Setter:
             resolved: list[Payload],
             tail: Entry,
             inline: bool,
-    ) -> Optional[RenderNode]:
+    ) -> Optional[RenderOutcome]:
         """Render ``resolved`` payloads against ``tail`` context."""
 
         return await self._renderer.render(

--- a/core/contracts/__init__.py
+++ b/core/contracts/__init__.py
@@ -1,0 +1,6 @@
+"""Public contracts shared across layers."""
+
+from .back import NavigatorBackContext, NavigatorBackEvent
+from .state import StateLike
+
+__all__ = ["NavigatorBackContext", "NavigatorBackEvent", "StateLike"]

--- a/core/contracts/back.py
+++ b/core/contracts/back.py
@@ -1,4 +1,4 @@
-"""Domain oriented context objects for navigator back operations."""
+"""Shared rewind context contracts decoupled from service details."""
 
 from __future__ import annotations
 
@@ -46,7 +46,7 @@ class NavigatorBackEvent:
 
 @dataclass(frozen=True, slots=True)
 class NavigatorBackContext:
-    """Stable contract passed from the presentation layer into rewind use cases."""
+    """Stable contract passed from presentation into rewind use cases."""
 
     payload: Mapping[str, Any]
     event: NavigatorBackEvent | None = None
@@ -69,3 +69,4 @@ class NavigatorBackContext:
 
 
 __all__ = ["NavigatorBackContext", "NavigatorBackEvent"]
+

--- a/core/contracts/state.py
+++ b/core/contracts/state.py
@@ -1,0 +1,15 @@
+"""Shared state-related contracts available to external consumers."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class StateLike(Protocol):
+    """Protocol describing objects exposing an FSM state string."""
+
+    state: str
+
+
+__all__ = ["StateLike"]
+

--- a/presentation/telegram/back/context.py
+++ b/presentation/telegram/back/context.py
@@ -6,10 +6,7 @@ from typing import Mapping, MutableMapping
 
 from aiogram.types import CallbackQuery, Message, User
 
-from navigator.app.service.navigator_runtime.back_context import (
-    NavigatorBackContext,
-    NavigatorBackEvent,
-)
+from navigator.core.contracts.back import NavigatorBackContext, NavigatorBackEvent
 
 
 class RetreatContextBuilder:

--- a/presentation/telegram/back/protocols.py
+++ b/presentation/telegram/back/protocols.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import Protocol
 
-from navigator.app.service.navigator_runtime.back_context import NavigatorBackContext
+from navigator.core.contracts.back import NavigatorBackContext
 
 
 class RetreatHistory(Protocol):

--- a/presentation/telegram/back/workflow.py
+++ b/presentation/telegram/back/workflow.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping
 
 from aiogram.types import CallbackQuery
 
-from navigator.app.service.navigator_runtime.back_context import NavigatorBackContext
+from navigator.core.contracts.back import NavigatorBackContext
 from navigator.app.service.retreat_failure import RetreatFailureResolver
 
 from .context import RetreatContextBuilder

--- a/presentation/types.py
+++ b/presentation/types.py
@@ -1,12 +1,6 @@
 from __future__ import annotations
 
-from typing import Protocol
-
-
-class StateLike(Protocol):
-    """Protocol describing objects exposing an FSM state string."""
-
-    state: str
+from navigator.core.contracts.state import StateLike
 
 
 __all__ = ["StateLike"]


### PR DESCRIPTION
## Summary
- extract shared back-context and state contracts into `navigator.core.contracts` and update API, presentation, and use-cases to consume them
- update navigator runtime ports and state services to depend on structural protocols instead of concrete use case classes, breaking service<->use case cycles
- simplify container resolution by introducing an immutable `ContainerResolver` without global caches

## Testing
- python -m compileall core app api bootstrap presentation

------
https://chatgpt.com/codex/tasks/task_e_68d74ec7d21083308b989465e34f2a92