### PR TITLE
Refactor telegram assembly and container resolution

### DIFF
--- a/bootstrap/navigator/container.py
+++ b/bootstrap/navigator/container.py
@@ -6,6 +6,7 @@ from navigator.core.telemetry import Telemetry
 
 from .adapter import LedgerAdapter
 from .container_collaborators import ContainerCollaboratorsResolver
+from .container_resolution import ContainerResolution, create_container_resolution
 from .container_types import ContainerBuilder, ContainerRequest, RuntimeContainer
 from .context import BootstrapContext, ViewContainerFactory
 
@@ -20,12 +21,14 @@ class ContainerFactory:
         alert: MissingAlert | None = None,
         view_container: ViewContainerFactory | None = None,
         builder: ContainerBuilder | None = None,
+        resolution: ContainerResolution | None = None,
     ) -> None:
         self._telemetry = telemetry
         self._alert = alert or (lambda scope: "")
         self._collaborators = ContainerCollaboratorsResolver(
             default_view=view_container,
             default_builder=builder,
+            resolution=resolution or create_container_resolution(),
         )
 
     def create(self, context: BootstrapContext) -> RuntimeContainer:

--- a/bootstrap/navigator/container_collaborators.py
+++ b/bootstrap/navigator/container_collaborators.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from .container_resolution import resolve_container_builder, resolve_view_container
+from .container_resolution import ContainerResolution, create_container_resolution
 from .container_types import ContainerBuilder, ViewContainerFactory
 from .context import BootstrapContext
 
@@ -24,15 +24,17 @@ class ContainerCollaboratorsResolver:
         *,
         default_view: ViewContainerFactory | None = None,
         default_builder: ContainerBuilder | None = None,
+        resolution: ContainerResolution | None = None,
     ) -> None:
         self._default_view = default_view
         self._default_builder = default_builder
+        self._resolution = resolution or create_container_resolution()
 
     def resolve(self, context: BootstrapContext) -> ContainerCollaborators:
         view_container = context.view_container or self._default_view
         if view_container is None:
-            view_container = resolve_view_container()
-        builder = self._default_builder or resolve_container_builder()
+            view_container = self._resolution.resolve_view_container()
+        builder = self._default_builder or self._resolution.resolve_container_builder()
         return ContainerCollaborators(builder=builder, view_container=view_container)
 
 

--- a/entrypoints/telegram/assemble.py
+++ b/entrypoints/telegram/assemble.py
@@ -3,14 +3,19 @@ from __future__ import annotations
 from typing import Any, TYPE_CHECKING
 
 from navigator.core.port.factory import ViewLedger
-from navigator.presentation.telegram.assembly import TelegramNavigatorAssembler
+from navigator.presentation.telegram.assembly import (
+    TelegramNavigatorAssembler,
+    TelegramRuntimeConfiguration,
+)
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from navigator.presentation.navigator import Navigator
 
 
 async def assemble(event: Any, state: Any, ledger: ViewLedger) -> "Navigator":
-    assembler = TelegramNavigatorAssembler(ledger)
+    assembler = TelegramNavigatorAssembler(
+        ledger, configuration=TelegramRuntimeConfiguration.create()
+    )
     return await assembler.assemble(event, state)
 
 

--- a/presentation/telegram/back/__init__.py
+++ b/presentation/telegram/back/__init__.py
@@ -13,7 +13,7 @@ from .providers import default_retreat_providers
 from .protocols import NavigatorBack, Translator
 from .result import RetreatResult
 from .telemetry import RetreatTelemetry
-from .workflow import RetreatWorkflow
+from .workflow import RetreatBackExecutor, RetreatFailureHandler, RetreatWorkflow
 
 __all__ = [
     "NavigatorBack",
@@ -25,6 +25,8 @@ __all__ = [
     "RetreatOutcome",
     "RetreatResult",
     "RetreatTelemetry",
+    "RetreatBackExecutor",
+    "RetreatFailureHandler",
     "RetreatWorkflow",
     "Translator",
     "default_retreat_providers",

--- a/presentation/telegram/back/providers.py
+++ b/presentation/telegram/back/providers.py
@@ -18,7 +18,7 @@ def default_retreat_providers() -> RetreatHandlerProviders:
     def build_workflow(
         context: RetreatContextBuilder, failures: RetreatFailureResolver
     ) -> RetreatWorkflow:
-        return RetreatWorkflow(context=context, failures=failures)
+        return RetreatWorkflow.from_builders(context=context, failures=failures)
 
     def build_orchestrator(
         instrumentation: RetreatTelemetry, workflow: RetreatWorkflow

--- a/presentation/telegram/back/workflow.py
+++ b/presentation/telegram/back/workflow.py
@@ -14,17 +14,58 @@ from .protocols import NavigatorBack
 from .result import RetreatResult
 
 
+class RetreatBackExecutor:
+    """Construct navigator contexts and invoke retreat operations."""
+
+    def __init__(self, context: RetreatContextBuilder) -> None:
+        self._context = context
+
+    async def execute(
+        self,
+        cb: CallbackQuery,
+        navigator: NavigatorBack,
+        payload: Mapping[str, object],
+    ) -> None:
+        context: NavigatorBackContext = self._context.build(cb, payload)
+        await navigator.history.back(context=context)
+
+
+class RetreatFailureHandler:
+    """Translate application failures into user-facing retreat results."""
+
+    def __init__(self, resolver: RetreatFailureResolver) -> None:
+        self._resolver = resolver
+
+    def handle(self, error: Exception) -> RetreatResult | None:
+        note = self._resolver.translate(error)
+        if note is None:
+            return None
+        return RetreatResult.failed(note)
+
+
 class RetreatWorkflow:
-    """Drive navigator back actions while building execution context."""
+    """Drive navigator back actions while delegating policies to collaborators."""
 
     def __init__(
         self,
         *,
+        executor: RetreatBackExecutor,
+        failures: RetreatFailureHandler,
+    ) -> None:
+        self._executor = executor
+        self._failures = failures
+
+    @classmethod
+    def from_builders(
+        cls,
+        *,
         context: RetreatContextBuilder,
         failures: RetreatFailureResolver,
-    ) -> None:
-        self._context = context
-        self._failures = failures
+    ) -> "RetreatWorkflow":
+        return cls(
+            executor=RetreatBackExecutor(context),
+            failures=RetreatFailureHandler(failures),
+        )
 
     async def execute(
         self,
@@ -33,14 +74,17 @@ class RetreatWorkflow:
         payload: Mapping[str, object],
     ) -> RetreatResult:
         try:
-            context: NavigatorBackContext = self._context.build(cb, payload)
-            await navigator.history.back(context=context)
+            await self._executor.execute(cb, navigator, payload)
         except Exception as error:  # pragma: no cover - mapper branch
-            note = self._failures.translate(error)
-            if note is None:
+            result = self._failures.handle(error)
+            if result is None:
                 raise
-            return RetreatResult.failed(note)
+            return result
         return RetreatResult.ok()
 
 
-__all__ = ["RetreatWorkflow"]
+__all__ = [
+    "RetreatBackExecutor",
+    "RetreatFailureHandler",
+    "RetreatWorkflow",
+]

--- a/presentation/telegram/middleware.py
+++ b/presentation/telegram/middleware.py
@@ -8,9 +8,12 @@ from aiogram import BaseMiddleware
 from aiogram.types import TelegramObject
 
 from navigator.api.contracts import NavigatorRuntimeInstrument
-from navigator.bootstrap.navigator import NavigatorAssembler as BootstrapNavigatorAssembler
 from navigator.core.port.factory import ViewLedger
-from .assembly import NavigatorAssembler, TelegramNavigatorAssembler
+from .assembly import (
+    NavigatorAssembler,
+    TelegramNavigatorAssembler,
+    TelegramRuntimeConfiguration,
+)
 
 Handler = Callable[[TelegramObject, Dict[str, Any]], Awaitable[Any]]
 
@@ -43,8 +46,11 @@ class NavigatorMiddleware(BaseMiddleware):
     ) -> "NavigatorMiddleware":
         """Provide a convenient constructor for the default assembler."""
 
+        configuration = TelegramRuntimeConfiguration.create(
+            instrumentation=instrumentation
+        )
         return cls(
-            TelegramNavigatorAssembler(ledger, instrumentation=instrumentation)
+            TelegramNavigatorAssembler(ledger, configuration=configuration)
         )
 
     async def __call__(


### PR DESCRIPTION
## Summary
- decouple telegram retreat instrumentation from a module-level router by introducing configurator factories
- introduce an explicit Telegram runtime configuration object and update middleware/entrypoints to consume it
- remove the global container resolution registry, inject a resolution service, and split retreat workflow responsibilities

## Testing
- pytest *(fails: ModuleNotFoundError: manual)*

------
https://chatgpt.com/codex/tasks/task_e_68d7856d72248330b6a435fad0e1db67