### PR TITLE
Refactor navigator assembly boundaries

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from typing import Any, Iterable, cast
 
+from navigator.app.service.navigator_runtime.entrypoints import assemble_navigator
+from ._scope import scope_from_dto
 from .contracts import (
     NavigatorAssemblyOverrides,
     NavigatorLike,
@@ -11,8 +13,6 @@ from .contracts import (
     ViewLedgerDTO,
 )
 from ..core.contracts import MissingAlert
-from ..app.service.navigator_runtime.facade import NavigatorFacade
-from ..bootstrap.navigator import assemble as _bootstrap
 
 
 async def assemble(
@@ -27,20 +27,15 @@ async def assemble(
 ) -> NavigatorLike:
     """Assemble and return a Navigator facade instance."""
 
-    bootstrap_kwargs = {
-        "missing_alert": missing_alert,
-    }
-    if overrides is not None and overrides.view_container is not None:
-        bootstrap_kwargs["view_container"] = overrides.view_container
-    bundle = await _bootstrap(
+    navigator = await assemble_navigator(
         event=event,
         state=state,
         ledger=ledger,
-        scope=scope,
+        scope=scope_from_dto(scope),
         instrumentation=instrumentation,
-        **bootstrap_kwargs,
+        missing_alert=missing_alert,
+        overrides=overrides,
     )
-    navigator = NavigatorFacade(bundle.runtime)
     return cast(NavigatorLike, navigator)
 
 

--- a/api/_scope.py
+++ b/api/_scope.py
@@ -1,0 +1,22 @@
+"""Helpers for translating public scope DTOs into domain objects."""
+from __future__ import annotations
+
+from .contracts import ScopeDTO
+from ..core.value.message import Scope
+
+
+def scope_from_dto(dto: ScopeDTO) -> Scope:
+    """Translate external ``ScopeDTO`` structures into domain scopes."""
+
+    return Scope(
+        chat=getattr(dto, "chat", None),
+        lang=getattr(dto, "lang", None),
+        inline=getattr(dto, "inline", None),
+        business=getattr(dto, "business", None),
+        category=getattr(dto, "category", None),
+        topic=getattr(dto, "topic", None),
+        direct=bool(getattr(dto, "direct", False)),
+    )
+
+
+__all__ = ["scope_from_dto"]

--- a/api/contracts.py
+++ b/api/contracts.py
@@ -5,15 +5,13 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Awaitable, Protocol, SupportsInt, runtime_checkable
 
+from navigator.app.service.navigator_runtime.api_contracts import (
+    NavigatorAssemblyOverrides,
+    NavigatorRuntimeBundleLike,
+    NavigatorRuntimeInstrument,
+)
 from ..core.contracts.back import NavigatorBackContext
 from ..core.contracts.state import StateLike
-
-
-@dataclass(slots=True)
-class NavigatorAssemblyOverrides:
-    """Configuration overrides accepted by the public API."""
-
-    view_container: Any | None = None
 
 
 @dataclass(slots=True)
@@ -78,21 +76,6 @@ class NavigatorLike(Protocol):
     history: NavigatorHistoryLike
     state: NavigatorStateLike
     tail: NavigatorTailLike
-
-
-@runtime_checkable
-class NavigatorRuntimeBundleLike(Protocol):
-    """Structural contract describing runtime bundles exposed to the API."""
-
-    telemetry: Any
-    container: Any
-    runtime: Any
-
-
-class NavigatorRuntimeInstrument(Protocol):
-    """Protocol describing runtime instrumentation hooks accepted by the API."""
-
-    def __call__(self, bundle: NavigatorRuntimeBundleLike) -> None: ...
 
 
 __all__ = [

--- a/app/service/navigator_runtime/__init__.py
+++ b/app/service/navigator_runtime/__init__.py
@@ -1,6 +1,11 @@
 """Navigator runtime package exposing orchestration helpers."""
 from __future__ import annotations
 
+from .api_contracts import (
+    NavigatorAssemblyOverrides,
+    NavigatorRuntimeBundleLike,
+    NavigatorRuntimeInstrument,
+)
 from .assembly import build_runtime_from_dependencies
 from .builder import build_navigator_runtime
 from .contracts import HistoryContracts, NavigatorRuntimeContracts, StateContracts, TailContracts
@@ -30,8 +35,11 @@ from .types import MissingAlert
 from .usecases import NavigatorUseCases
 
 __all__ = [
+    "NavigatorAssemblyOverrides",
     "NavigatorBackContext",
     "NavigatorBackEvent",
+    "NavigatorRuntimeInstrument",
+    "NavigatorRuntimeBundleLike",
     "build_navigator_runtime",
     "build_runtime_from_dependencies",
     "HistoryAddOperation",

--- a/app/service/navigator_runtime/api_contracts.py
+++ b/app/service/navigator_runtime/api_contracts.py
@@ -1,0 +1,34 @@
+"""Shared contracts for navigator assembly entry points."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+
+@dataclass(slots=True)
+class NavigatorAssemblyOverrides:
+    """Configuration overrides accepted by assembly entrypoints."""
+
+    view_container: Any | None = None
+
+
+@runtime_checkable
+class NavigatorRuntimeBundleLike(Protocol):
+    """Structural contract describing runtime bundles exposed externally."""
+
+    telemetry: Any
+    container: Any
+    runtime: Any
+
+
+class NavigatorRuntimeInstrument(Protocol):
+    """Protocol describing runtime instrumentation hooks."""
+
+    def __call__(self, bundle: NavigatorRuntimeBundleLike) -> None: ...
+
+
+__all__ = [
+    "NavigatorAssemblyOverrides",
+    "NavigatorRuntimeBundleLike",
+    "NavigatorRuntimeInstrument",
+]

--- a/app/service/navigator_runtime/entrypoints.py
+++ b/app/service/navigator_runtime/entrypoints.py
@@ -1,0 +1,75 @@
+"""Application-level entrypoints for assembling navigator facades."""
+from __future__ import annotations
+
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from typing import Type, TypeVar
+
+from navigator.bootstrap.navigator import assemble as bootstrap_assemble
+from navigator.bootstrap.navigator.container_resolution import ContainerResolution
+from navigator.bootstrap.navigator.context import ViewContainerFactory
+from navigator.core.contracts import MissingAlert
+from navigator.core.port.factory import ViewLedger
+from navigator.core.value.message import Scope
+
+from .api_contracts import NavigatorAssemblyOverrides, NavigatorRuntimeInstrument
+from .facade import NavigatorFacade
+
+FacadeT = TypeVar("FacadeT", bound=NavigatorFacade)
+
+
+@dataclass(slots=True)
+class InstrumentationPlan:
+    """Normalize instrumentation payloads before bootstrapping."""
+
+    instruments: Sequence[NavigatorRuntimeInstrument]
+
+    @classmethod
+    def from_iterable(
+        cls, payload: Iterable[NavigatorRuntimeInstrument] | None
+    ) -> "InstrumentationPlan":
+        if payload is None:
+            return cls(())
+        if isinstance(payload, tuple):
+            return cls(payload)
+        return cls(tuple(payload))
+
+
+def _override_view_container(
+    overrides: NavigatorAssemblyOverrides | None,
+) -> ViewContainerFactory | None:
+    if overrides is None:
+        return None
+    return overrides.view_container
+
+
+async def assemble_navigator(
+    *,
+    event: object,
+    state: object,
+    ledger: ViewLedger,
+    scope: Scope,
+    instrumentation: Iterable[NavigatorRuntimeInstrument] | None = None,
+    missing_alert: MissingAlert | None = None,
+    overrides: NavigatorAssemblyOverrides | None = None,
+    resolution: ContainerResolution | None = None,
+    facade_type: Type[FacadeT] = NavigatorFacade,
+) -> FacadeT:
+    """Assemble a navigator facade for the provided runtime inputs."""
+
+    plan = InstrumentationPlan.from_iterable(instrumentation)
+    bundle = await bootstrap_assemble(
+        event=event,
+        state=state,
+        ledger=ledger,
+        scope=scope,
+        instrumentation=plan.instruments,
+        missing_alert=missing_alert,
+        view_container=_override_view_container(overrides),
+        resolution=resolution,
+    )
+    navigator = facade_type(bundle.runtime)
+    return navigator
+
+
+__all__ = ["assemble_navigator", "InstrumentationPlan"]

--- a/bootstrap/navigator/__init__.py
+++ b/bootstrap/navigator/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from .adapter import LedgerAdapter
 from .assembly import NavigatorAssembler, assemble
 from .container import ContainerFactory
-from .context import BootstrapContext, scope_from_dto
+from .context import BootstrapContext
 from .runtime import ContainerRuntimeFactory, NavigatorFactory, NavigatorRuntimeBundle
 from .telemetry import TelemetryFactory, calibrate_telemetry
 
@@ -19,5 +19,4 @@ __all__ = [
     "TelemetryFactory",
     "assemble",
     "calibrate_telemetry",
-    "scope_from_dto",
 ]

--- a/bootstrap/navigator/adapter.py
+++ b/bootstrap/navigator/adapter.py
@@ -1,14 +1,12 @@
-"""Adapters bridging DTO infrastructure with the domain layer."""
 from __future__ import annotations
 
-from navigator.api.contracts import ViewLedgerDTO
 from navigator.core.port.factory import ViewForge, ViewLedger
 
 
 class LedgerAdapter(ViewLedger):
-    """Expose a DTO-backed ledger through the domain ``ViewLedger``."""
+    """Expose a ledger through the domain ``ViewLedger`` interface."""
 
-    def __init__(self, ledger: ViewLedgerDTO) -> None:
+    def __init__(self, ledger: ViewLedger) -> None:
         self._ledger = ledger
 
     def get(self, key: str) -> ViewForge:

--- a/bootstrap/navigator/context.py
+++ b/bootstrap/navigator/context.py
@@ -3,25 +3,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from navigator.api.contracts import ScopeDTO, ViewLedgerDTO
 from navigator.core.contracts import MissingAlert
+from navigator.core.port.factory import ViewLedger
 from navigator.core.value.message import Scope
 
 from .container_types import ViewContainerFactory
-
-
-def scope_from_dto(dto: ScopeDTO) -> Scope:
-    """Translate external ``ScopeDTO`` structures into domain scopes."""
-
-    return Scope(
-        chat=getattr(dto, "chat", None),
-        lang=getattr(dto, "lang", None),
-        inline=getattr(dto, "inline", None),
-        business=getattr(dto, "business", None),
-        category=getattr(dto, "category", None),
-        topic=getattr(dto, "topic", None),
-        direct=bool(getattr(dto, "direct", False)),
-    )
 
 
 @dataclass(frozen=True)
@@ -30,10 +16,10 @@ class BootstrapContext:
 
     event: object
     state: object
-    ledger: ViewLedgerDTO
-    scope: ScopeDTO
+    ledger: ViewLedger
+    scope: Scope
     missing_alert: MissingAlert | None = None
     view_container: ViewContainerFactory | None = None
 
 
-__all__ = ["BootstrapContext", "scope_from_dto", "ViewContainerFactory"]
+__all__ = ["BootstrapContext", "ViewContainerFactory"]

--- a/bootstrap/navigator/runtime/composition.py
+++ b/bootstrap/navigator/runtime/composition.py
@@ -6,7 +6,7 @@ from navigator.app.service.navigator_runtime.activation import create_activation
 from navigator.app.service.navigator_runtime.snapshot import NavigatorRuntimeSnapshot
 from navigator.core.telemetry import Telemetry
 
-from ..context import BootstrapContext, scope_from_dto
+from ..context import BootstrapContext
 from ..telemetry import calibrate_telemetry
 
 
@@ -25,12 +25,10 @@ class NavigatorRuntimeComposer:
         snapshot: NavigatorRuntimeSnapshot,
         context: BootstrapContext,
     ) -> NavigatorRuntime:
-        scope = scope_from_dto(context.scope)
-        missing_alert = context.missing_alert
         plan = create_activation_plan(
             snapshot,
-            scope,
-            missing_alert=missing_alert,
+            context.scope,
+            missing_alert=context.missing_alert,
         )
         return plan.activate()
 

--- a/presentation/telegram/assembly.py
+++ b/presentation/telegram/assembly.py
@@ -3,15 +3,15 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Protocol, cast
 
 from aiogram.fsm.context import FSMContext
 from aiogram.types import TelegramObject
 
-from navigator.api import assemble as assemble_navigator
-from navigator.api.contracts import (
+from navigator.app.service.navigator_runtime import (
     NavigatorAssemblyOverrides,
     NavigatorRuntimeInstrument,
+    assemble_navigator,
 )
 from navigator.core.contracts import MissingAlert
 from navigator.core.port.factory import ViewLedger
@@ -50,8 +50,9 @@ class TelegramRuntimeConfiguration:
         return cls(instrumentation=instruments, missing_alert=missing_alert or missing)
 
 
+@dataclass(frozen=True)
 class TelegramNavigatorAssembler:
-    """Concrete assembler translating Telegram primitives for navigator API."""
+    """Concrete assembler translating Telegram primitives for navigator runtime."""
 
     def __init__(
         self,
@@ -73,8 +74,9 @@ class TelegramNavigatorAssembler:
             instrumentation=self._configuration.instrumentation,
             missing_alert=self._configuration.missing_alert,
             overrides=self._overrides,
+            facade_type=Navigator,
         )
-        return navigator
+        return cast(Navigator, navigator)
 
 
 NavigatorInstrument = NavigatorRuntimeInstrument

--- a/presentation/telegram/instrumentation.py
+++ b/presentation/telegram/instrumentation.py
@@ -1,9 +1,8 @@
-"""Bootstrap adapters for Telegram presentation components."""
 from __future__ import annotations
 
 from typing import Callable, Protocol
 
-from navigator.api.contracts import NavigatorRuntimeBundleLike
+from navigator.app.service.navigator_runtime import NavigatorRuntimeBundleLike
 
 from .router import RetreatDependencies, RetreatRouterConfigurator, retreat_configurator
 

--- a/presentation/telegram/middleware.py
+++ b/presentation/telegram/middleware.py
@@ -1,13 +1,10 @@
-"""Aiogram middleware that injects a Navigator instance into handler context."""
-from __future__ import annotations
-
 from collections.abc import Iterable
 from typing import Any, Awaitable, Callable, Dict, Optional, Protocol, runtime_checkable
 
 from aiogram import BaseMiddleware
 from aiogram.types import TelegramObject
 
-from navigator.api.contracts import NavigatorRuntimeInstrument
+from navigator.app.service.navigator_runtime import NavigatorRuntimeInstrument
 from navigator.core.port.factory import ViewLedger
 from .assembly import (
     NavigatorAssembler,


### PR DESCRIPTION
## Summary
- introduce service-level assembly entrypoints and contracts so API and Telegram presentation layers no longer depend on bootstrap internals
- normalize bootstrap context to domain entities and refactor runtime assembly helpers to isolate view resolution and instrumentation concerns
- update presentation instrumentation imports to rely on shared service contracts

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'manual')*

------
https://chatgpt.com/codex/tasks/task_e_68d7a08577f483308934e01d5f544dce