### PR TITLE
Refactor inline flows and tail runtime composition

### DIFF
--- a/adapters/telegram/gateway/planner.py
+++ b/adapters/telegram/gateway/planner.py
@@ -1,0 +1,223 @@
+"""Prepare Telegram edit requests decoupled from bot operations."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Iterable, Mapping, Sequence
+
+from navigator.core.error import CaptionOverflow, TextOverflow
+from navigator.core.port.extraschema import ExtraSchema
+from navigator.core.port.limits import Limits
+from navigator.core.port.markup import MarkupCodec
+from navigator.core.port.pathpolicy import MediaPathPolicy
+from navigator.core.port.preview import LinkPreviewCodec
+from navigator.core.telemetry import LogCode, TelemetryChannel
+from navigator.core.value.content import Payload
+from navigator.core.value.message import Scope
+from . import util
+from ..media import compose
+from ..serializer import caption as captionkit
+from ..serializer import text as textkit
+from ..serializer.screen import SignatureScreen
+
+
+@dataclass(frozen=True)
+class TelemetryEvent:
+    """Structured telemetry emission request."""
+
+    level: int
+    code: LogCode
+    fields: Mapping[str, object]
+
+
+@dataclass(frozen=True)
+class TextEditPlan:
+    """Prepared data for ``edit_message_text`` operations."""
+
+    text: str
+    markup: object
+    extras: Mapping[str, object]
+    preview_options: object | None
+    telemetry: Sequence[TelemetryEvent]
+
+
+@dataclass(frozen=True)
+class MediaEditPlan:
+    """Prepared data for ``edit_message_media`` operations."""
+
+    media: object
+    markup: object
+    extras: Mapping[str, object]
+    telemetry: Sequence[TelemetryEvent]
+
+
+@dataclass(frozen=True)
+class CaptionEditPlan:
+    """Prepared data for ``edit_message_caption`` operations."""
+
+    caption: str | None
+    markup: object
+    extras: Mapping[str, object]
+    telemetry: Sequence[TelemetryEvent]
+
+
+@dataclass(frozen=True)
+class MarkupEditPlan:
+    """Prepared data for ``edit_message_reply_markup`` operations."""
+
+    markup: object
+
+
+def _truncate_event(scope: Scope, *, stage: str) -> TelemetryEvent:
+    return TelemetryEvent(
+        logging.INFO,
+        LogCode.TOO_LONG_TRUNCATED,
+        {"scope": util.profile(scope), "stage": stage},
+    )
+
+
+def prepare_text_edit(
+    payload: Payload,
+    *,
+    codec: MarkupCodec,
+    schema: ExtraSchema,
+    limits: Limits,
+    preview: LinkPreviewCodec | None,
+    scope: Scope,
+    truncate: bool,
+) -> TextEditPlan:
+    """Return text edit inputs applying policy checks."""
+
+    text = payload.text or ""
+    events: list[TelemetryEvent] = []
+    limit = limits.textlimit()
+    if len(text) > limit:
+        if truncate:
+            text = text[:limit]
+            events.append(_truncate_event(scope, stage="edit.text"))
+        else:
+            raise TextOverflow()
+
+    extras = schema.edit(scope, payload.extra, span=len(text), media=False)
+    markup = textkit.decode(codec, payload.reply)
+    options = None
+    if preview is not None and payload.preview is not None:
+        options = preview.encode(payload.preview)
+
+    return TextEditPlan(
+        text=text,
+        markup=markup,
+        extras=extras,
+        preview_options=options,
+        telemetry=tuple(events),
+    )
+
+
+def prepare_media_edit(
+    payload: Payload,
+    *,
+    codec: MarkupCodec,
+    schema: ExtraSchema,
+    screen: SignatureScreen,
+    policy: MediaPathPolicy,
+    limits: Limits,
+    scope: Scope,
+    truncate: bool,
+) -> MediaEditPlan:
+    """Return media edit inputs applying caption constraints."""
+
+    caption = captionkit.caption(payload)
+    events: list[TelemetryEvent] = []
+    limit = limits.captionlimit()
+    if caption is not None and len(caption) > limit:
+        if truncate:
+            caption = caption[:limit]
+            events.append(_truncate_event(scope, stage="edit.caption"))
+        else:
+            raise CaptionOverflow()
+
+    extras = schema.edit(scope, payload.extra, span=len(caption or ""), media=True)
+    media = compose(
+        payload.media,
+        caption=caption,
+        captionmeta=extras.get("caption", {}),
+        mediameta=extras.get("media", {}),
+        policy=policy,
+        screen=screen,
+        limits=limits,
+        native=not scope.inline,
+    )
+    markup = textkit.decode(codec, payload.reply)
+
+    return MediaEditPlan(
+        media=media,
+        markup=markup,
+        extras=extras,
+        telemetry=tuple(events),
+    )
+
+
+def prepare_caption_edit(
+    payload: Payload,
+    *,
+    codec: MarkupCodec,
+    schema: ExtraSchema,
+    limits: Limits,
+    scope: Scope,
+    truncate: bool,
+) -> CaptionEditPlan:
+    """Return caption edit inputs with guardrails applied."""
+
+    caption = captionkit.restate(payload)
+    events: list[TelemetryEvent] = []
+    limit = limits.captionlimit()
+    if caption is not None and len(caption) > limit:
+        if truncate:
+            caption = caption[:limit]
+            events.append(_truncate_event(scope, stage="edit.caption"))
+        else:
+            raise CaptionOverflow()
+
+    extras = schema.edit(scope, payload.extra, span=len(caption or ""), media=True)
+    markup = textkit.decode(codec, payload.reply)
+
+    return CaptionEditPlan(
+        caption=caption,
+        markup=markup,
+        extras=extras,
+        telemetry=tuple(events),
+    )
+
+
+def prepare_markup_edit(
+    payload: Payload,
+    *,
+    codec: MarkupCodec,
+) -> MarkupEditPlan:
+    """Prepare reply markup edits."""
+
+    markup = textkit.decode(codec, payload.reply)
+    return MarkupEditPlan(markup=markup)
+
+
+def emit_telemetry(
+    channel: TelemetryChannel, events: Iterable[TelemetryEvent]
+) -> None:
+    """Forward prepared telemetry events to ``channel``."""
+
+    for event in events:
+        channel.emit(event.level, event.code, **event.fields)
+
+
+__all__ = [
+    "CaptionEditPlan",
+    "MediaEditPlan",
+    "MarkupEditPlan",
+    "TelemetryEvent",
+    "TextEditPlan",
+    "emit_telemetry",
+    "prepare_caption_edit",
+    "prepare_media_edit",
+    "prepare_markup_edit",
+    "prepare_text_edit",
+]

--- a/app/service/navigator_runtime/history/__init__.py
+++ b/app/service/navigator_runtime/history/__init__.py
@@ -1,0 +1,23 @@
+"""History runtime helpers grouped into a dedicated package."""
+from __future__ import annotations
+
+from .appender import HistoryAppendRequest, HistoryPayloadAppender
+from .operations import (
+    HistoryAddOperation,
+    HistoryBackOperation,
+    HistoryRebaseOperation,
+    HistoryReplaceOperation,
+    HistoryTrimOperation,
+)
+from .service import NavigatorHistoryService
+
+__all__ = [
+    "HistoryAppendRequest",
+    "HistoryPayloadAppender",
+    "HistoryAddOperation",
+    "HistoryBackOperation",
+    "HistoryRebaseOperation",
+    "HistoryReplaceOperation",
+    "HistoryTrimOperation",
+    "NavigatorHistoryService",
+]

--- a/app/service/navigator_runtime/history/appender.py
+++ b/app/service/navigator_runtime/history/appender.py
@@ -1,0 +1,53 @@
+"""Prepare payload bundles for history append operations."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ..bundler import PayloadBundleSource, PayloadBundler
+from ..ports import AppendHistoryUseCase
+
+
+@dataclass(frozen=True)
+class HistoryAppendRequest:
+    """Payload bundle prepared for history append operations."""
+
+    payloads: list[object]
+    key: str | None
+    root: bool
+
+    @property
+    def count(self) -> int:
+        return len(self.payloads)
+
+
+class HistoryPayloadAppender:
+    """Prepare payload bundles and delegate execution to the use-case."""
+
+    def __init__(self, *, appender: AppendHistoryUseCase, bundler: PayloadBundler) -> None:
+        self._appender = appender
+        self._bundler = bundler
+
+    def bundle(self, source: PayloadBundleSource) -> list[object]:
+        """Return bundled payloads derived from ``source``."""
+
+        return self._bundler.bundle(source)
+
+    def prepare(
+        self,
+        source: PayloadBundleSource,
+        *,
+        key: str | None,
+        root: bool,
+    ) -> HistoryAppendRequest:
+        """Return a structured append request derived from ``source``."""
+
+        payloads = self.bundle(source)
+        return HistoryAppendRequest(payloads=payloads, key=key, root=root)
+
+    async def append(self, scope, request: HistoryAppendRequest) -> None:
+        """Execute the append use-case using a prepared ``request``."""
+
+        await self._appender.execute(scope, request.payloads, request.key, root=request.root)
+
+
+__all__ = ["HistoryAppendRequest", "HistoryPayloadAppender"]

--- a/app/service/navigator_runtime/history/base.py
+++ b/app/service/navigator_runtime/history/base.py
@@ -1,0 +1,36 @@
+"""Foundational helpers shared across history operations."""
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable
+
+from navigator.app.locks.guard import Guardian
+
+from ..reporter import NavigatorReporter
+
+
+class _HistoryOperation:
+    """Base helper coordinating guard and telemetry for history actions."""
+
+    def __init__(
+        self,
+        *,
+        guard: Guardian,
+        scope,
+        reporter: NavigatorReporter,
+    ) -> None:
+        self._guard = guard
+        self._scope = scope
+        self._reporter = reporter
+
+    async def _run(
+        self,
+        method: str,
+        action: Callable[[], Awaitable[None]],
+        **fields: object,
+    ) -> None:
+        self._reporter.emit(method, **fields)
+        async with self._guard(self._scope):
+            await action()
+
+
+__all__ = ["_HistoryOperation"]

--- a/app/service/navigator_runtime/history/service.py
+++ b/app/service/navigator_runtime/history/service.py
@@ -1,0 +1,56 @@
+"""Facade aggregating history operations for the runtime."""
+from __future__ import annotations
+
+from navigator.core.contracts.back import NavigatorBackContext
+
+from ..bundler import PayloadBundleSource
+from .operations import (
+    HistoryAddOperation,
+    HistoryBackOperation,
+    HistoryRebaseOperation,
+    HistoryReplaceOperation,
+    HistoryTrimOperation,
+)
+
+
+class NavigatorHistoryService:
+    """Coordinate history-centric operations via dedicated actions."""
+
+    def __init__(
+        self,
+        *,
+        add: HistoryAddOperation,
+        replace: HistoryReplaceOperation,
+        rebase: HistoryRebaseOperation,
+        back: HistoryBackOperation,
+        pop: HistoryTrimOperation,
+    ) -> None:
+        self._add = add
+        self._replace = replace
+        self._rebase = rebase
+        self._back = back
+        self._pop = pop
+
+    async def add(
+        self,
+        content: PayloadBundleSource,
+        *,
+        key: str | None = None,
+        root: bool = False,
+    ) -> None:
+        await self._add(content, key=key, root=root)
+
+    async def replace(self, content: PayloadBundleSource) -> None:
+        await self._replace(content)
+
+    async def rebase(self, message) -> None:
+        await self._rebase(message)
+
+    async def back(self, context: NavigatorBackContext) -> None:
+        await self._back(context)
+
+    async def pop(self, count: int = 1) -> None:
+        await self._pop(count)
+
+
+__all__ = ["NavigatorHistoryService"]

--- a/app/service/view/inline/__init__.py
+++ b/app/service/view/inline/__init__.py
@@ -1,7 +1,8 @@
 """Inline view service public interface."""
 from __future__ import annotations
 
-from .editor import InlineEditor, InlineOutcome
+from .editor import InlineEditor
+from .outcome import InlineOutcome
 from .guard import InlineGuard
 from .handler import InlineHandler
 from .remap import InlineRemapper

--- a/app/service/view/inline/editor.py
+++ b/app/service/view/inline/editor.py
@@ -1,19 +1,12 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 from navigator.core.entity.history import Message
 from navigator.core.service.rendering import decision as D
 from navigator.core.value.content import Payload
 from navigator.core.value.message import Scope
 
 from ..executor import EditExecutor, Execution
-
-
-@dataclass(slots=True)
-class InlineOutcome:
-    execution: Execution
-    decision: D.Decision
-    payload: Payload
+from .outcome import InlineOutcome
 
 
 class InlineEditor:

--- a/app/service/view/inline/flows.py
+++ b/app/service/view/inline/flows.py
@@ -12,6 +12,7 @@ from .mediator import InlineEditMediator
 from .telemetry import InlineTelemetryAdapter
 from .guard import InlineGuard
 from .remap import InlineRemapper
+from .outcome import InlineOutcome
 from ..executor import EditExecutor
 
 
@@ -37,9 +38,7 @@ class InlineMediaFlow:
         base: Message | None,
         executor: EditExecutor,
         config: RenderingConfig,
-    ) -> "InlineOutcome" | None:
-        from .editor import InlineOutcome
-
+    ) -> InlineOutcome | None:
         if not self._guard.admissible(entry):
             return await self._fallback(scope, entry, base, executor)
         verdict = D.decide(base, entry, config)
@@ -51,9 +50,7 @@ class InlineMediaFlow:
         entry: Payload,
         base: Message | None,
         executor: EditExecutor,
-    ) -> "InlineOutcome" | None:
-        from .editor import InlineOutcome
-
+    ) -> InlineOutcome | None:
         if base and not match(getattr(base, "markup", None), getattr(entry, "reply", None)):
             adjusted = entry.morph(media=base.media if base else None, group=None)
             outcome = await self._mediator.apply(
@@ -75,9 +72,7 @@ class InlineMediaFlow:
         entry: Payload,
         base: Message | None,
         executor: EditExecutor,
-    ) -> "InlineOutcome" | None:
-        from .editor import InlineOutcome
-
+    ) -> InlineOutcome | None:
         if verdict is D.Decision.DELETE_SEND:
             return await self._handle_delete_send(scope, entry, base, executor=executor)
         if verdict in (D.Decision.EDIT_MEDIA_CAPTION, D.Decision.EDIT_MARKUP):
@@ -103,9 +98,7 @@ class InlineMediaFlow:
         base: Message | None,
         *,
         executor: EditExecutor,
-    ) -> "InlineOutcome" | None:
-        from .editor import InlineOutcome
-
+    ) -> InlineOutcome | None:
         remapped = self._remapper.remap(base, entry)
         self._telemetry.remap_delete_send(remapped)
         if remapped is D.Decision.EDIT_MARKUP:
@@ -148,9 +141,7 @@ class InlineTextFlow:
         entry: Payload,
         base: Message | None,
         executor: EditExecutor,
-    ) -> "InlineOutcome" | None:
-        from .editor import InlineOutcome
-
+    ) -> InlineOutcome | None:
         if base and getattr(base, "media", None):
             adjusted = entry.morph(media=base.media, group=None)
             if self._requires_caption_refresh(adjusted):

--- a/app/service/view/inline/handler.py
+++ b/app/service/view/inline/handler.py
@@ -15,7 +15,8 @@ from .guard import InlineGuard
 from .mediator import InlineEditMediator
 from .remap import InlineRemapper
 from .telemetry import InlineTelemetryAdapter
-from .editor import InlineEditor, InlineOutcome
+from .editor import InlineEditor
+from .outcome import InlineOutcome
 from ..executor import EditExecutor
 
 if TYPE_CHECKING:

--- a/app/service/view/inline/mediator.py
+++ b/app/service/view/inline/mediator.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 from navigator.core.value.content import Payload
 from navigator.core.value.message import Scope
 
-from .editor import InlineEditor, InlineOutcome
+from .editor import InlineEditor
+from .outcome import InlineOutcome
 from ..executor import EditExecutor
 
 

--- a/app/service/view/inline/outcome.py
+++ b/app/service/view/inline/outcome.py
@@ -1,0 +1,25 @@
+"""Shared inline outcome model used across flow components."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from navigator.core.service.rendering import decision as D
+
+from ..executor import Execution
+from typing import TYPE_CHECKING
+
+
+@dataclass(slots=True)
+class InlineOutcome:
+    """Capture the result of inline reconciliation."""
+
+    execution: Execution
+    decision: D.Decision
+    payload: "Payload"
+
+
+if TYPE_CHECKING:
+    from navigator.core.value.content import Payload
+
+
+__all__ = ["InlineOutcome"]

--- a/app/service/view/inline/telemetry.py
+++ b/app/service/view/inline/telemetry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 
+from navigator.core.service.rendering import decision as D
 from navigator.core.telemetry import LogCode, Telemetry, TelemetryChannel
 
 
@@ -12,9 +13,7 @@ class InlineTelemetryAdapter:
     def __init__(self, telemetry: Telemetry) -> None:
         self._channel: TelemetryChannel = telemetry.channel(__name__)
 
-    def remap_delete_send(self, target: "D.Decision") -> None:
-        from navigator.core.service.rendering import decision as D
-
+    def remap_delete_send(self, target: D.Decision) -> None:
         self._channel.emit(
             logging.INFO,
             LogCode.INLINE_REMAP_DELETE_SEND,

--- a/app/usecase/last/editing.py
+++ b/app/usecase/last/editing.py
@@ -1,0 +1,116 @@
+"""Supporting components for tail edit coordination."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Sequence
+
+from ....core.service.rendering import decision
+from ....core.value.message import Scope
+
+from ...service.tail_history import TailHistoryWriter
+from ...service.history_mutation import TailHistoryMutator
+from ...service.view.executor import EditExecutor
+from ...service.view.planner import RenderResult
+
+from .context import TailResolution, TailSnapshot
+
+
+class TailFallbackPolicy:
+    """Encapsulate resend eligibility checks."""
+
+    _RESENDABLE = (
+        decision.Decision.EDIT_TEXT,
+        decision.Decision.EDIT_MEDIA,
+        decision.Decision.EDIT_MEDIA_CAPTION,
+        decision.Decision.DELETE_SEND,
+    )
+
+    def allows_resend(self, resolution: TailResolution, scope: Scope) -> bool:
+        """Return ``True`` when resend fallback is permitted."""
+
+        if scope.inline:
+            return False
+        verdict = resolution.decision
+        if verdict not in self._RESENDABLE:
+            return False
+        payload = resolution.payload
+        if verdict is decision.Decision.EDIT_TEXT and not (
+            payload.text and str(payload.text).strip()
+        ):
+            return False
+        if verdict in (
+            decision.Decision.EDIT_MEDIA,
+            decision.Decision.EDIT_MEDIA_CAPTION,
+        ) and not (payload.media or payload.group):
+            return False
+        return True
+
+
+class TailEditService:
+    """Apply edit decisions through the view executor."""
+
+    def __init__(self, executor: EditExecutor) -> None:
+        self._executor = executor
+
+    @property
+    def executor(self) -> EditExecutor:
+        return self._executor
+
+    async def apply(
+        self,
+        scope: Scope,
+        verdict: decision.Decision,
+        payload,
+        base,
+    ) -> RenderResult | None:
+        execution = await self._executor.execute(scope, verdict, payload, base)
+        if not execution:
+            return None
+        meta = self._executor.refine(execution, verdict, payload)
+        return RenderResult(
+            id=execution.result.id,
+            extra=list(execution.result.extra),
+            meta=meta,
+        )
+
+    async def resend(self, scope: Scope, payload) -> RenderResult | None:
+        """Apply a resend fallback using ``payload``."""
+
+        return await self.apply(
+            scope,
+            decision.Decision.RESEND,
+            payload,
+            None,
+        )
+
+
+@dataclass(slots=True)
+class TailHistoryPersistence:
+    """Persist updated tail history snapshots."""
+
+    history: TailHistoryWriter
+    mutator: TailHistoryMutator
+
+    async def persist(
+        self,
+        snapshot: TailSnapshot,
+        outcome: RenderResult,
+        *,
+        scope: Scope,
+        op: str,
+        extras: Sequence[Sequence[int]] | None = None,
+    ) -> None:
+        index = snapshot.index
+        if index is not None and 0 <= index < len(snapshot.history):
+            history = snapshot.clone()
+            entry = history[index]
+            bundle = extras
+            if bundle is None and entry.messages:
+                mismatch = int(entry.messages[0].id) != int(outcome.id)
+                bundle = [outcome.extra] if mismatch else None
+            history[index] = self.mutator.reindex(entry, [outcome.id], bundle)
+            await self.history.save(history, op=op)
+        await self.history.mark(outcome.id, op=op, scope=scope)
+
+
+__all__ = ["TailEditService", "TailFallbackPolicy", "TailHistoryPersistence"]


### PR DESCRIPTION
## Summary
- extract InlineOutcome into a dedicated module so flows and telemetry can import it without lazy imports
- introduce Telegram gateway planners that prepare edit payloads and emit telemetry before bot interaction
- split navigator history runtime logic into focused modules and encapsulate tail edit persistence and fallback policies

## Testing
- python -m compileall app/service/view/inline adapters/telegram/gateway app/usecase/last app/service/navigator_runtime

------
https://chatgpt.com/codex/tasks/task_e_68d7a505b1448330946584a33922ec4b