### PR TITLE
Refactor rendering decisions and runtime wiring

### DIFF
--- a/app/service/navigator_runtime/runtime_builder.py
+++ b/app/service/navigator_runtime/runtime_builder.py
@@ -28,21 +28,9 @@ class NavigatorRuntimeBuilder:
         *,
         plan: RuntimeAssemblyPlan,
     ) -> NavigatorRuntime:
-        history = self._builders.history.build(
-            plan.contracts.history,
-            reporter=plan.collaborators.reporter,
-            bundler=plan.collaborators.bundler,
-        )
-        state = self._builders.state.build(
-            plan.contracts.state,
-            reporter=plan.collaborators.reporter,
-            missing_alert=plan.collaborators.missing_alert,
-        )
-        tail = self._builders.tail.build(
-            plan.contracts.tail,
-            telemetry=plan.collaborators.telemetry,
-            tail_telemetry=plan.collaborators.tail_telemetry,
-        )
+        history = plan.history.build_with(self._builders.history)
+        state = plan.state.build_with(self._builders.state)
+        tail = plan.tail.build_with(self._builders.tail)
         return NavigatorRuntime(history=history, state=state, tail=tail)
 
 

--- a/app/usecase/add_components.py
+++ b/app/usecase/add_components.py
@@ -63,23 +63,33 @@ class AppendHistoryJournal(AppendHistoryObserver):
         )
 
 
-class AppendHistoryAccess:
-    """Provide read helpers around history repositories."""
+class HistorySnapshotAccess:
+    """Expose history snapshots while notifying interested observers."""
 
     def __init__(
             self,
             archive: HistoryRepository,
-            state: StateRepository,
             observer: AppendHistoryObserver | None = None,
     ) -> None:
         self._archive = archive
-        self._state = state
         self._observer: AppendHistoryObserver = observer or NullAppendHistoryObserver()
 
     async def snapshot(self, scope: Scope) -> List[Entry]:
         records = await self._archive.recall()
         self._observer.history_loaded(scope, len(records))
         return records
+
+
+class StateStatusAccess:
+    """Retrieve state information while surfacing observer notifications."""
+
+    def __init__(
+            self,
+            state: StateRepository,
+            observer: AppendHistoryObserver | None = None,
+    ) -> None:
+        self._state = state
+        self._observer: AppendHistoryObserver = observer or NullAppendHistoryObserver()
 
     async def status(self) -> Optional[str]:
         status = await self._state.status()
@@ -175,11 +185,12 @@ class AppendEntryAssembler:
 
 __all__ = [
     "AppendEntryAssembler",
-    "AppendHistoryAccess",
     "AppendHistoryObserver",
     "AppendHistoryJournal",
     "AppendHistoryWriter",
     "AppendPayloadAdapter",
     "AppendRenderPlanner",
+    "HistorySnapshotAccess",
     "NullAppendHistoryObserver",
+    "StateStatusAccess",
 ]

--- a/core/service/rendering/decision.py
+++ b/core/service/rendering/decision.py
@@ -2,47 +2,20 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping as MappingView
-from dataclasses import dataclass, field
 from enum import Enum, auto
-from typing import Any, Mapping, Optional
+from typing import Optional
 
 from .config import RenderingConfig
 from .helpers import match
-from ...entity.markup import Markup
-from ...entity.media import MediaItem, MediaType
-from ...port.mediaid import MediaIdentityPolicy
-from ...value.content import Payload, Preview, caption
-
-
-@dataclass(frozen=True, slots=True)
-class NormalizedView:
-    """Capture the minimal surface we compare across history entries."""
-
-    text: str | None = None
-    media: MediaItem | None = None
-    group: tuple[MediaItem, ...] = ()
-    reply: Markup | None = None
-    extra: Mapping[str, Any] = field(default_factory=dict)
-    preview: Preview | None = None
-
-    @property
-    def has_group(self) -> bool:
-        """Report whether the view represents an album submission."""
-
-        return bool(self.group)
-
-    @property
-    def has_media(self) -> bool:
-        """Report whether the view carries a single media item."""
-
-        return self.media is not None
-
-    @property
-    def is_media_payload(self) -> bool:
-        """Report whether the view is backed by media rather than text."""
-
-        return self.has_group or self.has_media
+from ...value.content import Payload, caption
+from .media_profile import identical_media, profile_media, requires_delete_send
+from .normalization import (
+    NormalizedView,
+    preview_payload,
+    text_content,
+    textual_extras,
+    view_of,
+)
 
 
 class Decision(Enum):
@@ -57,146 +30,13 @@ class Decision(Enum):
     NO_CHANGE = auto()
 
 
-def _view_of(source: object | None) -> NormalizedView:
-    """Normalize supported message views into a comparison surface."""
-
-    if source is None:
-        return NormalizedView()
-
-    text = getattr(source, "text", None)
-    media = getattr(source, "media", None)
-    group = getattr(source, "group", None) or ()
-    if group and not isinstance(group, tuple):
-        group = tuple(group)
-
-    reply = getattr(source, "reply", getattr(source, "markup", None))
-
-    extra_value = getattr(source, "extra", None)
-    extra: Mapping[str, Any]
-    if isinstance(extra_value, MappingView):
-        extra = dict(extra_value)
-    else:
-        extra = {}
-
-    preview = getattr(source, "preview", None)
-
-    return NormalizedView(
-        text=text,
-        media=media,
-        group=group,
-        reply=reply,
-        extra=extra,
-        preview=preview,
-    )
-
-
-def _textual_extras(view: NormalizedView) -> dict[str, Any]:
-    """Preserve extra fields that influence text rendering semantics."""
-
-    data = view.extra or {}
-    snapshot: dict[str, Any] = {}
-    if "mode" in data:
-        snapshot["mode"] = data["mode"]
-    if "entities" in data:
-        snapshot["entities"] = data["entities"]
-    return snapshot
-
-
-@dataclass(frozen=True, slots=True)
-class _CaptionFlag:
-    """Capture caption-level options relevant for edits."""
-
-    above: bool
-
-
-@dataclass(frozen=True, slots=True)
-class _MediaFlag:
-    """Describe media edit options that require resend safeguards."""
-
-    spoiler: bool
-    start: object
-    thumb: bool
-
-
-@dataclass(frozen=True, slots=True)
-class _MediaProfile:
-    """Bundle caption and media attributes for comparison."""
-
-    caption: _CaptionFlag
-    edit: _MediaFlag
-
-
-def _profile_media(view: NormalizedView, config: RenderingConfig) -> _MediaProfile:
-    """Extract mutable media attributes that affect edit compatibility."""
-
-    payload = dict(view.extra or {})
-    caption = _CaptionFlag(above=bool(payload.get("show_caption_above_media")))
-    start = payload.get("start")
-    try:
-        start = int(start) if start is not None else None
-    except Exception:
-        pass
-    present = bool((payload.get("thumb") is not None) or payload.get("has_thumb"))
-    edit = _MediaFlag(
-        spoiler=bool(payload.get("spoiler")),
-        start=start,
-        thumb=(present if config.thumbguard else False),
-    )
-    return _MediaProfile(caption=caption, edit=edit)
-
-
-def _text(view: NormalizedView) -> Optional[str]:
-    """Return trimmed textual content when no media is present."""
-
-    if view.is_media_payload:
-        return None
-    value = view.text
-    return str(value).strip() if value is not None else None
-
-
-def _preview(view: NormalizedView):
-    """Expose the preview payload so comparisons stay encapsulated."""
-
-    return view.preview
-
-
-def _identical(old: NormalizedView, new: NormalizedView, policy: MediaIdentityPolicy) -> bool:
-    """Check whether two views refer to the same underlying media file."""
-
-    if not (old.media and new.media):
-        return False
-    if old.media.type != new.media.type:
-        return False
-    former = getattr(old.media, "path", None)
-    latter = getattr(new.media, "path", None)
-    return policy.same(former, latter, type=getattr(old.media.type, "value", ""))
-
-
-def _requires_delete_send(prior: NormalizedView, fresh: NormalizedView) -> bool:
-    """Return ``True`` when reconciliation requires send+delete fallback."""
-
-    if prior.has_group or fresh.has_group:
-        return True
-
-    restricted = (MediaType.VOICE, MediaType.VIDEO_NOTE)
-    if fresh.media and fresh.media.type in restricted:
-        return True
-    if prior.media and prior.media.type in restricted:
-        return True
-
-    if prior.is_media_payload != fresh.is_media_payload:
-        return True
-
-    return False
-
-
 def _decide_textual(prior: NormalizedView, fresh: NormalizedView) -> Decision:
     """Resolve reconciliation for purely textual payloads."""
 
-    if (_text(prior) or "") == (_text(fresh) or ""):
+    if (text_content(prior) or "") == (text_content(fresh) or ""):
         if (
-                (_textual_extras(prior) != _textual_extras(fresh))
-                or (_preview(prior) != _preview(fresh))
+                (textual_extras(prior) != textual_extras(fresh))
+                or (preview_payload(prior) != preview_payload(fresh))
         ):
             return Decision.EDIT_TEXT
         aligned = match(prior.reply, fresh.reply)
@@ -212,16 +52,16 @@ def _decide_media(
 ) -> Decision:
     """Resolve reconciliation for payloads carrying media objects."""
 
-    if _identical(prior, fresh, config.identity):
-        before = _profile_media(prior, config)
-        after = _profile_media(fresh, config)
+    if identical_media(prior, fresh, config.identity):
+        before = profile_media(prior, config)
+        after = profile_media(fresh, config)
 
         if before.edit != after.edit:
             return Decision.EDIT_MEDIA
 
         if (
                 (caption(prior) or "") == (caption(fresh) or "")
-                and _textual_extras(prior) == _textual_extras(fresh)
+                and textual_extras(prior) == textual_extras(fresh)
                 and before.caption == after.caption
         ):
             aligned = match(prior.reply, fresh.reply)
@@ -237,10 +77,10 @@ def decide(old: Optional[object], new: Payload, config: RenderingConfig) -> Deci
     if not old:
         return Decision.RESEND
 
-    prior = _view_of(old)
-    fresh = _view_of(new)
+    prior = view_of(old)
+    fresh = view_of(new)
 
-    if _requires_delete_send(prior, fresh):
+    if requires_delete_send(prior, fresh):
         return Decision.DELETE_SEND
 
     if not prior.is_media_payload and not fresh.is_media_payload:

--- a/core/service/rendering/media_profile.py
+++ b/core/service/rendering/media_profile.py
@@ -1,0 +1,96 @@
+"""Media comparison helpers used during rendering decisions."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .normalization import NormalizedView
+from .config import RenderingConfig
+from ...entity.media import MediaType
+from ...port.mediaid import MediaIdentityPolicy
+
+
+@dataclass(frozen=True, slots=True)
+class CaptionFlag:
+    """Capture caption-level options relevant for edits."""
+
+    above: bool
+
+
+@dataclass(frozen=True, slots=True)
+class MediaFlag:
+    """Describe media edit options that require resend safeguards."""
+
+    spoiler: bool
+    start: object
+    thumb: bool
+
+
+@dataclass(frozen=True, slots=True)
+class MediaProfile:
+    """Bundle caption and media attributes for comparison."""
+
+    caption: CaptionFlag
+    edit: MediaFlag
+
+
+def profile_media(view: NormalizedView, config: RenderingConfig) -> MediaProfile:
+    """Extract mutable media attributes that affect edit compatibility."""
+
+    payload = dict(view.extra or {})
+    caption = CaptionFlag(above=bool(payload.get("show_caption_above_media")))
+    start = payload.get("start")
+    try:
+        start = int(start) if start is not None else None
+    except Exception:  # pragma: no cover - defensive conversion
+        pass
+    present = bool((payload.get("thumb") is not None) or payload.get("has_thumb"))
+    edit = MediaFlag(
+        spoiler=bool(payload.get("spoiler")),
+        start=start,
+        thumb=(present if config.thumbguard else False),
+    )
+    return MediaProfile(caption=caption, edit=edit)
+
+
+def identical_media(
+    old: NormalizedView,
+    new: NormalizedView,
+    policy: MediaIdentityPolicy,
+) -> bool:
+    """Check whether two views refer to the same underlying media file."""
+
+    if not (old.media and new.media):
+        return False
+    if old.media.type != new.media.type:
+        return False
+    former = getattr(old.media, "path", None)
+    latter = getattr(new.media, "path", None)
+    return policy.same(former, latter, type=getattr(old.media.type, "value", ""))
+
+
+def requires_delete_send(prior: NormalizedView, fresh: NormalizedView) -> bool:
+    """Return ``True`` when reconciliation requires send+delete fallback."""
+
+    if prior.has_group or fresh.has_group:
+        return True
+
+    restricted = (MediaType.VOICE, MediaType.VIDEO_NOTE)
+    if fresh.media and fresh.media.type in restricted:
+        return True
+    if prior.media and prior.media.type in restricted:
+        return True
+
+    if prior.is_media_payload != fresh.is_media_payload:
+        return True
+
+    return False
+
+
+__all__ = [
+    "CaptionFlag",
+    "MediaFlag",
+    "MediaProfile",
+    "identical_media",
+    "profile_media",
+    "requires_delete_send",
+]

--- a/core/service/rendering/normalization.py
+++ b/core/service/rendering/normalization.py
@@ -1,0 +1,108 @@
+"""Normalize rendering inputs into comparison-friendly views."""
+from __future__ import annotations
+
+from collections.abc import Mapping as MappingView
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from ...entity.markup import Markup
+from ...entity.media import MediaItem
+from ...value.content import Preview
+
+
+@dataclass(frozen=True, slots=True)
+class NormalizedView:
+    """Capture the minimal surface we compare across history entries."""
+
+    text: str | None = None
+    media: MediaItem | None = None
+    group: tuple[MediaItem, ...] = ()
+    reply: Markup | None = None
+    extra: Mapping[str, Any] = field(default_factory=dict)
+    preview: Preview | None = None
+
+    @property
+    def has_group(self) -> bool:
+        """Report whether the view represents an album submission."""
+
+        return bool(self.group)
+
+    @property
+    def has_media(self) -> bool:
+        """Report whether the view carries a single media item."""
+
+        return self.media is not None
+
+    @property
+    def is_media_payload(self) -> bool:
+        """Report whether the view is backed by media rather than text."""
+
+        return self.has_group or self.has_media
+
+
+def view_of(source: object | None) -> NormalizedView:
+    """Normalize supported message views into a comparison surface."""
+
+    if source is None:
+        return NormalizedView()
+
+    text = getattr(source, "text", None)
+    media = getattr(source, "media", None)
+    group = getattr(source, "group", None) or ()
+    if group and not isinstance(group, tuple):
+        group = tuple(group)
+
+    reply = getattr(source, "reply", getattr(source, "markup", None))
+
+    extra_value = getattr(source, "extra", None)
+    if isinstance(extra_value, MappingView):
+        extra = dict(extra_value)
+    else:
+        extra = {}
+
+    preview = getattr(source, "preview", None)
+
+    return NormalizedView(
+        text=text,
+        media=media,
+        group=group,
+        reply=reply,
+        extra=extra,
+        preview=preview,
+    )
+
+
+def textual_extras(view: NormalizedView) -> dict[str, Any]:
+    """Preserve extra fields that influence text rendering semantics."""
+
+    data = view.extra or {}
+    snapshot: dict[str, Any] = {}
+    if "mode" in data:
+        snapshot["mode"] = data["mode"]
+    if "entities" in data:
+        snapshot["entities"] = data["entities"]
+    return snapshot
+
+
+def text_content(view: NormalizedView) -> Optional[str]:
+    """Return trimmed textual content when no media is present."""
+
+    if view.is_media_payload:
+        return None
+    value = view.text
+    return str(value).strip() if value is not None else None
+
+
+def preview_payload(view: NormalizedView):
+    """Expose the preview payload so comparisons stay encapsulated."""
+
+    return view.preview
+
+
+__all__ = [
+    "NormalizedView",
+    "preview_payload",
+    "text_content",
+    "textual_extras",
+    "view_of",
+]

--- a/infra/di/container/usecases/history/append.py
+++ b/infra/di/container/usecases/history/append.py
@@ -12,11 +12,12 @@ from navigator.app.usecase.add import (
 )
 from navigator.app.usecase.add_components import (
     AppendEntryAssembler,
-    AppendHistoryAccess,
     AppendHistoryJournal,
     AppendHistoryWriter,
     AppendPayloadAdapter,
     AppendRenderPlanner,
+    HistorySnapshotAccess,
+    StateStatusAccess,
 )
 from navigator.core.telemetry import Telemetry
 
@@ -30,9 +31,13 @@ class AppendUseCaseContainer(containers.DeclarativeContainer):
     history_limit = providers.Dependency()
 
     journal = providers.Factory(AppendHistoryJournal, telemetry=telemetry)
-    history = providers.Factory(
-        AppendHistoryAccess,
+    history_snapshot = providers.Factory(
+        HistorySnapshotAccess,
         archive=storage.chronicle,
+        observer=journal,
+    )
+    state_status = providers.Factory(
+        StateStatusAccess,
         state=storage.status,
         observer=journal,
     )
@@ -48,7 +53,8 @@ class AppendUseCaseContainer(containers.DeclarativeContainer):
     )
     bundle = providers.Factory(
         AppendDependencies,
-        history=history,
+        history=history_snapshot,
+        state=state_status,
         payloads=payloads,
         planner=planner,
         assembler=assembler,

--- a/presentation/bootstrap/runtime_gateway.py
+++ b/presentation/bootstrap/runtime_gateway.py
@@ -1,0 +1,70 @@
+"""Presentation-facing gateway for building navigator runtimes."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol, TYPE_CHECKING
+
+from navigator.app.locks.guard import Guardian
+from navigator.core.contracts import MissingAlert
+from navigator.core.value.message import Scope
+
+from .runtime_factory import NavigatorRuntimeFactory, default_runtime_factory
+
+if TYPE_CHECKING:
+    from navigator.app.service.navigator_runtime.dependencies import NavigatorDependencies
+    from navigator.app.service.navigator_runtime.runtime import NavigatorRuntime
+else:  # pragma: no cover - runtime typing fallback
+    NavigatorDependencies = Any
+    NavigatorRuntime = Any
+
+
+@dataclass(frozen=True)
+class RuntimeRequest:
+    """Capture the information required to provision a runtime instance."""
+
+    scope: Scope
+    guard: Guardian | None = None
+    missing_alert: MissingAlert | None = None
+
+
+class NavigatorRuntimePort(Protocol):
+    """Protocol abstracting runtime construction for presentation layer."""
+
+    def create_runtime(
+        self,
+        dependencies: NavigatorDependencies,
+        request: RuntimeRequest,
+    ) -> NavigatorRuntime:
+        """Provision a runtime using resolved dependencies and request metadata."""
+
+
+class _FactoryRuntimePort:
+    """Default implementation backed by an application runtime factory."""
+
+    def __init__(self, factory: NavigatorRuntimeFactory) -> None:
+        self._factory = factory
+
+    def create_runtime(
+        self,
+        dependencies: NavigatorDependencies,
+        request: RuntimeRequest,
+    ) -> NavigatorRuntime:
+        return self._factory(
+            dependencies,
+            request.scope,
+            guard=request.guard,
+            missing_alert=request.missing_alert,
+        )
+
+
+def default_runtime_port() -> NavigatorRuntimePort:
+    """Return a runtime port backed by the default application factory."""
+
+    return _FactoryRuntimePort(default_runtime_factory())
+
+
+__all__ = [
+    "NavigatorRuntimePort",
+    "RuntimeRequest",
+    "default_runtime_port",
+]


### PR DESCRIPTION
## Summary
- extract normalization and media profiling helpers from the rendering decision module and reuse them in the reconciler
- split append history access into dedicated history and state readers and wire them through the append workflow container
- restructure runtime assembly plans and presentation bootstrap to use dedicated ports, reducing coupling across layers

## Testing
- pytest *(fails: trial.py depends on unavailable manual module in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7ad78868083308b6600afecc3c85a