### PR TITLE
Refactor runtime planning and append history pipeline

### DIFF
--- a/app/service/navigator_runtime/runtime_components.py
+++ b/app/service/navigator_runtime/runtime_components.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import cast
 
 from navigator.core.telemetry import Telemetry
 
@@ -12,7 +11,11 @@ from .history import NavigatorHistoryService
 from .history_builder import build_history_service
 from .reporter import NavigatorReporter
 from .runtime_context import RuntimeBuildContext
-from .runtime_plan import ComponentAssemblyRequest
+from .runtime_plan import (
+    HistoryAssemblyRequest,
+    StateAssemblyRequest,
+    TailAssemblyRequest,
+)
 from .state import NavigatorStateService
 from .state_builder import build_state_service
 from .tail import NavigatorTail
@@ -43,10 +46,13 @@ class HistoryServiceBuilder:
         )
 
     def build_component(
-        self, request: ComponentAssemblyRequest
+        self, request: HistoryAssemblyRequest
     ) -> NavigatorHistoryService:
-        contracts = cast(HistoryContracts, request.contract)
-        return self.build(contracts, **dict(request.parameters))
+        return self.build(
+            request.contract,
+            reporter=request.reporter,
+            bundler=request.bundler,
+        )
 
 
 @dataclass(frozen=True)
@@ -71,10 +77,13 @@ class StateServiceBuilder:
         )
 
     def build_component(
-        self, request: ComponentAssemblyRequest
+        self, request: StateAssemblyRequest
     ) -> NavigatorStateService:
-        contracts = cast(StateContracts, request.contract)
-        return self.build(contracts, **dict(request.parameters))
+        return self.build(
+            request.contract,
+            reporter=request.reporter,
+            missing_alert=request.missing_alert,
+        )
 
 
 @dataclass(frozen=True)
@@ -99,10 +108,13 @@ class TailServiceBuilder:
         )
 
     def build_component(
-        self, request: ComponentAssemblyRequest
+        self, request: TailAssemblyRequest
     ) -> NavigatorTail:
-        contracts = cast(TailContracts, request.contract)
-        return self.build(contracts, **dict(request.parameters))
+        return self.build(
+            request.contract,
+            telemetry=request.telemetry,
+            tail_telemetry=request.tail_telemetry,
+        )
 
 
 @dataclass(frozen=True)

--- a/app/service/store/__init__.py
+++ b/app/service/store/__init__.py
@@ -3,6 +3,7 @@
 from .persistence import (
     HistoryArchiver,
     HistoryPersistencePipeline,
+    HistoryPersistencePipelineFactory,
     HistoryTrimmer,
     LatestMarkerUpdater,
     persist,
@@ -12,6 +13,7 @@ from .preservation import preserve
 __all__ = [
     "HistoryArchiver",
     "HistoryPersistencePipeline",
+    "HistoryPersistencePipelineFactory",
     "HistoryTrimmer",
     "LatestMarkerUpdater",
     "preserve",


### PR DESCRIPTION
## Summary
- replace runtime plan contract resolution with typed assembly requests and helper functions
- update runtime component builders to work with the new plan types
- introduce a reusable history persistence pipeline factory and inject it into the append flow
- add an orchestrator factory to the Telegram retreat providers to decouple wiring from concrete implementations

## Testing
- python -m compileall app/service/navigator_runtime app/service/store app/usecase/add_components.py presentation/telegram/back/providers.py

------
https://chatgpt.com/codex/tasks/task_e_68d7b57609148330a384792c22b450dc