### PR TITLE
Refactor runtime and retreat assembly wiring

### DIFF
--- a/app/service/navigator_runtime/__init__.py
+++ b/app/service/navigator_runtime/__init__.py
@@ -7,7 +7,11 @@ from .api_contracts import (
     NavigatorRuntimeInstrument,
 )
 from .assembly import build_runtime_from_dependencies
-from .runtime_factory import build_navigator_runtime
+from .runtime_factory import (
+    NavigatorRuntimeAssembly,
+    build_navigator_runtime,
+    create_runtime_plan_request,
+)
 from .contracts import HistoryContracts, NavigatorRuntimeContracts, StateContracts, TailContracts
 from navigator.core.contracts.back import NavigatorBackContext, NavigatorBackEvent
 from .bundler import PayloadBundler
@@ -40,7 +44,9 @@ __all__ = [
     "NavigatorBackEvent",
     "NavigatorRuntimeInstrument",
     "NavigatorRuntimeBundleLike",
+    "NavigatorRuntimeAssembly",
     "build_navigator_runtime",
+    "create_runtime_plan_request",
     "build_runtime_from_dependencies",
     "HistoryAddOperation",
     "HistoryBackOperation",

--- a/app/service/navigator_runtime/activation.py
+++ b/app/service/navigator_runtime/activation.py
@@ -7,7 +7,11 @@ from typing import TYPE_CHECKING
 from navigator.app.locks.guard import Guardian
 from navigator.core.value.message import Scope
 
-from .runtime_factory import build_navigator_runtime
+from .runtime_factory import (
+    NavigatorRuntimeAssembly,
+    build_navigator_runtime,
+    create_runtime_plan_request,
+)
 from .dependencies import NavigatorDependencies
 from .runtime import NavigatorRuntime
 from .types import MissingAlert
@@ -28,13 +32,14 @@ class RuntimeActivationPlan:
     def activate(self) -> NavigatorRuntime:
         """Build a runtime instance according to the stored plan."""
 
-        return build_navigator_runtime(
-            usecases=self.dependencies.usecases,
+        plan_request = create_runtime_plan_request(
             scope=self.scope,
-            guard=self.guard,
+            usecases=self.dependencies.usecases,
             telemetry=self.dependencies.telemetry,
             missing_alert=self.missing_alert,
         )
+        assembly = NavigatorRuntimeAssembly(guard=self.guard, plan=plan_request)
+        return build_navigator_runtime(assembly=assembly)
 
 
 def create_activation_plan(

--- a/app/service/navigator_runtime/contracts.py
+++ b/app/service/navigator_runtime/contracts.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from typing import Protocol
+
 from .ports import (
     AlarmUseCase,
     AppendHistoryUseCase,
@@ -14,6 +16,30 @@ from .ports import (
     TrimHistoryUseCase,
 )
 from .usecases import NavigatorUseCases
+
+
+class RuntimeContractSource(Protocol):
+    """Protocol describing objects capable of resolving runtime contracts."""
+
+    def resolve(self) -> "NavigatorRuntimeContracts":
+        """Return contracts that should be used by the runtime."""
+
+
+@dataclass(frozen=True)
+class RuntimeContractSelection(RuntimeContractSource):
+    """Capture how runtime contracts should be resolved for assembly."""
+
+    usecases: NavigatorUseCases | None = None
+    contracts: "NavigatorRuntimeContracts" | None = None
+
+    def resolve(self) -> "NavigatorRuntimeContracts":
+        """Derive runtime contracts from the configured sources."""
+
+        if self.contracts is not None:
+            return self.contracts
+        if self.usecases is None:
+            raise ValueError("either usecases or contracts must be provided")
+        return NavigatorRuntimeContracts.from_usecases(self.usecases)
 
 
 @dataclass(frozen=True)
@@ -73,6 +99,8 @@ class NavigatorRuntimeContracts:
 __all__ = [
     "HistoryContracts",
     "NavigatorRuntimeContracts",
+    "RuntimeContractSelection",
+    "RuntimeContractSource",
     "StateContracts",
     "TailContracts",
 ]

--- a/app/service/navigator_runtime/runtime_factory.py
+++ b/app/service/navigator_runtime/runtime_factory.py
@@ -1,47 +1,82 @@
 """Factory helpers building the navigator runtime."""
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from navigator.app.locks.guard import Guardian
 from navigator.core.telemetry import Telemetry
 from navigator.core.value.message import Scope
 
 from .bundler import PayloadBundler
-from .contracts import NavigatorRuntimeContracts
+from .contracts import NavigatorRuntimeContracts, RuntimeContractSelection
 from .reporter import NavigatorReporter
 from .runtime import NavigatorRuntime
 from .runtime_assembler import NavigatorRuntimeAssembler
-from .runtime_plan import RuntimeAssemblyPlan, create_runtime_plan
+from .runtime_inputs import RuntimeCollaboratorRequest
+from .runtime_plan import RuntimeAssemblyPlan, RuntimePlanRequest, create_runtime_plan
 from .tail_components import TailTelemetry
 from .types import MissingAlert
 from .usecases import NavigatorUseCases
 
 
-def build_navigator_runtime(
+@dataclass(frozen=True)
+class NavigatorRuntimeAssembly:
+    """Capture the minimal context required to assemble the runtime."""
+
+    guard: Guardian
+    plan: RuntimePlanRequest
+
+    @property
+    def scope(self) -> Scope:
+        """Expose scope associated with the runtime plan."""
+
+        return self.plan.collaborators.scope
+
+
+def create_runtime_plan_request(
     *,
+    scope: Scope,
     usecases: NavigatorUseCases | None = None,
     contracts: NavigatorRuntimeContracts | None = None,
-    scope: Scope,
-    guard: Guardian,
     telemetry: Telemetry | None = None,
     bundler: PayloadBundler | None = None,
     reporter: NavigatorReporter | None = None,
     missing_alert: MissingAlert | None = None,
     tail_telemetry: TailTelemetry | None = None,
-) -> NavigatorRuntime:
-    """Create a navigator runtime wiring use cases with cross-cutting tools."""
+) -> RuntimePlanRequest:
+    """Build a runtime plan request aggregating domain and infrastructure inputs."""
 
-    plan = create_runtime_plan(
-        usecases=usecases,
-        contracts=contracts,
+    contract_source = RuntimeContractSelection(
+        usecases=usecases, contracts=contracts
+    )
+    collaborator_request = RuntimeCollaboratorRequest(
         scope=scope,
         telemetry=telemetry,
-        bundler=bundler,
         reporter=reporter,
-        missing_alert=missing_alert,
+        bundler=bundler,
         tail_telemetry=tail_telemetry,
+        missing_alert=missing_alert,
     )
-    assembler = NavigatorRuntimeAssembler.from_context(guard=guard, scope=scope)
+    return RuntimePlanRequest(
+        contracts=contract_source,
+        collaborators=collaborator_request,
+    )
+
+
+def build_navigator_runtime(*, assembly: NavigatorRuntimeAssembly) -> NavigatorRuntime:
+    """Create a navigator runtime wiring use cases with cross-cutting tools."""
+
+    plan = create_runtime_plan(assembly.plan)
+    assembler = NavigatorRuntimeAssembler.from_context(
+        guard=assembly.guard, scope=assembly.scope
+    )
     return assembler.assemble(plan)
 
 
-__all__ = ["RuntimeAssemblyPlan", "build_navigator_runtime", "create_runtime_plan"]
+__all__ = [
+    "NavigatorRuntimeAssembly",
+    "RuntimeAssemblyPlan",
+    "build_navigator_runtime",
+    "create_runtime_plan",
+    "create_runtime_plan_request",
+]


### PR DESCRIPTION
## Summary
- add explicit contract selection and collaborator request objects to simplify navigator runtime planning
- introduce a plan request builder and assembly dataclass so runtime creation no longer wires every dependency directly
- restructure retreat providers and factory helpers to isolate workflow/orchestrator setup behind dedicated helpers

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'manual')*

------
https://chatgpt.com/codex/tasks/task_e_68d7b913b8ac8330840ed0d7fa1c7a32