### PR TITLE
Refine runtime dependency boundaries and contracts

### DIFF
--- a/api/contracts.py
+++ b/api/contracts.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Awaitable, Protocol, SupportsInt, runtime_checkable
 
-from navigator.app.service.navigator_runtime.api_contracts import (
+from navigator.contracts.runtime import (
     NavigatorAssemblyOverrides,
     NavigatorRuntimeBundleLike,
     NavigatorRuntimeInstrument,

--- a/app/service/navigator_runtime/__init__.py
+++ b/app/service/navigator_runtime/__init__.py
@@ -1,15 +1,23 @@
 """Navigator runtime package exposing orchestration helpers."""
 from __future__ import annotations
 
-from .api_contracts import (
+from navigator.contracts.runtime import (
     NavigatorAssemblyOverrides,
     NavigatorRuntimeBundleLike,
     NavigatorRuntimeInstrument,
 )
+
 from .assembly import build_runtime_from_dependencies
+from .dependencies import (
+    RuntimeDomainServices,
+    RuntimeSafetyServices,
+    RuntimeTelemetryServices,
+)
 from .runtime_factory import (
     NavigatorRuntimeAssembly,
     build_navigator_runtime,
+    build_runtime_collaborators,
+    build_runtime_contract_selection,
     create_runtime_plan_request,
 )
 from .contracts import HistoryContracts, NavigatorRuntimeContracts, StateContracts, TailContracts
@@ -45,6 +53,11 @@ __all__ = [
     "NavigatorRuntimeInstrument",
     "NavigatorRuntimeBundleLike",
     "NavigatorRuntimeAssembly",
+    "RuntimeDomainServices",
+    "RuntimeSafetyServices",
+    "RuntimeTelemetryServices",
+    "build_runtime_collaborators",
+    "build_runtime_contract_selection",
     "build_navigator_runtime",
     "create_runtime_plan_request",
     "build_runtime_from_dependencies",

--- a/app/service/navigator_runtime/assembly.py
+++ b/app/service/navigator_runtime/assembly.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 from navigator.app.locks.guard import Guardian
 from navigator.core.value.message import Scope
 
-from .activation import RuntimeActivationPlan
-from .dependencies import NavigatorDependencies
 from .runtime import NavigatorRuntime
+from .snapshot import NavigatorRuntimeSnapshot
 from .types import MissingAlert
 
 
 def build_runtime_from_dependencies(
-    dependencies: NavigatorDependencies,
+    snapshot: NavigatorRuntimeSnapshot,
     scope: Scope,
     *,
     guard: Guardian | None = None,
@@ -19,11 +18,10 @@ def build_runtime_from_dependencies(
 ) -> NavigatorRuntime:
     """Compose a :class:`NavigatorRuntime` from resolved dependencies."""
 
-    plan = RuntimeActivationPlan(
-        dependencies=dependencies,
-        scope=scope,
-        guard=guard or dependencies.guard,
-        missing_alert=missing_alert or dependencies.missing_alert,
+    plan = snapshot.create_activation_plan(
+        scope,
+        guard=guard,
+        missing_alert=missing_alert,
     )
     return plan.activate()
 

--- a/app/service/navigator_runtime/dependencies.py
+++ b/app/service/navigator_runtime/dependencies.py
@@ -5,19 +5,49 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from navigator.app.locks.guard import Guardian
+from navigator.core.telemetry import Telemetry
+
 from .types import MissingAlert
 from .usecases import NavigatorUseCases
-from navigator.core.telemetry import Telemetry
 
 
 @dataclass(frozen=True)
-class NavigatorDependencies:
-    """Minimal set of services required to assemble a navigator runtime."""
+class RuntimeDomainServices:
+    """Expose domain level collaborators required by the runtime."""
 
     usecases: NavigatorUseCases
-    guard: Guardian
+
+
+@dataclass(frozen=True)
+class RuntimeTelemetryServices:
+    """Capture telemetry dependencies for the runtime."""
+
     telemetry: Telemetry
-    missing_alert: MissingAlert
 
 
-__all__ = ["NavigatorDependencies"]
+@dataclass(frozen=True)
+class RuntimeSafetyServices:
+    """Keep runtime safety and alerting facilities grouped together."""
+
+    guard: Guardian
+    missing_alert: MissingAlert | None
+
+    def apply_overrides(
+        self,
+        *,
+        guard: Guardian | None = None,
+        missing_alert: MissingAlert | None = None,
+    ) -> "RuntimeSafetyServices":
+        """Return a new bundle that prefers the provided overrides."""
+
+        return RuntimeSafetyServices(
+            guard=guard or self.guard,
+            missing_alert=missing_alert or self.missing_alert,
+        )
+
+
+__all__ = [
+    "RuntimeDomainServices",
+    "RuntimeSafetyServices",
+    "RuntimeTelemetryServices",
+]

--- a/app/service/navigator_runtime/entrypoints.py
+++ b/app/service/navigator_runtime/entrypoints.py
@@ -1,6 +1,3 @@
-"""Application-level entrypoints for assembling navigator facades."""
-from __future__ import annotations
-
 from collections.abc import Iterable
 from typing import Type, TypeVar
 
@@ -8,11 +5,14 @@ from navigator.bootstrap.navigator import assemble as bootstrap_assemble
 from navigator.bootstrap.navigator.container_resolution import ContainerResolution
 from navigator.bootstrap.navigator.context import ViewContainerFactory
 from navigator.bootstrap.navigator.instrumentation import as_sequence
+from navigator.contracts.runtime import (
+    NavigatorAssemblyOverrides,
+    NavigatorRuntimeInstrument,
+)
 from navigator.core.contracts import MissingAlert
 from navigator.core.port.factory import ViewLedger
 from navigator.core.value.message import Scope
 
-from .api_contracts import NavigatorAssemblyOverrides, NavigatorRuntimeInstrument
 from .facade import NavigatorFacade
 
 FacadeT = TypeVar("FacadeT", bound=NavigatorFacade)

--- a/app/service/navigator_runtime/runtime_factory.py
+++ b/app/service/navigator_runtime/runtime_factory.py
@@ -33,6 +33,36 @@ class NavigatorRuntimeAssembly:
         return self.plan.collaborators.scope
 
 
+def build_runtime_contract_selection(
+    *, usecases: NavigatorUseCases | None = None,
+    contracts: NavigatorRuntimeContracts | None = None,
+) -> RuntimeContractSelection:
+    """Create the contract selection descriptor for a runtime plan."""
+
+    return RuntimeContractSelection(usecases=usecases, contracts=contracts)
+
+
+def build_runtime_collaborators(
+    *,
+    scope: Scope,
+    telemetry: Telemetry | None = None,
+    bundler: PayloadBundler | None = None,
+    reporter: NavigatorReporter | None = None,
+    missing_alert: MissingAlert | None = None,
+    tail_telemetry: TailTelemetry | None = None,
+) -> RuntimeCollaboratorRequest:
+    """Create the collaborator request for a runtime plan."""
+
+    return RuntimeCollaboratorRequest(
+        scope=scope,
+        telemetry=telemetry,
+        reporter=reporter,
+        bundler=bundler,
+        tail_telemetry=tail_telemetry,
+        missing_alert=missing_alert,
+    )
+
+
 def create_runtime_plan_request(
     *,
     scope: Scope,
@@ -46,10 +76,10 @@ def create_runtime_plan_request(
 ) -> RuntimePlanRequest:
     """Build a runtime plan request aggregating domain and infrastructure inputs."""
 
-    contract_source = RuntimeContractSelection(
+    contract_source = build_runtime_contract_selection(
         usecases=usecases, contracts=contracts
     )
-    collaborator_request = RuntimeCollaboratorRequest(
+    collaborator_request = build_runtime_collaborators(
         scope=scope,
         telemetry=telemetry,
         reporter=reporter,
@@ -77,6 +107,8 @@ __all__ = [
     "NavigatorRuntimeAssembly",
     "RuntimeAssemblyPlan",
     "build_navigator_runtime",
+    "build_runtime_collaborators",
+    "build_runtime_contract_selection",
     "create_runtime_plan",
     "create_runtime_plan_request",
 ]

--- a/bootstrap/navigator/instrumentation.py
+++ b/bootstrap/navigator/instrumentation.py
@@ -1,12 +1,9 @@
-"""Shared helpers for normalising instrumentation payloads."""
 from __future__ import annotations
 
 from collections.abc import Iterable
 from typing import Sequence, Tuple, TypeVar
 
-from navigator.app.service.navigator_runtime.api_contracts import (
-    NavigatorRuntimeInstrument,
-)
+from navigator.contracts.runtime import NavigatorRuntimeInstrument
 
 InstrumentT = TypeVar("InstrumentT", bound=NavigatorRuntimeInstrument)
 

--- a/contracts/__init__.py
+++ b/contracts/__init__.py
@@ -1,0 +1,13 @@
+"""Top-level contracts shared across Navigator layers."""
+
+from .runtime import (
+    NavigatorAssemblyOverrides,
+    NavigatorRuntimeBundleLike,
+    NavigatorRuntimeInstrument,
+)
+
+__all__ = [
+    "NavigatorAssemblyOverrides",
+    "NavigatorRuntimeBundleLike",
+    "NavigatorRuntimeInstrument",
+]

--- a/contracts/runtime.py
+++ b/contracts/runtime.py
@@ -1,4 +1,4 @@
-"""Shared contracts for navigator assembly entry points."""
+"""Shared contracts describing runtime assembly collaboration points."""
 from __future__ import annotations
 
 from dataclasses import dataclass

--- a/infra/di/container/runtime.py
+++ b/infra/di/container/runtime.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from dependency_injector import containers, providers
 
 from navigator.core.telemetry import Telemetry
-from navigator.app.service.navigator_runtime.dependencies import NavigatorDependencies
+from navigator.app.service.navigator_runtime.dependencies import (
+    RuntimeDomainServices,
+    RuntimeSafetyServices,
+    RuntimeTelemetryServices,
+)
 from navigator.app.service.navigator_runtime.snapshot import NavigatorRuntimeSnapshot
 
 
@@ -16,11 +20,19 @@ class NavigatorRuntimeContainer(containers.DeclarativeContainer):
     usecases = providers.DependenciesContainer()
     telemetry = providers.Dependency(instance_of=Telemetry)
 
-    navigator_bundle = providers.Factory(
-        NavigatorDependencies,
+    domain_services = providers.Factory(
+        RuntimeDomainServices,
         usecases=usecases.provided.navigator,
-        guard=core.provided.guard,
+    )
+
+    telemetry_services = providers.Factory(
+        RuntimeTelemetryServices,
         telemetry=telemetry,
+    )
+
+    safety_services = providers.Factory(
+        RuntimeSafetyServices,
+        guard=core.provided.guard,
         missing_alert=core.alert,
     )
 
@@ -31,10 +43,11 @@ class NavigatorRuntimeContainer(containers.DeclarativeContainer):
 
     snapshot = providers.Factory(
         NavigatorRuntimeSnapshot,
-        _dependencies=navigator_bundle,
+        domain=domain_services,
+        telemetry=telemetry_services,
+        safety=safety_services,
         redaction=redaction,
     )
 
 
 __all__ = ["NavigatorRuntimeContainer"]
-

--- a/presentation/bootstrap/__init__.py
+++ b/presentation/bootstrap/__init__.py
@@ -2,7 +2,7 @@
 
 from .navigator import (
     NavigatorComposer,
-    NavigatorDependencies,
+    NavigatorRuntimeSnapshot,
     build_runtime,
     compose,
     wrap_runtime,
@@ -10,7 +10,7 @@ from .navigator import (
 
 __all__ = [
     "NavigatorComposer",
-    "NavigatorDependencies",
+    "NavigatorRuntimeSnapshot",
     "build_runtime",
     "compose",
     "wrap_runtime",

--- a/presentation/bootstrap/navigator.py
+++ b/presentation/bootstrap/navigator.py
@@ -1,6 +1,3 @@
-"""Bootstrap helpers assembling presentation navigators."""
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import Any, TYPE_CHECKING
 
@@ -16,10 +13,10 @@ from .runtime_gateway import (
 )
 
 if TYPE_CHECKING:
-    from navigator.app.service.navigator_runtime.dependencies import NavigatorDependencies
+    from navigator.app.service.navigator_runtime.snapshot import NavigatorRuntimeSnapshot
     from navigator.app.service.navigator_runtime.runtime import NavigatorRuntime
 else:  # pragma: no cover - runtime typing fallback
-    NavigatorDependencies = Any
+    NavigatorRuntimeSnapshot = Any
     NavigatorRuntime = Any
 
 
@@ -31,7 +28,7 @@ class NavigatorComposer:
 
     def build_runtime(
         self,
-        dependencies: NavigatorDependencies,
+        dependencies: NavigatorRuntimeSnapshot,
         scope: Scope,
         *,
         guard: Guardian | None = None,
@@ -42,7 +39,7 @@ class NavigatorComposer:
 
     def compose(
         self,
-        dependencies: NavigatorDependencies,
+        dependencies: NavigatorRuntimeSnapshot,
         scope: Scope,
         *,
         guard: Guardian | None = None,
@@ -58,7 +55,7 @@ class NavigatorComposer:
 
 
 def build_runtime(
-    dependencies: NavigatorDependencies,
+    dependencies: NavigatorRuntimeSnapshot,
     scope: Scope,
     *,
     guard: Guardian | None = None,
@@ -84,7 +81,7 @@ def wrap_runtime(runtime: NavigatorRuntime) -> Navigator:
 
 
 def compose(
-    dependencies: NavigatorDependencies,
+    dependencies: NavigatorRuntimeSnapshot,
     scope: Scope,
     *,
     guard: Guardian | None = None,

--- a/presentation/bootstrap/runtime_factory.py
+++ b/presentation/bootstrap/runtime_factory.py
@@ -6,8 +6,8 @@ from typing import Protocol
 
 from navigator.app.locks.guard import Guardian
 from navigator.app.service.navigator_runtime import build_runtime_from_dependencies
-from navigator.app.service.navigator_runtime.dependencies import NavigatorDependencies
 from navigator.app.service.navigator_runtime.runtime import NavigatorRuntime
+from navigator.app.service.navigator_runtime.snapshot import NavigatorRuntimeSnapshot
 from navigator.core.contracts import MissingAlert
 from navigator.core.value.message import Scope
 
@@ -17,7 +17,7 @@ class NavigatorRuntimeFactory(Protocol):
 
     def __call__(
         self,
-        dependencies: NavigatorDependencies,
+        dependencies: NavigatorRuntimeSnapshot,
         scope: Scope,
         *,
         guard: Guardian | None = None,
@@ -30,7 +30,7 @@ def default_runtime_factory() -> NavigatorRuntimeFactory:
     """Return the default runtime factory backed by the application service."""
 
     def _factory(
-        dependencies: NavigatorDependencies,
+        dependencies: NavigatorRuntimeSnapshot,
         scope: Scope,
         *,
         guard: Guardian | None = None,

--- a/presentation/bootstrap/runtime_gateway.py
+++ b/presentation/bootstrap/runtime_gateway.py
@@ -1,6 +1,3 @@
-"""Presentation-facing gateway for building navigator runtimes."""
-from __future__ import annotations
-
 from dataclasses import dataclass
 from typing import Any, Protocol, TYPE_CHECKING
 
@@ -11,10 +8,10 @@ from navigator.core.value.message import Scope
 from .runtime_factory import NavigatorRuntimeFactory, default_runtime_factory
 
 if TYPE_CHECKING:
-    from navigator.app.service.navigator_runtime.dependencies import NavigatorDependencies
+    from navigator.app.service.navigator_runtime.snapshot import NavigatorRuntimeSnapshot
     from navigator.app.service.navigator_runtime.runtime import NavigatorRuntime
 else:  # pragma: no cover - runtime typing fallback
-    NavigatorDependencies = Any
+    NavigatorRuntimeSnapshot = Any
     NavigatorRuntime = Any
 
 
@@ -32,7 +29,7 @@ class NavigatorRuntimePort(Protocol):
 
     def create_runtime(
         self,
-        dependencies: NavigatorDependencies,
+        dependencies: NavigatorRuntimeSnapshot,
         request: RuntimeRequest,
     ) -> NavigatorRuntime:
         """Provision a runtime using resolved dependencies and request metadata."""
@@ -46,7 +43,7 @@ class _FactoryRuntimePort:
 
     def create_runtime(
         self,
-        dependencies: NavigatorDependencies,
+        dependencies: NavigatorRuntimeSnapshot,
         request: RuntimeRequest,
     ) -> NavigatorRuntime:
         return self._factory(


### PR DESCRIPTION
## Summary
- replace the monolithic navigator dependency bundle with dedicated domain, telemetry, and safety service objects that flow through the snapshot and activation plan
- extract shared runtime contracts into `navigator/contracts` so API and bootstrap layers no longer import service internals and adjust DI container plus presentation bootstrap to work with runtime snapshots
- restructure the runtime assembly pipeline into smaller steps to separate provisioning, calibration, composition, and bundling concerns

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7bcf712108330a8469b23b592ca24