### PR TITLE
Refactor entity sanitization and album planning

### DIFF
--- a/adapters/telegram/entities.py
+++ b/adapters/telegram/entities.py
@@ -1,0 +1,65 @@
+"""Telegram-specific entity schema and sanitizer helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from navigator.core.util.entities import (
+    EntitySanitizer,
+    EntitySchema,
+    OptionalFieldRule,
+)
+
+
+def _is_str(value: Any) -> bool:
+    """Return ``True`` when ``value`` is a string instance."""
+
+    return isinstance(value, str)
+
+
+def _is_present(value: Any) -> bool:
+    """Return ``True`` when ``value`` is present (not ``None``)."""
+
+    return value is not None
+
+
+_OPTIONAL_RULES: dict[str, tuple[OptionalFieldRule, ...]] = {
+    "text_link": (("url", _is_str),),
+    "text_mention": (("user", _is_present),),
+    "pre": (("language", _is_str),),
+    "custom_emoji": (("custom_emoji_id", _is_str),),
+}
+
+TELEGRAM_ENTITY_SCHEMA = EntitySchema(
+    allowed_types=(
+        "mention",
+        "hashtag",
+        "cashtag",
+        "bot_command",
+        "url",
+        "email",
+        "phone_number",
+        "bold",
+        "italic",
+        "underline",
+        "strikethrough",
+        "spoiler",
+        "code",
+        "pre",
+        "text_link",
+        "text_mention",
+        "custom_emoji",
+        "blockquote",
+        "expandable_blockquote",
+    ),
+    optional_fields=_OPTIONAL_RULES,
+)
+
+TELEGRAM_ENTITY_SANITIZER = EntitySanitizer(TELEGRAM_ENTITY_SCHEMA)
+
+
+__all__ = [
+    "TELEGRAM_ENTITY_SCHEMA",
+    "TELEGRAM_ENTITY_SANITIZER",
+]
+

--- a/adapters/telegram/serializer/extra.py
+++ b/adapters/telegram/serializer/extra.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from navigator.core.port.extraschema import ExtraSchema
 from navigator.core.service.history.extra import cleanse as history_cleanse
-from navigator.core.util.entities import sanitize
+from .entities import TELEGRAM_ENTITY_SANITIZER
 from navigator.core.value.message import Scope
 from typing import Any, Dict
 
@@ -29,7 +29,7 @@ class TelegramExtraSchema(ExtraSchema):
         return self._compose(scope, extra, span, media, editing=True)
 
     def history(self, extra: dict | None, *, length: int) -> dict | None:
-        return history_cleanse(extra, length=length)
+        return history_cleanse(extra, length=length, entities=TELEGRAM_ENTITY_SANITIZER)
 
     def _compose(
             self,
@@ -125,7 +125,7 @@ class TelegramExtraSchema(ExtraSchema):
         entities = extra.get("entities")
         if not entities:
             return None
-        return sanitize(entities, span or 0) or None
+        return TELEGRAM_ENTITY_SANITIZER.sanitize(entities, span or 0) or None
 
 
 __all__ = ["TelegramExtraSchema"]

--- a/app/internal/policy/prime.py
+++ b/app/internal/policy/prime.py
@@ -6,6 +6,7 @@ from navigator.core.entity.history import Entry, Message
 from navigator.core.entity.media import MediaItem
 from navigator.core.port.clock import Clock
 from navigator.core.service.history.extra import cleanse
+from navigator.core.util.entities import EntitySanitizer
 from navigator.core.value.content import Payload, caption
 
 
@@ -14,6 +15,7 @@ class PrimeEntryFactory:
     """Build lightweight history entries for tail editing workflows."""
 
     clock: Clock
+    entities: EntitySanitizer
 
     def create(self, identifier: int, payload: Payload) -> Entry:
         media = None
@@ -25,7 +27,7 @@ class PrimeEntryFactory:
             )
 
         length = _content_length(payload)
-        extra = cleanse(payload.extra, length=length)
+        extra = cleanse(payload.extra, length=length, entities=self.entities)
         message = Message(
             id=identifier,
             text=None if (payload.media or payload.group) else payload.text,
@@ -57,10 +59,16 @@ def _content_length(payload: Payload) -> int:
     return 0
 
 
-def prime(identifier: int, payload: Payload, *, clock: Clock) -> Entry:
+def prime(
+        identifier: int,
+        payload: Payload,
+        *,
+        clock: Clock,
+        entities: EntitySanitizer,
+) -> Entry:
     """Compatibility wrapper around :class:`PrimeEntryFactory`."""
 
-    return PrimeEntryFactory(clock).create(identifier, payload)
+    return PrimeEntryFactory(clock, entities).create(identifier, payload)
 
 
 __all__ = ["PrimeEntryFactory", "prime"]

--- a/app/service/view/album/__init__.py
+++ b/app/service/view/album/__init__.py
@@ -1,7 +1,8 @@
 """Album refresh orchestration primitives."""
 
 from .mutations import AlbumMutationExecutor
-from .planner import AlbumMutation, AlbumRefreshPlan, AlbumRefreshPlanner
+from .mutation_plan import AlbumMutation
+from .planner import AlbumRefreshPlan, AlbumRefreshPlanner
 from .service import AlbumService
 
 __all__ = [

--- a/app/service/view/album/diff.py
+++ b/app/service/view/album/diff.py
@@ -1,0 +1,94 @@
+"""Album diffing utilities decoupled from mutation planning."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Mapping, Sequence
+
+from navigator.core.entity.media import MediaItem
+
+
+@dataclass(frozen=True, slots=True)
+class AlbumDiff:
+    """Capture high-level album comparison outcomes."""
+
+    retitled: bool
+    reshaped: bool
+
+
+class AlbumComparator:
+    """Compare historic and fresh albums to detect structural changes."""
+
+    def __init__(self, *, thumbguard: bool) -> None:
+        self._thumbguard = thumbguard
+
+    def compare(
+            self,
+            former_band: Sequence[MediaItem],
+            latter_band: Sequence[MediaItem],
+            former_info: Mapping[str, object],
+            latter_info: Mapping[str, object],
+    ) -> AlbumDiff:
+        """Return the diff between the stored and fresh album payloads."""
+
+        retitled = self._retitled(former_band, latter_band, former_info, latter_info)
+        reshaped = self._reshaped(former_info, latter_info)
+        if self._thumbguard:
+            reshaped = reshaped or self._thumb_changed(former_info, latter_info)
+        return AlbumDiff(retitled=retitled, reshaped=reshaped)
+
+    @staticmethod
+    def _retitled(
+            former_band: Sequence[MediaItem],
+            latter_band: Sequence[MediaItem],
+            former_info: Mapping[str, object],
+            latter_info: Mapping[str, object],
+    ) -> bool:
+        return (
+            (former_band[0].caption or "") != (latter_band[0].caption or "")
+            or AlbumComparator._encoded_caption_fields(former_info)
+            != AlbumComparator._encoded_caption_fields(latter_info)
+            or bool(former_info.get("show_caption_above_media"))
+            != bool(latter_info.get("show_caption_above_media"))
+        )
+
+    @staticmethod
+    def _reshaped(
+            former_info: Mapping[str, object], latter_info: Mapping[str, object]
+    ) -> bool:
+        return (
+            bool(former_info.get("spoiler")) != bool(latter_info.get("spoiler"))
+            or AlbumComparator._ensure_int(former_info.get("start"))
+            != AlbumComparator._ensure_int(latter_info.get("start"))
+        )
+
+    @staticmethod
+    def _thumb_changed(
+            former_info: Mapping[str, object], latter_info: Mapping[str, object]
+    ) -> bool:
+        return bool(former_info.get("has_thumb")) != bool(
+            latter_info.get("thumb") is not None
+        )
+
+    @staticmethod
+    def _encoded_caption_fields(extra: Mapping[str, object]) -> str | None:
+        payload = {}
+        if "mode" in extra:
+            payload["mode"] = extra["mode"]
+        if "entities" in extra:
+            payload["entities"] = extra["entities"]
+        if not payload:
+            return None
+        return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+    @staticmethod
+    def _ensure_int(value: object) -> object:
+        try:
+            return int(value) if value is not None else None
+        except Exception:  # pragma: no cover - defensive
+            return value
+
+
+__all__ = ["AlbumComparator", "AlbumDiff"]
+

--- a/app/service/view/album/metadata.py
+++ b/app/service/view/album/metadata.py
@@ -1,0 +1,38 @@
+"""Helpers for deriving album metadata representations."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from navigator.core.entity.history import Message
+from navigator.core.entity.media import MediaItem
+from navigator.core.typing.result import Cluster, GroupMeta
+
+
+class AlbumMetadataBuilder:
+    """Derive lineup identifiers and metadata payloads for albums."""
+
+    def lineup(self, message: Message) -> List[int]:
+        """Return identifiers associated with the stored album head."""
+
+        return [int(message.id)] + [int(extra) for extra in (message.extras or [])]
+
+    def clusters(self, items: Iterable[MediaItem]) -> List[Cluster]:
+        """Return cluster descriptors for the refreshed album payload."""
+
+        clusters: List[Cluster] = []
+        for index, item in enumerate(items):
+            caption = item.caption if index == 0 else ""
+            clusters.append(
+                Cluster(medium=item.type.value, file=item.path, caption=caption)
+            )
+        return clusters
+
+    def meta(self, *, inline: bool, clusters: List[Cluster]) -> GroupMeta:
+        """Build group metadata from inline flag and prepared clusters."""
+
+        return GroupMeta(clusters=clusters, inline=inline)
+
+
+__all__ = ["AlbumMetadataBuilder"]
+

--- a/app/service/view/album/mutation_plan.py
+++ b/app/service/view/album/mutation_plan.py
@@ -1,0 +1,140 @@
+"""Produce album mutation plans without performing side effects."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+from navigator.core.entity.history import Message
+from navigator.core.entity.media import MediaItem
+from navigator.core.service.rendering.decision import Decision
+from navigator.core.service.rendering.helpers import match
+from navigator.core.value.content import Payload
+
+from .diff import AlbumDiff
+
+
+@dataclass(frozen=True, slots=True)
+class AlbumMutation:
+    """Describe a single edit operation required to refresh an album."""
+
+    decision: Decision
+    payload: Payload
+    reference: Message
+
+
+class AlbumMutationPlanner:
+    """Derive album mutations from diff results."""
+
+    def plan(
+            self,
+            *,
+            former: Message,
+            latter: Payload,
+            lineup: Sequence[int],
+            diff: AlbumDiff,
+    ) -> List[AlbumMutation]:
+        """Return mutations required to reconcile ``former`` with ``latter``."""
+
+        former_band = list(former.group or [])
+        latter_band = list(latter.group or [])
+        mutations: List[AlbumMutation] = []
+
+        if diff.retitled and latter_band:
+            mutations.append(self._retitle(former, latter, latter_band[0]))
+
+        if not match(former.markup, latter.reply):
+            mutations.append(
+                AlbumMutation(
+                    decision=Decision.EDIT_MARKUP,
+                    payload=latter,
+                    reference=former,
+                )
+            )
+
+        mutations.extend(
+            self._refresh_media(
+                former,
+                latter,
+                former_band,
+                latter_band,
+                lineup,
+                diff,
+            )
+        )
+        return mutations
+
+    @staticmethod
+    def _retitle(
+            former: Message, latter: Payload, refreshed_head: MediaItem
+    ) -> AlbumMutation:
+        cap = refreshed_head.caption or ""
+        captiondraft = latter.morph(
+            media=refreshed_head,
+            group=None,
+            text=("" if cap == "" else None),
+        )
+        return AlbumMutation(
+            decision=Decision.EDIT_MEDIA_CAPTION,
+            payload=captiondraft,
+            reference=former,
+        )
+
+    def _refresh_media(
+            self,
+            former: Message,
+            latter: Payload,
+            former_band: Sequence[MediaItem],
+            latter_band: Sequence[MediaItem],
+            lineup: Sequence[int],
+            diff: AlbumDiff,
+    ) -> Iterable[AlbumMutation]:
+        for index, pair in enumerate(zip(former_band, latter_band)):
+            past, latest = pair
+            target = lineup[0] if index == 0 else lineup[index]
+            altered = self._changed(past, latest)
+            pathmatch = (
+                isinstance(getattr(past, "path", None), str)
+                and isinstance(getattr(latest, "path", None), str)
+                and getattr(past, "path") == getattr(latest, "path")
+            )
+            if self._should_refresh_media(altered, diff.reshaped, pathmatch):
+                head = former if index == 0 else self._copy(former, target, past)
+                payload = latter.morph(media=latest, group=None)
+                yield AlbumMutation(
+                    decision=Decision.EDIT_MEDIA,
+                    payload=payload,
+                    reference=head,
+                )
+
+    @staticmethod
+    def _should_refresh_media(altered: bool, reshaped: bool, path_match: bool) -> bool:
+        return altered or (reshaped and path_match)
+
+    @staticmethod
+    def _changed(old: MediaItem, new: MediaItem) -> bool:
+        if old.type != new.type:
+            return True
+        prior = getattr(old, "path", None)
+        fresh = getattr(new, "path", None)
+        return not (isinstance(prior, str) and isinstance(fresh, str) and prior == fresh)
+
+    @staticmethod
+    def _copy(message: Message, identifier: int, media: MediaItem) -> Message:
+        return Message(
+            id=identifier,
+            text=None,
+            media=media,
+            group=None,
+            markup=message.markup,
+            preview=message.preview,
+            extra=message.extra,
+            extras=[],
+            inline=message.inline,
+            automated=message.automated,
+            ts=message.ts,
+        )
+
+
+__all__ = ["AlbumMutation", "AlbumMutationPlanner"]
+

--- a/app/service/view/album/mutations.py
+++ b/app/service/view/album/mutations.py
@@ -7,7 +7,7 @@ from typing import Iterable
 from navigator.core.value.message import Scope
 
 from ..executor import EditExecutor
-from .planner import AlbumMutation
+from .mutation_plan import AlbumMutation
 
 
 class AlbumMutationExecutor:

--- a/app/service/view/album/planner.py
+++ b/app/service/view/album/planner.py
@@ -1,28 +1,19 @@
-"""Plan album refresh operations."""
+"""Plan album refresh operations using dedicated collaborators."""
 
 from __future__ import annotations
 
-import json
 from dataclasses import dataclass
-from typing import Iterable, Optional
+from typing import Optional
 
 from navigator.core.entity.history import Message
-from navigator.core.entity.media import MediaItem
 from navigator.core.port.limits import Limits
 from navigator.core.service.rendering.album import aligned
-from navigator.core.service.rendering.decision import Decision
-from navigator.core.service.rendering.helpers import match
-from navigator.core.typing.result import Cluster, GroupMeta
+from navigator.core.typing.result import GroupMeta
 from navigator.core.value.content import Payload
 
-
-@dataclass(frozen=True, slots=True)
-class AlbumMutation:
-    """Describe a single edit operation required to refresh an album."""
-
-    decision: Decision
-    payload: Payload
-    reference: Message
+from .diff import AlbumComparator, AlbumDiff
+from .metadata import AlbumMetadataBuilder
+from .mutation_plan import AlbumMutation, AlbumMutationPlanner
 
 
 @dataclass(frozen=True, slots=True)
@@ -35,135 +26,26 @@ class AlbumRefreshPlan:
     mutations: list[AlbumMutation]
 
 
-@dataclass(frozen=True, slots=True)
-class _AlbumDiff:
-    """Capture high-level album comparison outcomes."""
-
-    retitled: bool
-    reshaped: bool
-
-
-def _lineup(message: Message) -> list[int]:
-    """Return identifiers associated with the stored album head."""
-
-    return [int(message.id)] + [int(extra) for extra in (message.extras or [])]
-
-
-def _changed(old: MediaItem, new: MediaItem) -> bool:
-    """Report whether the replacement media changed type or identity."""
-
-    if old.type != new.type:
-        return True
-    prior = getattr(old, "path", None)
-    fresh = getattr(new, "path", None)
-    return not (isinstance(prior, str) and isinstance(fresh, str) and prior == fresh)
-
-
-def _copy(message: Message, identifier: int, media: MediaItem) -> Message:
-    """Clone ``message`` while replacing media identity and identifier."""
-
-    return Message(
-        id=identifier,
-        text=None,
-        media=media,
-        group=None,
-        markup=message.markup,
-        preview=message.preview,
-        extra=message.extra,
-        extras=[],
-        inline=message.inline,
-        automated=message.automated,
-        ts=message.ts,
-    )
-
-
-def _collect(items: Iterable[MediaItem]) -> list[Cluster]:
-    """Return cluster descriptors for the refreshed album payload."""
-
-    clusters: list[Cluster] = []
-    for index, item in enumerate(items):
-        caption = item.caption if index == 0 else ""
-        clusters.append(Cluster(medium=item.type.value, file=item.path, caption=caption))
-    return clusters
-
-
-def _caption_fields(extra: dict | None) -> dict:
-    """Extract caption-related metadata influencing render decisions."""
-
-    extra = extra or {}
-    view: dict = {}
-    if "mode" in extra:
-        view["mode"] = extra["mode"]
-    if "entities" in extra:
-        view["entities"] = extra["entities"]
-    return view
-
-
-def _encode_dict(value: dict | None) -> Optional[str]:
-    """Return a canonical JSON representation used for comparisons."""
-
-    if not isinstance(value, dict):
-        return None
-    return json.dumps(value, sort_keys=True, separators=(",", ":"))
-
-
-def _ensure_int(value):
-    """Attempt to coerce ``value`` to ``int`` when feasible."""
-
-    try:
-        return int(value) if value is not None else None
-    except Exception:  # pragma: no cover - defensive
-        return value
-
-
-def _compare_album(
-    former_band: list[MediaItem],
-    latter_band: list[MediaItem],
-    former_info: dict,
-    latter_info: dict,
-    *,
-    thumbguard: bool,
-) -> _AlbumDiff:
-    """Summarize structural differences between historic and fresh albums."""
-
-    retitled = (
-        (former_band[0].caption or "") != (latter_band[0].caption or "")
-        or _encode_dict(_caption_fields(former_info))
-        != _encode_dict(_caption_fields(latter_info))
-        or bool(former_info.get("show_caption_above_media"))
-        != bool(latter_info.get("show_caption_above_media"))
-    )
-
-    reshaped = (
-        bool(former_info.get("spoiler")) != bool(latter_info.get("spoiler"))
-        or _ensure_int(former_info.get("start"))
-        != _ensure_int(latter_info.get("start"))
-    )
-
-    if thumbguard:
-        reshaped = reshaped or (
-            bool(former_info.get("has_thumb")) != bool(latter_info.get("thumb") is not None)
-        )
-
-    return _AlbumDiff(retitled=retitled, reshaped=reshaped)
-
-
-def _should_refresh_media(altered: bool, reshaped: bool, path_match: bool) -> bool:
-    """Return ``True`` when media needs refreshing or reshaping."""
-
-    return altered or (reshaped and path_match)
-
-
 class AlbumRefreshPlanner:
     """Derive album refresh plans without performing side effects."""
 
-    def __init__(self, *, limits: Limits, thumbguard: bool) -> None:
+    def __init__(
+            self,
+            *,
+            limits: Limits,
+            thumbguard: bool,
+            comparator: AlbumComparator | None = None,
+            metadata: AlbumMetadataBuilder | None = None,
+            mutations: AlbumMutationPlanner | None = None,
+    ) -> None:
         self._limits = limits
-        self._thumbguard = thumbguard
+        self._comparator = comparator or AlbumComparator(thumbguard=thumbguard)
+        self._metadata = metadata or AlbumMetadataBuilder()
+        self._mutations = mutations or AlbumMutationPlanner()
 
     def prepare(self, former: Message, latter: Payload) -> Optional[AlbumRefreshPlan]:
-        formerband = former.group or []
-        latterband = latter.group or []
+        formerband = list(former.group or [])
+        latterband = list(latter.group or [])
 
         if not (
             formerband
@@ -172,65 +54,19 @@ class AlbumRefreshPlanner:
         ):
             return None
 
-        lineup = _lineup(former)
-        formerinfo = former.extra or {}
-        latterinfo = latter.extra or {}
-        diff = _compare_album(
-            formerband,
-            latterband,
-            formerinfo,
-            latterinfo,
-            thumbguard=self._thumbguard,
+        lineup = self._metadata.lineup(former)
+        formerinfo = dict(former.extra or {})
+        latterinfo = dict(latter.extra or {})
+        diff = self._compare(formerband, latterband, formerinfo, latterinfo)
+
+        mutations = self._mutations.plan(
+            former=former,
+            latter=latter,
+            lineup=lineup,
+            diff=diff,
         )
-
-        mutations: list[AlbumMutation] = []
-
-        if diff.retitled:
-            cap = latterband[0].caption or ""
-            captiondraft = latter.morph(
-                media=latterband[0],
-                group=None,
-                text=("" if cap == "" else None),
-            )
-            mutations.append(
-                AlbumMutation(
-                    decision=Decision.EDIT_MEDIA_CAPTION,
-                    payload=captiondraft,
-                    reference=former,
-                )
-            )
-
-        if not match(former.markup, latter.reply):
-            mutations.append(
-                AlbumMutation(
-                    decision=Decision.EDIT_MARKUP,
-                    payload=latter,
-                    reference=former,
-                )
-            )
-
-        for index, pair in enumerate(zip(formerband, latterband)):
-            past, latest = pair
-            target = lineup[0] if index == 0 else lineup[index]
-            altered = _changed(past, latest)
-            pathmatch = (
-                isinstance(getattr(past, "path", None), str)
-                and isinstance(getattr(latest, "path", None), str)
-                and getattr(past, "path") == getattr(latest, "path")
-            )
-            if _should_refresh_media(altered, diff.reshaped, pathmatch):
-                head = former if index == 0 else _copy(former, target, past)
-                payload = latter.morph(media=latest, group=None)
-                mutations.append(
-                    AlbumMutation(
-                        decision=Decision.EDIT_MEDIA,
-                        payload=payload,
-                        reference=head,
-                    )
-                )
-
-        clusters = _collect(latterband)
-        meta = GroupMeta(clusters=clusters, inline=former.inline)
+        clusters = self._metadata.clusters(latterband)
+        meta = self._metadata.meta(inline=former.inline, clusters=clusters)
 
         return AlbumRefreshPlan(
             lineup=lineup,
@@ -239,9 +75,20 @@ class AlbumRefreshPlanner:
             mutations=mutations,
         )
 
+    def _compare(
+            self,
+            former_band: list,
+            latter_band: list,
+            former_info: dict,
+            latter_info: dict,
+    ) -> AlbumDiff:
+        return self._comparator.compare(
+            former_band,
+            latter_band,
+            former_info,
+            latter_info,
+        )
 
-__all__ = [
-    "AlbumMutation",
-    "AlbumRefreshPlan",
-    "AlbumRefreshPlanner",
-]
+
+__all__ = ["AlbumMutation", "AlbumRefreshPlan", "AlbumRefreshPlanner"]
+

--- a/app/usecase/add_components.py
+++ b/app/usecase/add_components.py
@@ -1,191 +1,18 @@
-"""Supporting collaborators for the ``add`` use case."""
+"""Aggregate reusable components required by the add use case."""
 
 from __future__ import annotations
 
-import logging
-from typing import List, Optional, Sequence, Protocol
-
-from navigator.app.map.entry import EntryMapper, Outcome
-from navigator.app.service.view.planner import ViewPlanner
-from navigator.app.service.view.policy import adapt
-from navigator.app.service.store import (
-    HistoryPersistencePipeline,
-    HistoryPersistencePipelineFactory,
-)
-from navigator.core.entity.history import Entry
-from navigator.core.port.history import HistoryRepository
-from navigator.core.port.state import StateRepository
-from navigator.core.service.scope import profile
-from navigator.core.telemetry import LogCode, Telemetry, TelemetryChannel
-from navigator.core.value.content import Payload, normalize
-from navigator.core.value.message import Scope
-from .render_contract import RenderOutcome
-
-
-class AppendHistoryObserver(Protocol):
-    """Protocol describing side effects performed during append access."""
-
-    def history_loaded(self, scope: Scope, count: int) -> None: ...
-
-    def state_retrieved(self, status: Optional[str]) -> None: ...
-
-
-class NullAppendHistoryObserver:
-    """No-op implementation shielding access from optional observers."""
-
-    def history_loaded(self, scope: Scope, count: int) -> None:  # pragma: no cover - no-op
-        return
-
-    def state_retrieved(self, status: Optional[str]) -> None:  # pragma: no cover - no-op
-        return
-
-
-class AppendHistoryJournal(AppendHistoryObserver):
-    """Emit telemetry envelopes for append history events."""
-
-    def __init__(self, telemetry: Telemetry) -> None:
-        self._channel: TelemetryChannel = telemetry.channel(f"{__name__}.history")
-
-    def history_loaded(self, scope: Scope, count: int) -> None:
-        self._channel.emit(
-            logging.DEBUG,
-            LogCode.HISTORY_LOAD,
-            op="add",
-            history={"len": count},
-            scope=profile(scope),
-        )
-
-    def state_retrieved(self, status: Optional[str]) -> None:
-        self._channel.emit(
-            logging.INFO,
-            LogCode.STATE_GET,
-            op="add",
-            state={"current": status},
-        )
-
-
-class HistorySnapshotAccess:
-    """Expose history snapshots while notifying interested observers."""
-
-    def __init__(
-            self,
-            archive: HistoryRepository,
-            observer: AppendHistoryObserver | None = None,
-    ) -> None:
-        self._archive = archive
-        self._observer: AppendHistoryObserver = observer or NullAppendHistoryObserver()
-
-    async def snapshot(self, scope: Scope) -> List[Entry]:
-        records = await self._archive.recall()
-        self._observer.history_loaded(scope, len(records))
-        return records
-
-
-class StateStatusAccess:
-    """Retrieve state information while surfacing observer notifications."""
-
-    def __init__(
-            self,
-            state: StateRepository,
-            observer: AppendHistoryObserver | None = None,
-    ) -> None:
-        self._state = state
-        self._observer: AppendHistoryObserver = observer or NullAppendHistoryObserver()
-
-    async def status(self) -> Optional[str]:
-        status = await self._state.status()
-        self._observer.state_retrieved(status)
-        return status
-
-
-class AppendHistoryWriter:
-    """Persist history timelines while applying pruning policy."""
-
-    def __init__(
-            self,
-            pipeline_factory: HistoryPersistencePipelineFactory,
-            *,
-            pipeline: HistoryPersistencePipeline | None = None,
-    ) -> None:
-        self._pipeline_factory = pipeline_factory
-        self._pipeline = pipeline
-
-    def _resolve_pipeline(self) -> HistoryPersistencePipeline:
-        if self._pipeline is None:
-            self._pipeline = self._pipeline_factory.create()
-        return self._pipeline
-
-    async def persist(self, timeline: Sequence[Entry]) -> None:
-        pipeline = self._resolve_pipeline()
-        await pipeline.persist(list(timeline), operation="add")
-
-
-class AppendPayloadAdapter:
-    """Apply normalisation and scope-specific adjustments to payload bundles."""
-
-    def normalize(self, scope: Scope, bundle: List[Payload]) -> List[Payload]:
-        return [adapt(scope, normalize(payload)) for payload in bundle]
-
-
-class AppendRenderPlanner:
-    """Delegate render planning to the configured view planner."""
-
-    def __init__(self, planner: ViewPlanner) -> None:
-        self._planner = planner
-
-    async def plan(
-            self,
-            scope: Scope,
-            payloads: Sequence[Payload],
-            trail: Optional[Entry],
-    ) -> object:
-        return await self._planner.render(
-            scope,
-            payloads,
-            trail,
-            inline=bool(scope.inline),
-        )
-
-
-class AppendEntryAssembler:
-    """Build entries and timelines using render outcomes."""
-
-    def __init__(self, mapper: EntryMapper) -> None:
-        self._mapper = mapper
-
-    def build_entry(
-            self,
-            adjusted: List[Payload],
-            render: RenderOutcome,
-            state: Optional[str],
-            view: Optional[str],
-            root: bool,
-            *,
-            base: Optional[Entry] = None,
-    ) -> Entry:
-        identifiers = list(render.ids)
-        usable = adjusted[:len(identifiers)]
-        outcome = Outcome(identifiers, list(render.extras), list(render.metas))
-        return self._mapper.convert(
-            outcome,
-            usable,
-            state,
-            view,
-            root,
-            base=base,
-        )
-
-    @staticmethod
-    def extend_timeline(records: List[Entry], entry: Entry, root: bool) -> List[Entry]:
-        if root:
-            return [entry]
-        return [*records, entry]
+from .add_support.assembly import AppendEntryAssembler
+from .add_support.history import AppendHistoryWriter, HistorySnapshotAccess, StateStatusAccess
+from .add_support.observer import AppendHistoryJournal, AppendHistoryObserver, NullAppendHistoryObserver
+from .add_support.payload import AppendPayloadAdapter
+from .add_support.rendering import AppendRenderPlanner
 
 
 __all__ = [
     "AppendEntryAssembler",
-    "AppendHistoryObserver",
     "AppendHistoryJournal",
+    "AppendHistoryObserver",
     "AppendHistoryWriter",
     "AppendPayloadAdapter",
     "AppendRenderPlanner",
@@ -193,3 +20,4 @@ __all__ = [
     "NullAppendHistoryObserver",
     "StateStatusAccess",
 ]
+

--- a/app/usecase/add_support/__init__.py
+++ b/app/usecase/add_support/__init__.py
@@ -1,0 +1,4 @@
+"""Support components reused by the add use case."""
+
+__all__ = []
+

--- a/app/usecase/add_support/assembly.py
+++ b/app/usecase/add_support/assembly.py
@@ -1,0 +1,50 @@
+"""Timeline assembly helpers for the add use case."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from navigator.app.map.entry import EntryMapper, Outcome
+from navigator.core.entity.history import Entry
+from navigator.core.value.content import Payload
+
+from ..render_contract import RenderOutcome
+
+
+class AppendEntryAssembler:
+    """Build entries and timelines using render outcomes."""
+
+    def __init__(self, mapper: EntryMapper) -> None:
+        self._mapper = mapper
+
+    def build_entry(
+            self,
+            adjusted: List[Payload],
+            render: RenderOutcome,
+            state: Optional[str],
+            view: Optional[str],
+            root: bool,
+            *,
+            base: Optional[Entry] = None,
+    ) -> Entry:
+        identifiers = list(render.ids)
+        usable = adjusted[:len(identifiers)]
+        outcome = Outcome(identifiers, list(render.extras), list(render.metas))
+        return self._mapper.convert(
+            outcome,
+            usable,
+            state,
+            view,
+            root,
+            base=base,
+        )
+
+    @staticmethod
+    def extend_timeline(records: List[Entry], entry: Entry, root: bool) -> List[Entry]:
+        if root:
+            return [entry]
+        return [*records, entry]
+
+
+__all__ = ["AppendEntryAssembler"]
+

--- a/app/usecase/add_support/history.py
+++ b/app/usecase/add_support/history.py
@@ -1,0 +1,80 @@
+"""History access and persistence helpers for the add use case."""
+
+from __future__ import annotations
+
+from typing import List, Optional, Sequence
+
+from navigator.core.entity.history import Entry
+from navigator.core.port.history import HistoryRepository
+from navigator.core.port.state import StateRepository
+from navigator.core.value.message import Scope
+
+from .observer import AppendHistoryObserver, NullAppendHistoryObserver
+from ...service.store import (
+    HistoryPersistencePipeline,
+    HistoryPersistencePipelineFactory,
+)
+
+
+class HistorySnapshotAccess:
+    """Expose history snapshots while notifying interested observers."""
+
+    def __init__(
+            self,
+            archive: HistoryRepository,
+            observer: AppendHistoryObserver | None = None,
+    ) -> None:
+        self._archive = archive
+        self._observer: AppendHistoryObserver = observer or NullAppendHistoryObserver()
+
+    async def snapshot(self, scope: Scope) -> List[Entry]:
+        records = await self._archive.recall()
+        self._observer.history_loaded(scope, len(records))
+        return records
+
+
+class StateStatusAccess:
+    """Retrieve state information while surfacing observer notifications."""
+
+    def __init__(
+            self,
+            state: StateRepository,
+            observer: AppendHistoryObserver | None = None,
+    ) -> None:
+        self._state = state
+        self._observer: AppendHistoryObserver = observer or NullAppendHistoryObserver()
+
+    async def status(self) -> Optional[str]:
+        status = await self._state.status()
+        self._observer.state_retrieved(status)
+        return status
+
+
+class AppendHistoryWriter:
+    """Persist history timelines while applying pruning policy."""
+
+    def __init__(
+            self,
+            pipeline_factory: HistoryPersistencePipelineFactory,
+            *,
+            pipeline: HistoryPersistencePipeline | None = None,
+    ) -> None:
+        self._pipeline_factory = pipeline_factory
+        self._pipeline = pipeline
+
+    def _resolve_pipeline(self) -> HistoryPersistencePipeline:
+        if self._pipeline is None:
+            self._pipeline = self._pipeline_factory.create()
+        return self._pipeline
+
+    async def persist(self, timeline: Sequence[Entry]) -> None:
+        pipeline = self._resolve_pipeline()
+        await pipeline.persist(list(timeline), operation="add")
+
+
+__all__ = [
+    "AppendHistoryWriter",
+    "HistorySnapshotAccess",
+    "StateStatusAccess",
+]
+

--- a/app/usecase/add_support/observer.py
+++ b/app/usecase/add_support/observer.py
@@ -1,0 +1,60 @@
+"""Telemetry observers for add-use-case history interactions."""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional, Protocol
+
+from navigator.core.service.scope import profile
+from navigator.core.telemetry import LogCode, Telemetry, TelemetryChannel
+from navigator.core.value.message import Scope
+
+
+class AppendHistoryObserver(Protocol):
+    """Protocol describing side effects performed during append access."""
+
+    def history_loaded(self, scope: Scope, count: int) -> None: ...
+
+    def state_retrieved(self, status: Optional[str]) -> None: ...
+
+
+class NullAppendHistoryObserver:
+    """No-op implementation shielding access from optional observers."""
+
+    def history_loaded(self, scope: Scope, count: int) -> None:  # pragma: no cover - no-op
+        return
+
+    def state_retrieved(self, status: Optional[str]) -> None:  # pragma: no cover - no-op
+        return
+
+
+class AppendHistoryJournal(AppendHistoryObserver):
+    """Emit telemetry envelopes for append history events."""
+
+    def __init__(self, telemetry: Telemetry) -> None:
+        self._channel: TelemetryChannel = telemetry.channel(f"{__name__}.history")
+
+    def history_loaded(self, scope: Scope, count: int) -> None:
+        self._channel.emit(
+            logging.DEBUG,
+            LogCode.HISTORY_LOAD,
+            op="add",
+            history={"len": count},
+            scope=profile(scope),
+        )
+
+    def state_retrieved(self, status: Optional[str]) -> None:
+        self._channel.emit(
+            logging.INFO,
+            LogCode.STATE_GET,
+            op="add",
+            state={"current": status},
+        )
+
+
+__all__ = [
+    "AppendHistoryJournal",
+    "AppendHistoryObserver",
+    "NullAppendHistoryObserver",
+]
+

--- a/app/usecase/add_support/payload.py
+++ b/app/usecase/add_support/payload.py
@@ -1,0 +1,21 @@
+"""Payload normalization helpers for add operations."""
+
+from __future__ import annotations
+
+from typing import List
+
+from navigator.core.value.content import Payload, normalize
+from navigator.core.value.message import Scope
+
+from ...service.view.policy import adapt
+
+
+class AppendPayloadAdapter:
+    """Apply normalisation and scope-specific adjustments to payload bundles."""
+
+    def normalize(self, scope: Scope, bundle: List[Payload]) -> List[Payload]:
+        return [adapt(scope, normalize(payload)) for payload in bundle]
+
+
+__all__ = ["AppendPayloadAdapter"]
+

--- a/app/usecase/add_support/rendering.py
+++ b/app/usecase/add_support/rendering.py
@@ -1,0 +1,34 @@
+"""Rendering helpers delegated by the add use case."""
+
+from __future__ import annotations
+
+from typing import Optional, Sequence
+
+from ...core.entity.history import Entry
+from ...core.value.content import Payload
+from ...core.value.message import Scope
+from ...service.view.planner import ViewPlanner
+
+
+class AppendRenderPlanner:
+    """Delegate render planning to the configured view planner."""
+
+    def __init__(self, planner: ViewPlanner) -> None:
+        self._planner = planner
+
+    async def plan(
+            self,
+            scope: Scope,
+            payloads: Sequence[Payload],
+            trail: Optional[Entry],
+    ) -> object:
+        return await self._planner.render(
+            scope,
+            payloads,
+            trail,
+            inline=bool(scope.inline),
+        )
+
+
+__all__ = ["AppendRenderPlanner"]
+

--- a/core/service/rendering/config.py
+++ b/core/service/rendering/config.py
@@ -5,12 +5,13 @@ from dataclasses import dataclass, field
 from ...port.mediaid import MediaIdentityPolicy
 
 
-class _FileIdIdentity(MediaIdentityPolicy):
-    """Match media payloads by their Telegram ``file_id`` value."""
+class StringIdentityPolicy(MediaIdentityPolicy):
+    """Match media payloads by a shared string identity."""
 
     def same(self, former: object, latter: object, *, type: str) -> bool:
-        """Return ``True`` when both identifiers reference the same file."""
+        """Return ``True`` when both identifiers reference the same value."""
 
+        del type
         return isinstance(former, str) and isinstance(latter, str) and former == latter
 
 
@@ -19,4 +20,7 @@ class RenderingConfig:
     """Capture knobs affecting render decisions and reconciliation."""
 
     thumbguard: bool = False
-    identity: MediaIdentityPolicy = field(default_factory=_FileIdIdentity)
+    identity: MediaIdentityPolicy = field(default_factory=StringIdentityPolicy)
+
+
+__all__ = ["RenderingConfig", "StringIdentityPolicy"]

--- a/infra/di/container/bindings/integration.py
+++ b/infra/di/container/bindings/integration.py
@@ -21,6 +21,7 @@ class IntegrationBindings(containers.DeclarativeContainer):
         StorageContainer,
         core=core.provided.core,
         telemetry=telemetry,
+        entities=view_container.provided.entities,
     )
     view = providers.Container(
         view_container,

--- a/infra/di/container/storage.py
+++ b/infra/di/container/storage.py
@@ -3,17 +3,24 @@ from __future__ import annotations
 from dependency_injector import containers, providers
 from navigator.adapters.storage.fsm import Chronicle, Latest, Status
 from navigator.app.map.entry import EntryMapper
+from navigator.core.util.entities import EntitySanitizer
 from navigator.core.telemetry import Telemetry
 
 
 class StorageContainer(containers.DeclarativeContainer):
     core = providers.DependenciesContainer()
     telemetry = providers.Dependency(instance_of=Telemetry)
+    entities = providers.Dependency(instance_of=EntitySanitizer)
 
     chronicle = providers.Factory(Chronicle, state=core.state, telemetry=telemetry)
     status = providers.Factory(Status, state=core.state, telemetry=telemetry)
     latest = providers.Factory(Latest, state=core.state, telemetry=telemetry)
-    mapper = providers.Factory(EntryMapper, ledger=core.ledger, clock=core.clock)
+    mapper = providers.Factory(
+        EntryMapper,
+        ledger=core.ledger,
+        clock=core.clock,
+        entities=entities,
+    )
 
 
 __all__ = ["StorageContainer"]

--- a/infra/di/container/telegram.py
+++ b/infra/di/container/telegram.py
@@ -1,6 +1,7 @@
 from dependency_injector import containers, providers
 
 from navigator.adapters.telegram.codec import AiogramCodec
+from navigator.adapters.telegram.entities import TELEGRAM_ENTITY_SANITIZER
 from navigator.adapters.telegram.gateway import create_gateway
 from navigator.adapters.telegram.media import TelegramMediaPolicy
 from navigator.adapters.telegram.serializer import (
@@ -22,6 +23,7 @@ class TelegramContainer(containers.DeclarativeContainer):
     schema = providers.Factory(TelegramExtraSchema)
     preview = providers.Factory(TelegramLinkPreviewCodec)
     policy = providers.Factory(TelegramMediaPolicy, strict=core.settings.provided.strictpath)
+    entities = providers.Object(TELEGRAM_ENTITY_SANITIZER)
     screen = providers.Factory(SignatureScreen, telemetry=telemetry)
     gateway = providers.Factory(
         create_gateway,

--- a/infra/di/container/usecases/tail.py
+++ b/infra/di/container/usecases/tail.py
@@ -59,7 +59,11 @@ class TailUseCaseContainer(containers.DeclarativeContainer):
         journal=tail_history_journal,
     )
     tail_mutator = providers.Factory(TailHistoryMutator)
-    tail_prime = providers.Factory(PrimeEntryFactory, clock=core.clock)
+    tail_prime = providers.Factory(
+        PrimeEntryFactory,
+        clock=core.clock,
+        entities=storage.entities,
+    )
     tail_decision = providers.Factory(
         TailDecisionService,
         rendering=core.rendering,


### PR DESCRIPTION
## Summary
- introduce schema-driven entity sanitization and expose a Telegram-specific sanitizer
- restructure album refresh planning into dedicated diff, metadata and mutation builders
- split add use-case collaborators into cohesive support modules and update pipeline factories and DI bindings accordingly
- wire entity sanitizers through history helpers, entry mapping, and prime entry factory along with a transport-agnostic media identity policy

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'manual')*
- python -m compileall adapters app core infra


------
https://chatgpt.com/codex/tasks/task_e_68d7c114f81c833082a870ff9b95b180