### PR TITLE
Refactor runtime planning and retreat orchestration modules

### DIFF
--- a/app/service/navigator_runtime/runtime_plan_request_builder.py
+++ b/app/service/navigator_runtime/runtime_plan_request_builder.py
@@ -1,0 +1,103 @@
+"""Builders producing runtime plan requests from domain inputs."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from navigator.core.telemetry import Telemetry
+
+from .bundler import PayloadBundler
+from .contracts import NavigatorRuntimeContracts, RuntimeContractSelection
+from .reporter import NavigatorReporter
+from .runtime_inputs import RuntimeCollaboratorRequest
+from .runtime_plan import RuntimePlanRequest
+from .tail_components import TailTelemetry
+from .types import MissingAlert
+from .usecases import NavigatorUseCases
+from navigator.core.value.message import Scope
+
+
+@dataclass(frozen=True)
+class RuntimeContractSelector:
+    """Build contract selections isolating domain knowledge."""
+
+    def select(
+        self,
+        *,
+        usecases: NavigatorUseCases | None = None,
+        contracts: NavigatorRuntimeContracts | None = None,
+    ) -> RuntimeContractSelection:
+        """Return a contract selection wrapper for runtime planning."""
+
+        return RuntimeContractSelection(usecases=usecases, contracts=contracts)
+
+
+@dataclass(frozen=True)
+class RuntimeCollaboratorFactory:
+    """Create collaborator requests decoupled from request orchestration."""
+
+    def create(
+        self,
+        *,
+        scope: Scope,
+        telemetry: Telemetry | None = None,
+        bundler: PayloadBundler | None = None,
+        reporter: NavigatorReporter | None = None,
+        missing_alert: MissingAlert | None = None,
+        tail_telemetry: TailTelemetry | None = None,
+    ) -> RuntimeCollaboratorRequest:
+        """Return a collaborator request describing runtime auxiliaries."""
+
+        return RuntimeCollaboratorRequest(
+            scope=scope,
+            telemetry=telemetry,
+            reporter=reporter,
+            bundler=bundler,
+            tail_telemetry=tail_telemetry,
+            missing_alert=missing_alert,
+        )
+
+
+@dataclass(frozen=True)
+class RuntimePlanRequestBuilder:
+    """Coordinate individual builders to produce runtime plan requests."""
+
+    contract_selector: RuntimeContractSelector
+    collaborator_factory: RuntimeCollaboratorFactory
+
+    def build(
+        self,
+        *,
+        scope: Scope,
+        usecases: NavigatorUseCases | None = None,
+        contracts: NavigatorRuntimeContracts | None = None,
+        telemetry: Telemetry | None = None,
+        bundler: PayloadBundler | None = None,
+        reporter: NavigatorReporter | None = None,
+        missing_alert: MissingAlert | None = None,
+        tail_telemetry: TailTelemetry | None = None,
+    ) -> RuntimePlanRequest:
+        """Create a runtime plan request aggregating domain and tooling inputs."""
+
+        contract_source = self.contract_selector.select(
+            usecases=usecases,
+            contracts=contracts,
+        )
+        collaborator_request = self.collaborator_factory.create(
+            scope=scope,
+            telemetry=telemetry,
+            bundler=bundler,
+            reporter=reporter,
+            missing_alert=missing_alert,
+            tail_telemetry=tail_telemetry,
+        )
+        return RuntimePlanRequest(
+            contracts=contract_source,
+            collaborators=collaborator_request,
+        )
+
+
+__all__ = [
+    "RuntimeCollaboratorFactory",
+    "RuntimeContractSelector",
+    "RuntimePlanRequestBuilder",
+]

--- a/infra/config/redaction.py
+++ b/infra/config/redaction.py
@@ -1,0 +1,21 @@
+"""Abstractions exposing runtime redaction settings."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RuntimeRedactionConfig:
+    """Structured representation of redaction options."""
+
+    value: str = ""
+
+    @classmethod
+    def from_settings(cls, settings: object) -> "RuntimeRedactionConfig":
+        """Build configuration from infrastructure settings."""
+
+        value = getattr(settings, "redaction", "")
+        return cls(value=value)
+
+
+__all__ = ["RuntimeRedactionConfig"]

--- a/infra/di/container/runtime.py
+++ b/infra/di/container/runtime.py
@@ -11,6 +11,7 @@ from navigator.app.service.navigator_runtime.dependencies import (
     RuntimeTelemetryServices,
 )
 from navigator.app.service.navigator_runtime.snapshot import NavigatorRuntimeSnapshot
+from navigator.infra.config.redaction import RuntimeRedactionConfig
 
 
 class NavigatorRuntimeContainer(containers.DeclarativeContainer):
@@ -36,9 +37,9 @@ class NavigatorRuntimeContainer(containers.DeclarativeContainer):
         missing_alert=core.alert,
     )
 
-    redaction = providers.Callable(
-        lambda settings: getattr(settings, "redaction", ""),
-        core.provided.settings,
+    redaction = providers.Factory(
+        RuntimeRedactionConfig.from_settings,
+        settings=core.provided.settings,
     )
 
     snapshot = providers.Factory(
@@ -46,7 +47,7 @@ class NavigatorRuntimeContainer(containers.DeclarativeContainer):
         domain=domain_services,
         telemetry=telemetry_services,
         safety=safety_services,
-        redaction=redaction,
+        redaction=redaction.provided.value,
     )
 
 

--- a/presentation/telegram/back/__init__.py
+++ b/presentation/telegram/back/__init__.py
@@ -7,11 +7,15 @@ from .factory import (
     create_retreat_handler,
 )
 from .handler import RetreatHandler
+from .failures import RetreatFailurePolicy
 from .orchestrator import RetreatOrchestrator
+from .reporting import RetreatOutcomeReporter
 from .outcome import RetreatOutcome
 from .providers import default_retreat_providers
 from .protocols import NavigatorBack, RetreatFailureTranslator, Translator
+from .runner import RetreatWorkflowRunner
 from .result import RetreatResult
+from .session import TelemetryScopeFactory, TelemetryScopeSession
 from .telemetry import RetreatTelemetry
 from .workflow import RetreatBackExecutor, RetreatFailureHandler, RetreatWorkflow
 
@@ -22,14 +26,19 @@ __all__ = [
     "RetreatHandlerOverrides",
     "RetreatHandlerProviders",
     "RetreatOrchestrator",
+    "RetreatOutcomeReporter",
     "RetreatOutcome",
     "RetreatResult",
     "RetreatTelemetry",
+    "RetreatFailurePolicy",
+    "RetreatWorkflowRunner",
     "RetreatBackExecutor",
     "RetreatFailureHandler",
     "RetreatFailureTranslator",
     "RetreatWorkflow",
     "Translator",
+    "TelemetryScopeFactory",
+    "TelemetryScopeSession",
     "default_retreat_providers",
     "create_retreat_handler",
 ]

--- a/presentation/telegram/back/assembly.py
+++ b/presentation/telegram/back/assembly.py
@@ -1,0 +1,127 @@
+"""Assembly helpers orchestrating retreat handler collaborators."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, TYPE_CHECKING
+
+from navigator.core.telemetry import Telemetry
+
+from .handler import RetreatHandler
+from .orchestrator import RetreatOrchestrator
+from .outcome import RetreatOutcomeFactory
+from .protocols import RetreatFailureTranslator, Translator
+from .telemetry import RetreatTelemetry
+
+if TYPE_CHECKING:
+    from .context import RetreatContextBuilder
+    from .workflow import RetreatWorkflow
+
+
+@dataclass(frozen=True, slots=True)
+class RetreatHandlerProviders:
+    """Expose hooks to lazily create retreat handler collaborators."""
+
+    context: Callable[[], "RetreatContextBuilder"]
+    failures: Callable[[], RetreatFailureTranslator]
+    workflow: Callable[["RetreatContextBuilder", RetreatFailureTranslator], "RetreatWorkflow"]
+    instrumentation: Callable[[Telemetry], RetreatTelemetry]
+    orchestrator: Callable[[RetreatTelemetry, "RetreatWorkflow"], RetreatOrchestrator]
+    outcomes: Callable[[Translator], RetreatOutcomeFactory]
+
+
+@dataclass(frozen=True, slots=True)
+class RetreatHandlerOverrides:
+    """Optional dependencies that may replace individual collaborators."""
+
+    context: "RetreatContextBuilder" | None = None
+    failures: RetreatFailureTranslator | None = None
+    workflow: "RetreatWorkflow" | None = None
+    instrumentation: RetreatTelemetry | None = None
+    orchestrator: RetreatOrchestrator | None = None
+    outcomes: RetreatOutcomeFactory | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class RetreatWorkflowBundle:
+    """Capture the workflow-related collaborators for handler assembly."""
+
+    context: "RetreatContextBuilder"
+    failures: RetreatFailureTranslator
+    workflow: "RetreatWorkflow"
+
+    @classmethod
+    def from_overrides(
+        cls,
+        overrides: RetreatHandlerOverrides,
+        providers: RetreatHandlerProviders,
+    ) -> "RetreatWorkflowBundle":
+        """Resolve workflow collaborators using overrides when present."""
+
+        context = overrides.context or providers.context()
+        failures = overrides.failures or providers.failures()
+        workflow = overrides.workflow or providers.workflow(context, failures)
+        return cls(context=context, failures=failures, workflow=workflow)
+
+
+@dataclass(slots=True)
+class RetreatHandlerResolution:
+    """Resolve orchestration and outcome collaborators for the handler."""
+
+    telemetry: Telemetry
+    translator: Translator
+    providers: RetreatHandlerProviders
+    overrides: RetreatHandlerOverrides
+
+    def resolve_orchestrator(self, bundle: RetreatWorkflowBundle) -> RetreatOrchestrator:
+        """Build the orchestrator honoring optional overrides."""
+
+        if self.overrides.orchestrator is not None:
+            return self.overrides.orchestrator
+        instrumentation = self.overrides.instrumentation or self.providers.instrumentation(
+            self.telemetry
+        )
+        return self.providers.orchestrator(instrumentation, bundle.workflow)
+
+    def resolve_outcomes(self) -> RetreatOutcomeFactory:
+        """Build the outcome factory honoring optional overrides."""
+
+        if self.overrides.outcomes is not None:
+            return self.overrides.outcomes
+        return self.providers.outcomes(self.translator)
+
+
+@dataclass(slots=True)
+class RetreatHandlerAssembler:
+    """Assemble retreat handlers while delegating collaborator resolution."""
+
+    providers: RetreatHandlerProviders
+
+    def assemble(
+        self,
+        *,
+        telemetry: Telemetry,
+        translator: Translator,
+        overrides: RetreatHandlerOverrides | None = None,
+    ) -> RetreatHandler:
+        """Return a fully assembled retreat handler."""
+
+        options = overrides or RetreatHandlerOverrides()
+        bundle = RetreatWorkflowBundle.from_overrides(options, self.providers)
+        resolution = RetreatHandlerResolution(
+            telemetry=telemetry,
+            translator=translator,
+            providers=self.providers,
+            overrides=options,
+        )
+        orchestrator = resolution.resolve_orchestrator(bundle)
+        outcomes = resolution.resolve_outcomes()
+        return RetreatHandler(orchestrator=orchestrator, outcomes=outcomes)
+
+
+__all__ = [
+    "RetreatHandlerAssembler",
+    "RetreatHandlerOverrides",
+    "RetreatHandlerProviders",
+    "RetreatHandlerResolution",
+    "RetreatWorkflowBundle",
+]

--- a/presentation/telegram/back/factory.py
+++ b/presentation/telegram/back/factory.py
@@ -1,45 +1,17 @@
 """Factories assembling retreat handlers with dependency overrides."""
-
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Callable, TYPE_CHECKING
 
 from navigator.core.telemetry import Telemetry
 
-from .context import RetreatContextBuilder
+from .assembly import (
+    RetreatHandlerAssembler,
+    RetreatHandlerOverrides,
+    RetreatHandlerProviders,
+)
 from .handler import RetreatHandler
-from .orchestrator import RetreatOrchestrator
-from .outcome import RetreatOutcomeFactory
-from .protocols import RetreatFailureTranslator, Translator
-from .telemetry import RetreatTelemetry
-
-if TYPE_CHECKING:
-    from .workflow import RetreatWorkflow
-
-
-@dataclass(frozen=True, slots=True)
-class RetreatHandlerProviders:
-    """Expose hooks to lazily create retreat handler collaborators."""
-
-    context: Callable[[], RetreatContextBuilder]
-    failures: Callable[[], RetreatFailureTranslator]
-    workflow: Callable[[RetreatContextBuilder, RetreatFailureTranslator], "RetreatWorkflow"]
-    instrumentation: Callable[[Telemetry], RetreatTelemetry]
-    orchestrator: Callable[[RetreatTelemetry, "RetreatWorkflow"], RetreatOrchestrator]
-    outcomes: Callable[[Translator], RetreatOutcomeFactory]
-
-
-@dataclass(frozen=True, slots=True)
-class RetreatHandlerOverrides:
-    """Optional dependencies that may replace individual collaborators."""
-
-    context: RetreatContextBuilder | None = None
-    failures: RetreatFailureTranslator | None = None
-    workflow: "RetreatWorkflow" | None = None
-    instrumentation: RetreatTelemetry | None = None
-    orchestrator: RetreatOrchestrator | None = None
-    outcomes: RetreatOutcomeFactory | None = None
+from .protocols import Translator
 
 
 @dataclass(slots=True)
@@ -48,77 +20,20 @@ class RetreatHandlerFactory:
 
     telemetry: Telemetry
     translator: Translator
-    providers: RetreatHandlerProviders
+    assembler: RetreatHandlerAssembler
 
     def create(
         self,
         *,
         overrides: RetreatHandlerOverrides | None = None,
     ) -> RetreatHandler:
-        options = overrides or RetreatHandlerOverrides()
-        providers = self.providers
+        """Return a retreat handler assembled by the configured collaborators."""
 
-        bundle = RetreatWorkflowBundle.from_overrides(options, providers)
-        resolution = RetreatHandlerResolution(
+        return self.assembler.assemble(
             telemetry=self.telemetry,
             translator=self.translator,
-            providers=providers,
-            overrides=options,
+            overrides=overrides,
         )
-        orchestrator = resolution.resolve_orchestrator(bundle)
-        outcomes = resolution.resolve_outcomes()
-        return RetreatHandler(orchestrator=orchestrator, outcomes=outcomes)
-
-
-@dataclass(frozen=True, slots=True)
-class RetreatWorkflowBundle:
-    """Capture the workflow-related collaborators for handler assembly."""
-
-    context: RetreatContextBuilder
-    failures: RetreatFailureTranslator
-    workflow: "RetreatWorkflow"
-
-    @classmethod
-    def from_overrides(
-        cls,
-        overrides: RetreatHandlerOverrides,
-        providers: RetreatHandlerProviders,
-    ) -> "RetreatWorkflowBundle":
-        """Resolve workflow collaborators using overrides when present."""
-
-        context = overrides.context or providers.context()
-        failures = overrides.failures or providers.failures()
-        workflow = overrides.workflow or providers.workflow(context, failures)
-        return cls(context=context, failures=failures, workflow=workflow)
-
-
-@dataclass(slots=True)
-class RetreatHandlerResolution:
-    """Resolve orchestration and outcome collaborators for the handler."""
-
-    telemetry: Telemetry
-    translator: Translator
-    providers: RetreatHandlerProviders
-    overrides: RetreatHandlerOverrides
-
-    def resolve_orchestrator(
-        self, bundle: RetreatWorkflowBundle
-    ) -> RetreatOrchestrator:
-        """Build the orchestrator honoring optional overrides."""
-
-        if self.overrides.orchestrator is not None:
-            return self.overrides.orchestrator
-        instrumentation = self.overrides.instrumentation or self.providers.instrumentation(
-            self.telemetry
-        )
-        return self.providers.orchestrator(instrumentation, bundle.workflow)
-
-    def resolve_outcomes(self) -> RetreatOutcomeFactory:
-        """Build the outcome factory honoring optional overrides."""
-
-        if self.overrides.outcomes is not None:
-            return self.overrides.outcomes
-        return self.providers.outcomes(self.translator)
 
 
 def create_retreat_handler(
@@ -130,10 +45,11 @@ def create_retreat_handler(
 ) -> RetreatHandler:
     """Convenience wrapper returning an assembled retreat handler."""
 
+    assembler = RetreatHandlerAssembler(providers=providers)
     factory = RetreatHandlerFactory(
         telemetry=telemetry,
         translator=translator,
-        providers=providers,
+        assembler=assembler,
     )
     return factory.create(overrides=overrides)
 

--- a/presentation/telegram/back/failures.py
+++ b/presentation/telegram/back/failures.py
@@ -1,0 +1,20 @@
+"""Failure handling policies for retreat workflows.""" 
+from __future__ import annotations
+
+from .result import RetreatResult
+
+
+class RetreatFailurePolicy:
+    """Translate unexpected workflow errors into retreat outcomes."""
+
+    def __init__(self, default_note: str = "generic") -> None:
+        self._default_note = default_note
+
+    def handle(self, error: Exception) -> RetreatResult:
+        """Convert an exception into a failed retreat result."""
+
+        del error  # defensive branch - logging handled upstream
+        return RetreatResult.failed(self._default_note)
+
+
+__all__ = ["RetreatFailurePolicy"]

--- a/presentation/telegram/back/orchestrator.py
+++ b/presentation/telegram/back/orchestrator.py
@@ -1,5 +1,4 @@
 """Telemetry-aware orchestration for retreat workflows."""
-
 from __future__ import annotations
 
 from collections.abc import Mapping
@@ -7,85 +6,10 @@ from collections.abc import Mapping
 from aiogram.types import CallbackQuery
 
 from .protocols import NavigatorBack
+from .reporting import RetreatOutcomeReporter
 from .result import RetreatResult
-from .telemetry import RetreatTelemetry
-from .workflow import RetreatWorkflow
-
-
-class TelemetryScopeSession:
-    """Encapsulate telemetry interactions for a single retreat execution."""
-
-    def __init__(self, telemetry: RetreatTelemetry, scope: object) -> None:
-        self._telemetry = telemetry
-        self._scope = scope
-
-    def enter(self) -> None:
-        self._telemetry.entered(self._scope)
-
-    def complete(self) -> None:
-        self._telemetry.completed(self._scope)
-
-    def fail(self, note: str) -> None:
-        self._telemetry.failed(note, self._scope)
-
-
-class TelemetryScopeFactory:
-    """Create telemetry sessions decoupled from orchestrator logic."""
-
-    def __init__(self, telemetry: RetreatTelemetry) -> None:
-        self._telemetry = telemetry
-
-    def start(self, cb: CallbackQuery) -> TelemetryScopeSession:
-        session = TelemetryScopeSession(
-            self._telemetry,
-            self._telemetry.scope(cb),
-        )
-        session.enter()
-        return session
-
-
-class RetreatFailurePolicy:
-    """Translate unexpected workflow errors into retreat outcomes."""
-
-    def __init__(self, default_note: str = "generic") -> None:
-        self._default_note = default_note
-
-    def handle(self, error: Exception) -> RetreatResult:
-        del error  # defensive branch - logging handled upstream
-        return RetreatResult.failed(self._default_note)
-
-
-class RetreatOutcomeReporter:
-    """Report workflow outcomes through telemetry sessions."""
-
-    def __init__(self, default_note: str = "generic") -> None:
-        self._default_note = default_note
-
-    def report(self, result: RetreatResult, session: TelemetryScopeSession) -> RetreatResult:
-        if result.success:
-            session.complete()
-        else:
-            session.fail(result.note or self._default_note)
-        return result
-
-
-class RetreatWorkflowRunner:
-    """Execute workflow logic while delegating failure handling."""
-
-    def __init__(self, workflow: RetreatWorkflow, failures: RetreatFailurePolicy) -> None:
-        self._workflow = workflow
-        self._failures = failures
-
-    async def run(
-        self,
-        cb: CallbackQuery,
-        navigator: NavigatorBack,
-        payload: Mapping[str, object],
-    ) -> RetreatResult:
-        try:
-            return await self._workflow.execute(cb, navigator, payload)
-        except Exception as error:  # pragma: no cover - defensive net for logging
-            return self._failures.handle(error)
+from .runner import RetreatWorkflowRunner
+from .session import TelemetryScopeFactory
 
 
 class RetreatOrchestrator:
@@ -113,11 +37,4 @@ class RetreatOrchestrator:
         return self._reporter.report(result, session)
 
 
-__all__ = [
-    "RetreatFailurePolicy",
-    "RetreatOrchestrator",
-    "RetreatOutcomeReporter",
-    "RetreatWorkflowRunner",
-    "TelemetryScopeFactory",
-    "TelemetryScopeSession",
-]
+__all__ = ["RetreatOrchestrator"]

--- a/presentation/telegram/back/providers.py
+++ b/presentation/telegram/back/providers.py
@@ -7,15 +7,13 @@ from dataclasses import dataclass
 
 from navigator.core.telemetry import Telemetry
 
+from .assembly import RetreatHandlerProviders
 from .context import RetreatContextBuilder
-from .factory import RetreatHandlerProviders
-from .orchestrator import (
-    RetreatFailurePolicy,
-    RetreatOrchestrator,
-    RetreatOutcomeReporter,
-    RetreatWorkflowRunner,
-    TelemetryScopeFactory,
-)
+from .failures import RetreatFailurePolicy
+from .orchestrator import RetreatOrchestrator
+from .reporting import RetreatOutcomeReporter
+from .runner import RetreatWorkflowRunner
+from .session import TelemetryScopeFactory
 from .outcome import RetreatOutcomeFactory
 from .protocols import RetreatFailureTranslator, Translator
 from .telemetry import RetreatTelemetry

--- a/presentation/telegram/back/reporting.py
+++ b/presentation/telegram/back/reporting.py
@@ -1,0 +1,24 @@
+"""Outcome reporting utilities for retreat orchestration."""
+from __future__ import annotations
+
+from .result import RetreatResult
+from .session import TelemetryScopeSession
+
+
+class RetreatOutcomeReporter:
+    """Report workflow outcomes through telemetry sessions."""
+
+    def __init__(self, default_note: str = "generic") -> None:
+        self._default_note = default_note
+
+    def report(self, result: RetreatResult, session: TelemetryScopeSession) -> RetreatResult:
+        """Emit telemetry around the supplied result and return it unchanged."""
+
+        if result.success:
+            session.complete()
+        else:
+            session.fail(result.note or self._default_note)
+        return result
+
+
+__all__ = ["RetreatOutcomeReporter"]

--- a/presentation/telegram/back/runner.py
+++ b/presentation/telegram/back/runner.py
@@ -1,0 +1,33 @@
+"""Workflow runner coordinating retreat execution."""
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from aiogram.types import CallbackQuery
+
+from .failures import RetreatFailurePolicy
+from .protocols import NavigatorBack
+from .result import RetreatResult
+from .workflow import RetreatWorkflow
+
+
+class RetreatWorkflowRunner:
+    """Execute workflow logic while delegating failure handling."""
+
+    def __init__(self, workflow: RetreatWorkflow, failures: RetreatFailurePolicy) -> None:
+        self._workflow = workflow
+        self._failures = failures
+
+    async def run(
+        self,
+        cb: CallbackQuery,
+        navigator: NavigatorBack,
+        payload: Mapping[str, object],
+    ) -> RetreatResult:
+        try:
+            return await self._workflow.execute(cb, navigator, payload)
+        except Exception as error:  # pragma: no cover - defensive net for logging
+            return self._failures.handle(error)
+
+
+__all__ = ["RetreatWorkflowRunner"]

--- a/presentation/telegram/back/session.py
+++ b/presentation/telegram/back/session.py
@@ -1,0 +1,41 @@
+"""Telemetry session helpers for retreat orchestration."""
+from __future__ import annotations
+
+from aiogram.types import CallbackQuery
+
+from .telemetry import RetreatTelemetry
+
+
+class TelemetryScopeSession:
+    """Encapsulate telemetry interactions for a single retreat execution."""
+
+    def __init__(self, telemetry: RetreatTelemetry, scope: object) -> None:
+        self._telemetry = telemetry
+        self._scope = scope
+
+    def enter(self) -> None:
+        self._telemetry.entered(self._scope)
+
+    def complete(self) -> None:
+        self._telemetry.completed(self._scope)
+
+    def fail(self, note: str) -> None:
+        self._telemetry.failed(note, self._scope)
+
+
+class TelemetryScopeFactory:
+    """Create telemetry sessions decoupled from orchestrator logic."""
+
+    def __init__(self, telemetry: RetreatTelemetry) -> None:
+        self._telemetry = telemetry
+
+    def start(self, cb: CallbackQuery) -> TelemetryScopeSession:
+        session = TelemetryScopeSession(
+            self._telemetry,
+            self._telemetry.scope(cb),
+        )
+        session.enter()
+        return session
+
+
+__all__ = ["TelemetryScopeFactory", "TelemetryScopeSession"]


### PR DESCRIPTION
## Summary
- introduce dedicated builders for runtime plan requests and reuse them within the runtime factory to clarify responsibilities
- extract retreat handler assembly/orchestration collaborators into focused modules and update providers to consume the new abstractions
- decouple history persistence telemetry and provide a structured runtime redaction config for the DI container

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7c63506908330a80ee5b937db66b9