### PR TITLE
Refine navigator runtime boundaries and presentation wiring

### DIFF
--- a/app/service/__init__.py
+++ b/app/service/__init__.py
@@ -1,14 +1,12 @@
 """Application service layer."""
 
 from .history_mutation import TailHistoryMutator
-from .navigator_runtime import (
-    NavigatorHistoryService,
-    NavigatorRuntime,
-    NavigatorStateService,
-    NavigatorTail,
-    NavigatorUseCases,
-    build_navigator_runtime,
-)
+from .navigator_runtime.history import NavigatorHistoryService
+from .navigator_runtime.runtime import NavigatorRuntime
+from .navigator_runtime.state import NavigatorStateService
+from .navigator_runtime.tail import NavigatorTail
+from .navigator_runtime.usecases import NavigatorUseCases
+from .navigator_runtime.runtime_factory import build_navigator_runtime
 from .tail_history import (
     TailHistoryAccess,
     TailHistoryJournal,

--- a/app/service/navigator_runtime/__init__.py
+++ b/app/service/navigator_runtime/__init__.py
@@ -1,18 +1,8 @@
-"""Navigator runtime package exposing orchestration helpers."""
+"""Navigator runtime package exposing orchestration entrypoints."""
 from __future__ import annotations
 
-from navigator.contracts.runtime import (
-    NavigatorAssemblyOverrides,
-    NavigatorRuntimeBundleLike,
-    NavigatorRuntimeInstrument,
-)
-
 from .assembly import build_runtime_from_dependencies
-from .dependencies import (
-    RuntimeDomainServices,
-    RuntimeSafetyServices,
-    RuntimeTelemetryServices,
-)
+from .entrypoints import assemble_navigator
 from .runtime_factory import (
     NavigatorRuntimeAssembly,
     RuntimePlannerDependencies,
@@ -21,71 +11,18 @@ from .runtime_factory import (
     build_runtime_contract_selection,
     create_runtime_plan_request,
 )
-from .contracts import HistoryContracts, NavigatorRuntimeContracts, StateContracts, TailContracts
-from navigator.core.contracts.back import NavigatorBackContext, NavigatorBackEvent
-from .bundler import PayloadBundler
-from .facade import (
-    NavigatorFacade,
-    NavigatorHistoryFacade,
-    NavigatorStateFacade,
-    NavigatorTailFacade,
-)
-from .history import (
-    HistoryAddOperation,
-    HistoryBackOperation,
-    HistoryRebaseOperation,
-    HistoryReplaceOperation,
-    HistoryTrimOperation,
-    NavigatorHistoryService,
-)
-from .reporter import NavigatorReporter
 from .runtime import NavigatorRuntime
-from .snapshot import NavigatorRuntimeSnapshot
-from .state import MissingStateAlarm, NavigatorStateService, StateDescriptor
-from .tail import NavigatorTail
-from .tail_view import TailView
-from .types import MissingAlert
 from .usecases import NavigatorUseCases
 
 __all__ = [
-    "NavigatorAssemblyOverrides",
-    "NavigatorBackContext",
-    "NavigatorBackEvent",
-    "NavigatorRuntimeInstrument",
-    "NavigatorRuntimeBundleLike",
+    "NavigatorRuntime",
     "NavigatorRuntimeAssembly",
+    "NavigatorUseCases",
     "RuntimePlannerDependencies",
-    "RuntimeDomainServices",
-    "RuntimeSafetyServices",
-    "RuntimeTelemetryServices",
+    "assemble_navigator",
+    "build_navigator_runtime",
     "build_runtime_collaborators",
     "build_runtime_contract_selection",
-    "build_navigator_runtime",
-    "create_runtime_plan_request",
     "build_runtime_from_dependencies",
-    "HistoryAddOperation",
-    "HistoryBackOperation",
-    "HistoryRebaseOperation",
-    "HistoryReplaceOperation",
-    "HistoryTrimOperation",
-    "HistoryContracts",
-    "MissingAlert",
-    "NavigatorFacade",
-    "NavigatorHistoryFacade",
-    "MissingStateAlarm",
-    "NavigatorHistoryService",
-    "NavigatorStateFacade",
-    "NavigatorReporter",
-    "NavigatorRuntime",
-    "NavigatorTailFacade",
-    "NavigatorRuntimeSnapshot",
-    "NavigatorRuntimeContracts",
-    "NavigatorStateService",
-    "NavigatorTail",
-    "NavigatorUseCases",
-    "PayloadBundler",
-    "StateContracts",
-    "StateDescriptor",
-    "TailContracts",
-    "TailView",
+    "create_runtime_plan_request",
 ]

--- a/app/service/retreat_failure.py
+++ b/app/service/retreat_failure.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Mapping
+from typing import Iterable
 
 from navigator.core.error import (
     HistoryEmpty,
@@ -46,22 +46,4 @@ class RetreatFailureResolver:
         return str(error) or self._DEFAULT_NOTE
 
 
-class RetreatFailureNoticePresenter:
-    """Map domain-specific failure notes to presentation lexemes."""
-
-    def __init__(
-        self,
-        *,
-        mapping: Mapping[str, str] | None = None,
-        fallback: str = "missing",
-    ) -> None:
-        self._mapping = dict(mapping or {"barred": "barred"})
-        self._fallback = fallback
-
-    def present(self, note: str | None) -> str:
-        if not note:
-            return self._fallback
-        return self._mapping.get(note, self._fallback)
-
-
-__all__ = ["RetreatFailureNoticePresenter", "RetreatFailureResolver"]
+__all__ = ["RetreatFailureResolver"]

--- a/bootstrap/navigator/assembly.py
+++ b/bootstrap/navigator/assembly.py
@@ -169,6 +169,7 @@ async def assemble(
     missing_alert: MissingAlert | None = None,
     view_container: ViewContainerFactory | None = None,
     resolution: ContainerResolution | None = None,
+    context_factory: BootstrapContextFactory | None = None,
 ) -> NavigatorRuntimeBundle:
     """High level entrypoint assembling navigator runtime bundles."""
 
@@ -178,7 +179,8 @@ async def assemble(
         resolution=resolution,
     )
     assembler = builder.create(runtime_factory)
-    context = BootstrapContext(
+    factory = context_factory or BootstrapContextFactory()
+    context = factory.create(
         event=event,
         state=state,
         ledger=ledger,

--- a/bootstrap/navigator/runtime/bundle.py
+++ b/bootstrap/navigator/runtime/bundle.py
@@ -2,7 +2,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from navigator.app.service.navigator_runtime import NavigatorRuntime
+
+from navigator.app.service.navigator_runtime.runtime import NavigatorRuntime
 from navigator.core.telemetry import Telemetry
 
 from ..container_types import RuntimeContainer

--- a/bootstrap/navigator/runtime/pipeline.py
+++ b/bootstrap/navigator/runtime/pipeline.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from navigator.app.service.navigator_runtime import NavigatorRuntime
+from navigator.app.service.navigator_runtime.runtime import NavigatorRuntime
 from navigator.core.contracts import MissingAlert
 
 from ..context import BootstrapContext, ViewContainerFactory

--- a/presentation/telegram/__init__.py
+++ b/presentation/telegram/__init__.py
@@ -1,6 +1,10 @@
 """Telegram presentation bindings."""
 
-from .instrumentation import instrument
+from .instrumentation import (
+    build_retreat_instrument,
+    instrument_for_configurator,
+    instrument_for_router,
+)
 from .middleware import NavigatorMiddleware
 from .router import (
     BACK_CALLBACK_DATA,
@@ -13,6 +17,8 @@ from .router import (
 )
 from .scope import outline
 
+instrument = instrument_for_router(router)
+
 __all__ = [
     "router",
     "NavigatorBack",
@@ -21,7 +27,10 @@ __all__ = [
     "RetreatDependencies",
     "build_retreat_handler",
     "configure_retreat",
+    "build_retreat_instrument",
     "instrument",
+    "instrument_for_configurator",
+    "instrument_for_router",
     "NavigatorMiddleware",
     "outline",
 ]

--- a/presentation/telegram/assembly.py
+++ b/presentation/telegram/assembly.py
@@ -8,17 +8,18 @@ from typing import Protocol, cast
 from aiogram.fsm.context import FSMContext
 from aiogram.types import TelegramObject
 
-from navigator.app.service.navigator_runtime import (
+from navigator.app.service.navigator_runtime import assemble_navigator
+from navigator.contracts.runtime import (
     NavigatorAssemblyOverrides,
     NavigatorRuntimeInstrument,
-    assemble_navigator,
 )
 from navigator.core.contracts import MissingAlert
 from navigator.core.port.factory import ViewLedger
 from navigator.presentation.navigator import Navigator
 
 from .alerts import missing
-from .instrumentation import instrument as default_instrument
+from .instrumentation import instrument_for_router
+from .router import router as default_router
 from .scope import outline
 
 
@@ -44,7 +45,7 @@ class TelegramRuntimeConfiguration:
     ) -> "TelegramRuntimeConfiguration":
         instruments: Sequence[NavigatorRuntimeInstrument]
         if instrumentation is None:
-            instruments = (default_instrument,)
+            instruments = (instrument_for_router(default_router),)
         else:
             instruments = tuple(instrumentation)
         return cls(instrumentation=instruments, missing_alert=missing_alert or missing)

--- a/presentation/telegram/failures.py
+++ b/presentation/telegram/failures.py
@@ -2,12 +2,29 @@
 
 from __future__ import annotations
 
-from navigator.app.service.retreat_failure import (
-    RetreatFailureNoticePresenter,
-    RetreatFailureResolver,
-)
+from typing import Mapping
+
+from navigator.app.service.retreat_failure import RetreatFailureResolver
 
 from .back.protocols import RetreatFailureNotes, RetreatFailureTranslator
+
+
+class RetreatFailureNoticePresenter:
+    """Map domain-specific failure notes to presentation translation keys."""
+
+    def __init__(
+        self,
+        *,
+        mapping: Mapping[str, str] | None = None,
+        fallback: str = "missing",
+    ) -> None:
+        self._mapping = dict(mapping or {"barred": "barred"})
+        self._fallback = fallback
+
+    def present(self, note: str | None) -> str:
+        if not note:
+            return self._fallback
+        return self._mapping.get(note, self._fallback)
 
 
 def default_retreat_failure_translator() -> RetreatFailureTranslator:
@@ -25,4 +42,5 @@ def default_retreat_failure_notes() -> RetreatFailureNotes:
 __all__ = [
     "default_retreat_failure_notes",
     "default_retreat_failure_translator",
+    "RetreatFailureNoticePresenter",
 ]

--- a/presentation/telegram/instrumentation.py
+++ b/presentation/telegram/instrumentation.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import Callable, Protocol
 
-from navigator.app.service.navigator_runtime import NavigatorRuntimeBundleLike
+from aiogram import Router
+
+from navigator.contracts.runtime import NavigatorRuntimeBundleLike
 
 from .router import RetreatDependencies, RetreatRouterConfigurator, retreat_configurator
 
@@ -29,13 +31,29 @@ def build_retreat_instrument(
     return _instrument
 
 
-def _default_factory(_: NavigatorRuntimeBundleLike) -> RetreatRouterConfigurator:
-    """Return configurator bound to the module router by default."""
+def instrument_for_configurator(
+    configurator: RetreatRouterConfigurator,
+) -> Callable[[NavigatorRuntimeBundleLike], None]:
+    """Return an instrumentation hook bound to ``configurator``."""
 
-    return retreat_configurator()
+    def _factory(_: NavigatorRuntimeBundleLike) -> RetreatRouterConfigurator:
+        return configurator
+
+    return build_retreat_instrument(_factory)
 
 
-instrument = build_retreat_instrument(_default_factory)
+def instrument_for_router(router: Router) -> Callable[[NavigatorRuntimeBundleLike], None]:
+    """Return an instrumentation hook registering callbacks on ``router``."""
+
+    def _factory(_: NavigatorRuntimeBundleLike) -> RetreatRouterConfigurator:
+        return retreat_configurator(router)
+
+    return build_retreat_instrument(_factory)
 
 
-__all__ = ["instrument", "build_retreat_instrument", "RetreatConfiguratorFactory"]
+__all__ = [
+    "build_retreat_instrument",
+    "instrument_for_configurator",
+    "instrument_for_router",
+    "RetreatConfiguratorFactory",
+]

--- a/presentation/telegram/middleware.py
+++ b/presentation/telegram/middleware.py
@@ -4,7 +4,7 @@ from typing import Any, Awaitable, Callable, Dict, Optional, Protocol, runtime_c
 from aiogram import BaseMiddleware
 from aiogram.types import TelegramObject
 
-from navigator.app.service.navigator_runtime import NavigatorRuntimeInstrument
+from navigator.contracts.runtime import NavigatorRuntimeInstrument
 from navigator.core.port.factory import ViewLedger
 from .assembly import (
     NavigatorAssembler,


### PR DESCRIPTION
## Summary
- reduce navigator runtime package exports to core orchestration helpers and update service imports
- split runtime planning duties into dedicated planner types and move presentation-specific failure presenter into the telegram layer
- allow telegram instrumentation to target explicit routers and reuse the bootstrap context factory in assembly orchestration

## Testing
- python -m compileall app presentation bootstrap infra

------
https://chatgpt.com/codex/tasks/task_e_68d7ea1628f88330b27dd319f2f26b15