### PR TITLE
Refactor runtime activation planning and decouple Telegram router

### DIFF
--- a/app/service/navigator_runtime/activation.py
+++ b/app/service/navigator_runtime/activation.py
@@ -1,57 +1,17 @@
 """Activation plans translating snapshots into runnable runtimes."""
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from navigator.core.value.message import Scope
 
-from .dependencies import RuntimeDomainServices, RuntimeSafetyServices, RuntimeTelemetryServices
-from .runtime_factory import (
-    NavigatorRuntimeAssembly,
-    RuntimePlannerDependencies,
-    RuntimePlanRequest,
-    build_navigator_runtime,
-    build_runtime_collaborators,
-    build_runtime_contract_selection,
-)
-from .runtime import NavigatorRuntime
+from .plan import RuntimeActivationPlan
 
 if TYPE_CHECKING:
     from navigator.app.locks.guard import Guardian
 
     from .snapshot import NavigatorRuntimeSnapshot
     from .types import MissingAlert
-
-
-@dataclass(frozen=True)
-class RuntimeActivationPlan:
-    """Immutable description of how to activate the navigator runtime."""
-
-    domain: RuntimeDomainServices
-    telemetry: RuntimeTelemetryServices
-    scope: Scope
-    safety: RuntimeSafetyServices
-
-    def activate(self) -> NavigatorRuntime:
-        """Build a runtime instance according to the stored plan."""
-
-        plan_request = self._create_plan_request()
-        assembly = NavigatorRuntimeAssembly(guard=self.safety.guard, plan=plan_request)
-        return build_navigator_runtime(assembly=assembly)
-
-    def _create_plan_request(self) -> RuntimePlanRequest:
-        """Compose the runtime plan request using dedicated builders."""
-
-        contracts = build_runtime_contract_selection(usecases=self.domain.usecases)
-        collaborators = build_runtime_collaborators(
-            scope=self.scope,
-            dependencies=RuntimePlannerDependencies(
-                telemetry=self.telemetry.telemetry,
-                missing_alert=self.safety.missing_alert,
-            ),
-        )
-        return RuntimePlanRequest(contracts=contracts, collaborators=collaborators)
 
 
 def create_activation_plan(

--- a/app/service/navigator_runtime/plan.py
+++ b/app/service/navigator_runtime/plan.py
@@ -1,0 +1,54 @@
+"""Activation plan primitives shared across navigator runtime services."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from navigator.core.value.message import Scope
+
+from .dependencies import (
+    RuntimeDomainServices,
+    RuntimeSafetyServices,
+    RuntimeTelemetryServices,
+)
+from .runtime import NavigatorRuntime
+from .runtime_factory import (
+    NavigatorRuntimeAssembly,
+    RuntimePlannerDependencies,
+    RuntimePlanRequest,
+    build_navigator_runtime,
+    build_runtime_collaborators,
+    build_runtime_contract_selection,
+)
+
+
+@dataclass(frozen=True)
+class RuntimeActivationPlan:
+    """Immutable description of how to activate the navigator runtime."""
+
+    domain: RuntimeDomainServices
+    telemetry: RuntimeTelemetryServices
+    scope: Scope
+    safety: RuntimeSafetyServices
+
+    def activate(self) -> NavigatorRuntime:
+        """Build a runtime instance according to the stored plan."""
+
+        plan_request = self._create_plan_request()
+        assembly = NavigatorRuntimeAssembly(guard=self.safety.guard, plan=plan_request)
+        return build_navigator_runtime(assembly=assembly)
+
+    def _create_plan_request(self) -> RuntimePlanRequest:
+        """Compose the runtime plan request using dedicated builders."""
+
+        contracts = build_runtime_contract_selection(usecases=self.domain.usecases)
+        collaborators = build_runtime_collaborators(
+            scope=self.scope,
+            dependencies=RuntimePlannerDependencies(
+                telemetry=self.telemetry.telemetry,
+                missing_alert=self.safety.missing_alert,
+            ),
+        )
+        return RuntimePlanRequest(contracts=contracts, collaborators=collaborators)
+
+
+__all__ = ["RuntimeActivationPlan"]

--- a/app/service/navigator_runtime/snapshot.py
+++ b/app/service/navigator_runtime/snapshot.py
@@ -9,12 +9,12 @@ from .dependencies import (
     RuntimeSafetyServices,
     RuntimeTelemetryServices,
 )
+from .plan import RuntimeActivationPlan
 
 if TYPE_CHECKING:
     from navigator.app.locks.guard import Guardian
     from navigator.core.value.message import Scope
 
-    from .activation import RuntimeActivationPlan
     from .types import MissingAlert
 
 
@@ -35,8 +35,6 @@ class NavigatorRuntimeSnapshot:
         missing_alert: MissingAlert | None = None,
     ) -> RuntimeActivationPlan:
         """Return an activation plan without exposing internal dependencies."""
-
-        from .activation import RuntimeActivationPlan
 
         safety = self.safety.apply_overrides(
             guard=guard,

--- a/bootstrap/navigator/assembly.py
+++ b/bootstrap/navigator/assembly.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from navigator.contracts.runtime import NavigatorRuntimeInstrument
 from navigator.core.contracts import MissingAlert
@@ -15,6 +16,10 @@ from .instrumentation import as_sequence
 from .runtime import NavigatorFactory, NavigatorRuntimeBundle
 from .runtime_instrumentation import InstrumentationDecorator
 from .runtime_resolution import RuntimeFactoryResolver, create_runtime_factory_resolver
+
+if TYPE_CHECKING:
+    from .container_resolution import ContainerResolution
+    from .context import ViewContainerFactory
 
 
 @dataclass(slots=True)
@@ -88,9 +93,6 @@ async def assemble(
     )
     return await assembler.build(context)
 
-
-from .container_resolution import ContainerResolution  # noqa: E402  circular
-from .context import ViewContainerFactory  # noqa: E402
 
 __all__ = [
     "AssemblerServices",

--- a/bootstrap/navigator/runtime/activation.py
+++ b/bootstrap/navigator/runtime/activation.py
@@ -1,6 +1,7 @@
 """Runtime activation interfaces decoupling bootstrap from services."""
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import Protocol, TYPE_CHECKING
 
 from navigator.core.contracts import MissingAlert
@@ -32,8 +33,30 @@ class RuntimeActivator(Protocol):
         ...
 
 
+class RuntimePlanFactory(Protocol):
+    """Callable signature creating activation plans for snapshots."""
+
+    def __call__(
+        self,
+        snapshot: "NavigatorRuntimeSnapshot",
+        scope: Scope,
+        *,
+        missing_alert: MissingAlert | None = None,
+    ) -> "RuntimeActivationPlan":
+        ...
+
+
+def _default_plan_factory() -> RuntimePlanFactory:
+    from navigator.app.service.navigator_runtime.activation import create_activation_plan
+
+    return create_activation_plan
+
+
+@dataclass(slots=True)
 class NavigatorRuntimeActivationBridge(RuntimeActivator):
     """Bridge service-layer activation helpers into bootstrap interfaces."""
+
+    plan_factory: RuntimePlanFactory = field(default_factory=_default_plan_factory)
 
     def create_plan(
         self,
@@ -42,11 +65,7 @@ class NavigatorRuntimeActivationBridge(RuntimeActivator):
         *,
         missing_alert: MissingAlert | None = None,
     ) -> "RuntimeActivationPlan":
-        from navigator.app.service.navigator_runtime.activation import (
-            create_activation_plan,
-        )
-
-        return create_activation_plan(
+        return self.plan_factory(
             snapshot,
             scope,
             missing_alert=missing_alert,

--- a/presentation/telegram/__init__.py
+++ b/presentation/telegram/__init__.py
@@ -11,8 +11,8 @@ from .router import (
     NavigatorBack,
     RetreatCallback,
     RetreatDependencies,
-    build_retreat_handler,
     configure_retreat,
+    create_retreat_callback,
     router,
 )
 from .scope import outline
@@ -25,8 +25,8 @@ __all__ = [
     "BACK_CALLBACK_DATA",
     "RetreatCallback",
     "RetreatDependencies",
-    "build_retreat_handler",
     "configure_retreat",
+    "create_retreat_callback",
     "build_retreat_instrument",
     "instrument",
     "instrument_for_configurator",

--- a/presentation/telegram/back/__init__.py
+++ b/presentation/telegram/back/__init__.py
@@ -1,5 +1,7 @@
 """Telegram retreat orchestration package."""
 
+from .callbacks import RetreatCallback, adapt_retreat_handler, build_callback
+from .dependencies import RetreatDependencies, RetreatDependencyOverrides
 from .factory import (
     RetreatHandlerFactory,
     RetreatHandlerOverrides,
@@ -11,7 +13,12 @@ from .failures import RetreatFailurePolicy
 from .orchestrator import RetreatOrchestrator
 from .reporting import RetreatOutcomeReporter
 from .outcome import RetreatOutcome
-from .providers import default_retreat_providers
+from .providers import (
+    RetreatOrchestratorProvidersFactory,
+    RetreatOutcomeProvidersFactory,
+    RetreatWorkflowProvidersFactory,
+    default_retreat_providers,
+)
 from .protocols import (
     NavigatorBack,
     RetreatFailureNotes,
@@ -21,30 +28,46 @@ from .protocols import (
 from .runner import RetreatWorkflowRunner
 from .result import RetreatResult
 from .session import TelemetryScopeFactory, TelemetryScopeSession
+from .setup import (
+    RetreatCallbackFactory,
+    RetreatHandlerBuilder,
+    create_retreat_callback,
+)
 from .telemetry import RetreatTelemetry
 from .workflow import RetreatBackExecutor, RetreatFailureHandler, RetreatWorkflow
 
 __all__ = [
     "NavigatorBack",
+    "RetreatCallback",
+    "RetreatCallbackFactory",
     "RetreatHandler",
     "RetreatHandlerFactory",
     "RetreatHandlerOverrides",
     "RetreatHandlerProviders",
+    "RetreatHandlerBuilder",
     "RetreatOrchestrator",
+    "RetreatOrchestratorProvidersFactory",
     "RetreatOutcomeReporter",
     "RetreatOutcome",
     "RetreatResult",
     "RetreatTelemetry",
     "RetreatFailurePolicy",
     "RetreatFailureNotes",
+    "RetreatOutcomeProvidersFactory",
     "RetreatWorkflowRunner",
     "RetreatBackExecutor",
     "RetreatFailureHandler",
     "RetreatFailureTranslator",
+    "RetreatWorkflowProvidersFactory",
     "RetreatWorkflow",
     "Translator",
     "TelemetryScopeFactory",
     "TelemetryScopeSession",
+    "RetreatDependencies",
+    "RetreatDependencyOverrides",
+    "adapt_retreat_handler",
+    "build_callback",
     "default_retreat_providers",
+    "create_retreat_callback",
     "create_retreat_handler",
 ]

--- a/presentation/telegram/back/callbacks.py
+++ b/presentation/telegram/back/callbacks.py
@@ -1,0 +1,46 @@
+"""Telegram specific callback adapters for retreat handlers."""
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any, Protocol
+
+from aiogram.types import CallbackQuery
+
+from .handler import RetreatHandler
+from .outcome import RetreatOutcome
+from .protocols import NavigatorBack
+
+
+class RetreatCallback(Protocol):
+    """Protocol describing Telegram callback signatures."""
+
+    def __call__(
+        self,
+        cb: CallbackQuery,
+        navigator: NavigatorBack,
+        **data: dict[str, Any],
+    ) -> Awaitable[None]: ...
+
+
+def adapt_retreat_handler(handler: RetreatHandler) -> RetreatCallback:
+    """Wrap a retreat handler into an Aiogram callback."""
+
+    async def _callback(
+        cb: CallbackQuery,
+        navigator: NavigatorBack,
+        **data: dict[str, Any],
+    ) -> None:
+        outcome: RetreatOutcome = await handler(cb, navigator, data)
+        await cb.answer(outcome.text, show_alert=outcome.show_alert)
+
+    return _callback
+
+
+def build_callback(factory: Callable[[], RetreatHandler]) -> RetreatCallback:
+    """Create a callback by instantiating a handler lazily."""
+
+    handler = factory()
+    return adapt_retreat_handler(handler)
+
+
+__all__ = ["RetreatCallback", "adapt_retreat_handler", "build_callback"]

--- a/presentation/telegram/back/dependencies.py
+++ b/presentation/telegram/back/dependencies.py
@@ -1,0 +1,44 @@
+"""Definitions describing dependencies required to build retreat handlers."""
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from navigator.core.telemetry import Telemetry
+from navigator.presentation.alerts import lexeme
+from navigator.presentation.telegram.failures import (
+    default_retreat_failure_notes,
+    default_retreat_failure_translator,
+)
+
+from .protocols import RetreatFailureNotes, RetreatFailureTranslator, Translator
+
+
+@dataclass(frozen=True)
+class RetreatDependencyOverrides:
+    """Factory hooks that allow customizing handler dependencies."""
+
+    failures: Callable[[], RetreatFailureTranslator]
+    notes: Callable[[], RetreatFailureNotes]
+
+
+@dataclass(frozen=True)
+class RetreatDependencies:
+    """Dependencies required to configure retreat handling."""
+
+    telemetry: Telemetry
+    translator: Translator = lexeme
+    failures: Callable[[], RetreatFailureTranslator] = field(
+        default=default_retreat_failure_translator,
+    )
+    notes: Callable[[], RetreatFailureNotes] = field(
+        default=default_retreat_failure_notes,
+    )
+
+    def overrides(self) -> RetreatDependencyOverrides:
+        """Return strongly typed override factories for handler configuration."""
+
+        return RetreatDependencyOverrides(failures=self.failures, notes=self.notes)
+
+
+__all__ = ["RetreatDependencies", "RetreatDependencyOverrides"]

--- a/presentation/telegram/back/setup.py
+++ b/presentation/telegram/back/setup.py
@@ -1,0 +1,51 @@
+"""High level helpers composing retreat callbacks from dependencies."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .callbacks import RetreatCallback, adapt_retreat_handler
+from .dependencies import RetreatDependencies
+from .factory import create_retreat_handler
+from .handler import RetreatHandler
+from .providers import default_retreat_providers
+
+
+@dataclass(slots=True)
+class RetreatHandlerBuilder:
+    """Build retreat handlers from presentation dependencies."""
+
+    def build(self, dependencies: RetreatDependencies) -> RetreatHandler:
+        providers = default_retreat_providers(
+            failures=dependencies.failures,
+            notes=dependencies.notes,
+        )
+        return create_retreat_handler(
+            dependencies.telemetry,
+            dependencies.translator,
+            providers=providers,
+        )
+
+
+@dataclass(slots=True)
+class RetreatCallbackFactory:
+    """Create Telegram callbacks from handler builders."""
+
+    builder: RetreatHandlerBuilder
+
+    def create(self, dependencies: RetreatDependencies) -> RetreatCallback:
+        handler = self.builder.build(dependencies)
+        return adapt_retreat_handler(handler)
+
+
+def create_retreat_callback(dependencies: RetreatDependencies) -> RetreatCallback:
+    """Convenience helper returning a configured retreat callback."""
+
+    factory = RetreatCallbackFactory(builder=RetreatHandlerBuilder())
+    return factory.create(dependencies)
+
+
+__all__ = [
+    "RetreatCallbackFactory",
+    "RetreatHandlerBuilder",
+    "create_retreat_callback",
+]

--- a/presentation/telegram/instrumentation.py
+++ b/presentation/telegram/instrumentation.py
@@ -25,8 +25,7 @@ def build_retreat_instrument(
     def _instrument(bundle: NavigatorRuntimeBundleLike) -> None:
         configurator = factory(bundle)
         dependencies = RetreatDependencies(telemetry=bundle.telemetry)
-        callback = configurator.build(dependencies)
-        configurator.register(callback)
+        configurator.configure(dependencies)
 
     return _instrument
 


### PR DESCRIPTION
## Summary
- extract the runtime activation plan into a dedicated module to eliminate snapshot import cycles and update bootstrap activation bridge for injectable factories
- clean up bootstrap assembly imports to rely on type-checking only
- reorganize Telegram retreat router by introducing focused callback, dependency, and provider modules to improve cohesion

## Testing
- pytest *(fails: ImportError while importing test module '/workspace/navigator/trial.py' - No module named 'manual')*
- python -m compileall app/service/navigator_runtime presentation/telegram

------
https://chatgpt.com/codex/tasks/task_e_68d7fa7d9c38833087a21061a354f659