### PR TITLE
Decouple runtime assembly defaults and refactor planning dependencies

### DIFF
--- a/app/service/navigator_runtime/__init__.py
+++ b/app/service/navigator_runtime/__init__.py
@@ -11,7 +11,8 @@ from .presentation import (
 )
 from .runtime_factory import (
     NavigatorRuntimeAssembly,
-    RuntimePlannerDependencies,
+    RuntimeInstrumentationDependencies,
+    RuntimeNotificationDependencies,
     build_navigator_runtime,
     build_runtime_collaborators,
     build_runtime_contract_selection,
@@ -19,6 +20,11 @@ from .runtime_factory import (
 )
 from .runtime import NavigatorRuntime
 from .runtime_assembly_port import RuntimeAssemblyPort, RuntimeAssemblyRequest
+from .runtime_assembly_resolver import (
+    BootstrapRuntimeAssemblyProvider,
+    RuntimeAssemblyProvider,
+    resolve_runtime_assembler,
+)
 from .usecases import NavigatorUseCases
 
 __all__ = [
@@ -26,9 +32,12 @@ __all__ = [
     "NavigatorRuntimeAssembly",
     "NavigatorRuntimeProvider",
     "NavigatorUseCases",
-    "RuntimePlannerDependencies",
+    "BootstrapRuntimeAssemblyProvider",
+    "RuntimeInstrumentationDependencies",
+    "RuntimeNotificationDependencies",
     "RuntimeAssemblyPort",
     "RuntimeAssemblyRequest",
+    "RuntimeAssemblyProvider",
     "RuntimeAssemblyConfiguration",
     "RuntimeAssemblyEntrypoint",
     "assemble_navigator",
@@ -36,6 +45,7 @@ __all__ = [
     "build_runtime_collaborators",
     "build_runtime_contract_selection",
     "build_runtime_from_dependencies",
+    "resolve_runtime_assembler",
     "default_configuration",
     "create_runtime_plan_request",
 ]

--- a/app/service/navigator_runtime/entrypoints.py
+++ b/app/service/navigator_runtime/entrypoints.py
@@ -9,10 +9,12 @@ from navigator.core.contracts import MissingAlert
 from navigator.core.port.factory import ViewLedger
 from navigator.core.value.message import Scope
 
-from navigator.adapters.navigator_runtime import BootstrapRuntimeAssembler
-
 from .facade import NavigatorFacade
 from .runtime_assembly_port import RuntimeAssemblyPort, RuntimeAssemblyRequest
+from .runtime_assembly_resolver import (
+    RuntimeAssemblyProvider,
+    resolve_runtime_assembler,
+)
 
 FacadeT = TypeVar("FacadeT", bound=NavigatorFacade)
 
@@ -29,6 +31,7 @@ async def assemble_navigator(
     resolution: "ContainerResolution" | None = None,
     facade_type: Type[FacadeT] = NavigatorFacade,
     assembler: RuntimeAssemblyPort[RuntimeAssemblyRequest] | None = None,
+    provider: RuntimeAssemblyProvider | None = None,
 ) -> FacadeT:
     """Assemble a navigator facade for the provided runtime inputs."""
 
@@ -42,7 +45,11 @@ async def assemble_navigator(
         overrides=overrides,
         resolution=resolution,
     )
-    runtime_assembler = assembler or BootstrapRuntimeAssembler()
+    runtime_assembler = resolve_runtime_assembler(
+        assembler=assembler,
+        provider=provider,
+        resolution=resolution,
+    )
     runtime = await runtime_assembler.assemble(request)
     navigator = facade_type(runtime)
     return navigator

--- a/app/service/navigator_runtime/plan.py
+++ b/app/service/navigator_runtime/plan.py
@@ -13,7 +13,8 @@ from .dependencies import (
 from .runtime import NavigatorRuntime
 from .runtime_factory import (
     NavigatorRuntimeAssembly,
-    RuntimePlannerDependencies,
+    RuntimeInstrumentationDependencies,
+    RuntimeNotificationDependencies,
     RuntimePlanRequest,
     build_navigator_runtime,
     build_runtime_collaborators,
@@ -43,8 +44,10 @@ class RuntimeActivationPlan:
         contracts = build_runtime_contract_selection(usecases=self.domain.usecases)
         collaborators = build_runtime_collaborators(
             scope=self.scope,
-            dependencies=RuntimePlannerDependencies.from_components(
+            instrumentation=RuntimeInstrumentationDependencies(
                 telemetry=self.telemetry.telemetry,
+            ),
+            notifications=RuntimeNotificationDependencies(
                 missing_alert=self.safety.missing_alert,
             ),
         )

--- a/app/service/navigator_runtime/runtime_assembly_resolver.py
+++ b/app/service/navigator_runtime/runtime_assembly_resolver.py
@@ -1,0 +1,64 @@
+"""Resolution helpers for runtime assemblers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from .runtime_assembly_port import RuntimeAssemblyPort, RuntimeAssemblyRequest
+
+
+class RuntimeAssemblyProvider(Protocol):
+    """Provide runtime assembler implementations for the application layer."""
+
+    def acquire(
+        self,
+        *,
+        resolution: "ContainerResolution" | None = None,
+    ) -> RuntimeAssemblyPort[RuntimeAssemblyRequest]:
+        """Return a runtime assembler honouring optional resolution overrides."""
+
+
+@dataclass(slots=True)
+class BootstrapRuntimeAssemblyProvider(RuntimeAssemblyProvider):
+    """Bridge application assembly with the default bootstrap assembler."""
+
+    def acquire(
+        self,
+        *,
+        resolution: "ContainerResolution" | None = None,
+    ) -> RuntimeAssemblyPort[RuntimeAssemblyRequest]:
+        # Import performed lazily to keep adapter coupling outside call sites.
+        from navigator.adapters.navigator_runtime import BootstrapRuntimeAssembler
+
+        return BootstrapRuntimeAssembler()
+
+
+def resolve_runtime_assembler(
+    *,
+    assembler: RuntimeAssemblyPort[RuntimeAssemblyRequest] | None,
+    provider: RuntimeAssemblyProvider | None,
+    resolution: "ContainerResolution" | None,
+) -> RuntimeAssemblyPort[RuntimeAssemblyRequest]:
+    """Return an assembler either from explicit override or configured provider."""
+
+    if assembler is not None:
+        return assembler
+    supplier = provider or BootstrapRuntimeAssemblyProvider()
+    return supplier.acquire(resolution=resolution)
+
+
+__all__ = [
+    "BootstrapRuntimeAssemblyProvider",
+    "RuntimeAssemblyProvider",
+    "resolve_runtime_assembler",
+]
+
+
+if __debug__:
+    from typing import TYPE_CHECKING
+
+    if TYPE_CHECKING:  # pragma: no cover - typing helpers only
+        from navigator.bootstrap.navigator.container_resolution import (
+            ContainerResolution,
+        )

--- a/app/service/navigator_runtime/runtime_builder.py
+++ b/app/service/navigator_runtime/runtime_builder.py
@@ -28,9 +28,9 @@ class NavigatorRuntimeBuilder:
         *,
         plan: RuntimeAssemblyPlan,
     ) -> NavigatorRuntime:
-        history = plan.history.build_with(self._builders.history)
-        state = plan.state.build_with(self._builders.state)
-        tail = plan.tail.build_with(self._builders.tail)
+        history = self._builders.history.build_from_plan(plan)
+        state = self._builders.state.build_from_plan(plan)
+        tail = self._builders.tail.build_from_plan(plan)
         return NavigatorRuntime(history=history, state=state, tail=tail)
 
 

--- a/app/service/navigator_runtime/runtime_components.py
+++ b/app/service/navigator_runtime/runtime_components.py
@@ -11,11 +11,7 @@ from .history import NavigatorHistoryService
 from .history_builder import build_history_service
 from .reporter import NavigatorReporter
 from .runtime_context import RuntimeBuildContext
-from .runtime_plan import (
-    HistoryAssemblyRequest,
-    StateAssemblyRequest,
-    TailAssemblyRequest,
-)
+from .runtime_plan import RuntimeAssemblyPlan
 from .state import NavigatorStateService
 from .state_builder import build_state_service
 from .tail import NavigatorTail
@@ -45,13 +41,13 @@ class HistoryServiceBuilder:
             bundler=bundler,
         )
 
-    def build_component(
-        self, request: HistoryAssemblyRequest
+    def build_from_plan(
+        self, plan: RuntimeAssemblyPlan
     ) -> NavigatorHistoryService:
         return self.build(
-            request.contract,
-            reporter=request.reporter,
-            bundler=request.bundler,
+            plan.contracts.history,
+            reporter=plan.collaborators.reporter,
+            bundler=plan.collaborators.bundler,
         )
 
 
@@ -76,13 +72,13 @@ class StateServiceBuilder:
             missing_alert=missing_alert,
         )
 
-    def build_component(
-        self, request: StateAssemblyRequest
+    def build_from_plan(
+        self, plan: RuntimeAssemblyPlan
     ) -> NavigatorStateService:
         return self.build(
-            request.contract,
-            reporter=request.reporter,
-            missing_alert=request.missing_alert,
+            plan.contracts.state,
+            reporter=plan.collaborators.reporter,
+            missing_alert=plan.collaborators.missing_alert,
         )
 
 
@@ -107,13 +103,13 @@ class TailServiceBuilder:
             tail_telemetry=tail_telemetry,
         )
 
-    def build_component(
-        self, request: TailAssemblyRequest
+    def build_from_plan(
+        self, plan: RuntimeAssemblyPlan
     ) -> NavigatorTail:
         return self.build(
-            request.contract,
-            telemetry=request.telemetry,
-            tail_telemetry=request.tail_telemetry,
+            plan.contracts.tail,
+            telemetry=plan.collaborators.telemetry,
+            tail_telemetry=plan.collaborators.tail_telemetry,
         )
 
 

--- a/app/service/navigator_runtime/runtime_factory.py
+++ b/app/service/navigator_runtime/runtime_factory.py
@@ -14,10 +14,13 @@ from .runtime_planning import (  # re-export for backwards compatibility
     RuntimeCollaboratorPlanner,
     RuntimeContractPlanner,
     RuntimePlanRequestPlanner,
-    RuntimePlannerDependencies,
     build_runtime_collaborators,
     build_runtime_contract_selection,
     create_runtime_plan_request,
+)
+from .runtime_plan_request_builder import (
+    RuntimeInstrumentationDependencies,
+    RuntimeNotificationDependencies,
 )
 
 
@@ -51,7 +54,8 @@ __all__ = [
     "RuntimeContractPlanner",
     "RuntimePlanRequestPlanner",
     "RuntimeAssemblyPlan",
-    "RuntimePlannerDependencies",
+    "RuntimeInstrumentationDependencies",
+    "RuntimeNotificationDependencies",
     "build_navigator_runtime",
     "build_runtime_collaborators",
     "build_runtime_contract_selection",

--- a/app/service/navigator_runtime/runtime_plan.py
+++ b/app/service/navigator_runtime/runtime_plan.py
@@ -2,95 +2,19 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Protocol
-
-from navigator.core.telemetry import Telemetry
-from .bundler import PayloadBundler
-from .contracts import (
-    HistoryContracts,
-    NavigatorRuntimeContracts,
-    RuntimeContractSource,
-    StateContracts,
-    TailContracts,
+from .contracts import NavigatorRuntimeContracts, RuntimeContractSource
+from .runtime_inputs import (
+    RuntimeCollaboratorRequest,
+    RuntimeCollaborators,
+    prepare_runtime_collaborators,
 )
-from .reporter import NavigatorReporter
-from .runtime_inputs import RuntimeCollaboratorRequest, RuntimeCollaborators, prepare_runtime_collaborators
-from .tail_components import TailTelemetry
-from .types import MissingAlert
-
-if TYPE_CHECKING:
-    from .history import NavigatorHistoryService
-    from .state import NavigatorStateService
-    from .tail import NavigatorTail
-
-
-class HistoryComponentBuilder(Protocol):
-    """Protocol describing builders for history services."""
-
-    def build_component(self, request: "HistoryAssemblyRequest") -> "NavigatorHistoryService": ...
-
-
-class StateComponentBuilder(Protocol):
-    """Protocol describing builders for state services."""
-
-    def build_component(self, request: "StateAssemblyRequest") -> "NavigatorStateService": ...
-
-
-class TailComponentBuilder(Protocol):
-    """Protocol describing builders for tail services."""
-
-    def build_component(self, request: "TailAssemblyRequest") -> "NavigatorTail": ...
-
-
-@dataclass(frozen=True)
-class HistoryAssemblyRequest:
-    """Capture inputs required to assemble history services."""
-
-    contract: HistoryContracts
-    reporter: NavigatorReporter
-    bundler: PayloadBundler
-
-    def build_with(self, builder: HistoryComponentBuilder) -> "NavigatorHistoryService":
-        """Delegate construction to the provided history builder."""
-
-        return builder.build_component(self)
-
-
-@dataclass(frozen=True)
-class StateAssemblyRequest:
-    """Capture inputs required to assemble state services."""
-
-    contract: StateContracts
-    reporter: NavigatorReporter
-    missing_alert: MissingAlert | None
-
-    def build_with(self, builder: StateComponentBuilder) -> "NavigatorStateService":
-        """Delegate construction to the provided state builder."""
-
-        return builder.build_component(self)
-
-
-@dataclass(frozen=True)
-class TailAssemblyRequest:
-    """Capture inputs required to assemble tail services."""
-
-    contract: TailContracts
-    telemetry: Telemetry | None
-    tail_telemetry: TailTelemetry | None
-
-    def build_with(self, builder: TailComponentBuilder) -> "NavigatorTail":
-        """Delegate construction to the provided tail builder."""
-
-        return builder.build_component(self)
-
 
 @dataclass(frozen=True)
 class RuntimeAssemblyPlan:
-    """Describe the collaborators required to assemble the runtime."""
+    """Pair resolved contracts with collaborators for runtime assembly."""
 
-    history: HistoryAssemblyRequest
-    state: StateAssemblyRequest
-    tail: TailAssemblyRequest
+    contracts: NavigatorRuntimeContracts
+    collaborators: RuntimeCollaborators
 
 
 @dataclass(frozen=True)
@@ -120,22 +44,10 @@ def resolve_runtime_plan_inputs(request: RuntimePlanRequest) -> RuntimePlanInput
 def build_runtime_plan(inputs: RuntimePlanInputs) -> RuntimeAssemblyPlan:
     """Create a runtime assembly plan from resolved inputs."""
 
-    history = HistoryAssemblyRequest(
-        contract=inputs.contracts.history,
-        reporter=inputs.collaborators.reporter,
-        bundler=inputs.collaborators.bundler,
+    return RuntimeAssemblyPlan(
+        contracts=inputs.contracts,
+        collaborators=inputs.collaborators,
     )
-    state = StateAssemblyRequest(
-        contract=inputs.contracts.state,
-        reporter=inputs.collaborators.reporter,
-        missing_alert=inputs.collaborators.missing_alert,
-    )
-    tail = TailAssemblyRequest(
-        contract=inputs.contracts.tail,
-        telemetry=inputs.collaborators.telemetry,
-        tail_telemetry=inputs.collaborators.tail_telemetry,
-    )
-    return RuntimeAssemblyPlan(history=history, state=state, tail=tail)
 
 
 def create_runtime_plan(request: RuntimePlanRequest) -> RuntimeAssemblyPlan:
@@ -146,12 +58,9 @@ def create_runtime_plan(request: RuntimePlanRequest) -> RuntimeAssemblyPlan:
 
 
 __all__ = [
-    "HistoryAssemblyRequest",
     "RuntimeAssemblyPlan",
     "RuntimePlanInputs",
     "RuntimePlanRequest",
-    "StateAssemblyRequest",
-    "TailAssemblyRequest",
     "build_runtime_plan",
     "create_runtime_plan",
     "resolve_runtime_plan_inputs",


### PR DESCRIPTION
## Summary
- introduce a runtime assembly resolver/provider so the service entrypoint no longer instantiates the bootstrap assembler directly and export the helper from the package
- split runtime planning dependencies into dedicated instrumentation and notification bundles, updating planners/builders and the assembly plan to avoid concrete type checks
- isolate append render notifications from the rendering planner, routing telemetry through a dedicated observer instead of the domain class

## Testing
- python -m compileall navigator/app/service/navigator_runtime navigator/app/usecase/add_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_68d80348ce0883309e0466880f552603