### PR TITLE
Refine Telegram runtime assembly and navigator planning modules

### DIFF
--- a/app/service/navigator_runtime/__init__.py
+++ b/app/service/navigator_runtime/__init__.py
@@ -14,16 +14,20 @@ from .presentation import (
     RuntimeAssemblyEntrypoint,
     default_configuration,
 )
+from .runtime_collaborator_factory import RuntimeCollaboratorFactory
+from .runtime_contract_selector import RuntimeContractSelector
 from .runtime_factory import (
     NavigatorRuntimeAssembly,
-    RuntimeInstrumentationDependencies,
-    RuntimeNotificationDependencies,
     build_navigator_runtime,
     build_runtime_collaborators,
     build_runtime_contract_selection,
     create_runtime_plan_request,
 )
 from .runtime import NavigatorRuntime
+from .runtime_plan_dependencies import (
+    RuntimeInstrumentationDependencies,
+    RuntimeNotificationDependencies,
+)
 from .runtime_assembly_port import RuntimeAssemblyPort, RuntimeAssemblyRequest
 from .runtime_assembly_resolver import (
     RuntimeAssemblerResolver,
@@ -34,12 +38,14 @@ from .runtime_assembly_resolver import (
 from .usecases import NavigatorUseCases
 
 __all__ = [
-    "NavigatorRuntime",
-    "NavigatorRuntimeAssembly",
-    "NavigatorRuntimeProvider",
-    "NavigatorUseCases",
-    "RuntimeInstrumentationDependencies",
-    "RuntimeNotificationDependencies",
+    "NavigatorRuntime", 
+    "NavigatorRuntimeAssembly", 
+    "NavigatorRuntimeProvider", 
+    "NavigatorUseCases", 
+    "RuntimeCollaboratorFactory",
+    "RuntimeContractSelector",
+    "RuntimeInstrumentationDependencies", 
+    "RuntimeNotificationDependencies", 
     "RuntimeAssemblyPort",
     "RuntimeAssemblyRequest",
     "RuntimeAssemblerResolver",

--- a/app/service/navigator_runtime/runtime_collaborator_factory.py
+++ b/app/service/navigator_runtime/runtime_collaborator_factory.py
@@ -1,0 +1,42 @@
+"""Factories responsible for creating runtime collaborator requests."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from navigator.core.value.message import Scope
+
+from .bundler import PayloadBundler
+from .runtime_inputs import RuntimeCollaboratorRequest
+from .runtime_plan_dependencies import (
+    RuntimeInstrumentationDependencies,
+    RuntimeNotificationDependencies,
+)
+
+
+@dataclass(frozen=True)
+class RuntimeCollaboratorFactory:
+    """Create collaborator requests decoupled from request orchestration."""
+
+    def create(
+        self,
+        *,
+        scope: Scope,
+        instrumentation: RuntimeInstrumentationDependencies | None = None,
+        notifications: RuntimeNotificationDependencies | None = None,
+        bundler: PayloadBundler | None = None,
+    ) -> RuntimeCollaboratorRequest:
+        """Return a collaborator request describing runtime auxiliaries."""
+
+        instrumentation = instrumentation or RuntimeInstrumentationDependencies()
+        notifications = notifications or RuntimeNotificationDependencies()
+        return RuntimeCollaboratorRequest(
+            scope=scope,
+            telemetry=instrumentation.telemetry,
+            reporter=notifications.reporter,
+            bundler=bundler,
+            tail_telemetry=instrumentation.tail,
+            missing_alert=notifications.missing_alert,
+        )
+
+
+__all__ = ["RuntimeCollaboratorFactory"]

--- a/app/service/navigator_runtime/runtime_contract_selector.py
+++ b/app/service/navigator_runtime/runtime_contract_selector.py
@@ -1,0 +1,25 @@
+"""Helpers responsible for selecting runtime contracts."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .contracts import NavigatorRuntimeContracts, RuntimeContractSelection
+from .usecases import NavigatorUseCases
+
+
+@dataclass(frozen=True)
+class RuntimeContractSelector:
+    """Build contract selections isolating domain knowledge."""
+
+    def select(
+        self,
+        *,
+        usecases: NavigatorUseCases | None = None,
+        contracts: NavigatorRuntimeContracts | None = None,
+    ) -> RuntimeContractSelection:
+        """Return a contract selection wrapper for runtime planning."""
+
+        return RuntimeContractSelection(usecases=usecases, contracts=contracts)
+
+
+__all__ = ["RuntimeContractSelector"]

--- a/app/service/navigator_runtime/runtime_factory.py
+++ b/app/service/navigator_runtime/runtime_factory.py
@@ -18,7 +18,7 @@ from .runtime_planning import (  # re-export for backwards compatibility
     build_runtime_contract_selection,
     create_runtime_plan_request,
 )
-from .runtime_plan_request_builder import (
+from .runtime_plan_dependencies import (
     RuntimeInstrumentationDependencies,
     RuntimeNotificationDependencies,
 )

--- a/app/service/navigator_runtime/runtime_plan_dependencies.py
+++ b/app/service/navigator_runtime/runtime_plan_dependencies.py
@@ -1,0 +1,32 @@
+"""Shared dataclasses describing runtime plan auxiliary dependencies."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from navigator.core.telemetry import Telemetry
+
+from .reporter import NavigatorReporter
+from .tail_components import TailTelemetry
+from .types import MissingAlert
+
+
+@dataclass(frozen=True)
+class RuntimeInstrumentationDependencies:
+    """Capture telemetry-related collaborators for runtime planning."""
+
+    telemetry: Telemetry | None = None
+    tail: TailTelemetry | None = None
+
+
+@dataclass(frozen=True)
+class RuntimeNotificationDependencies:
+    """Capture notification components required during runtime planning."""
+
+    reporter: NavigatorReporter | None = None
+    missing_alert: MissingAlert | None = None
+
+
+__all__ = [
+    "RuntimeInstrumentationDependencies",
+    "RuntimeNotificationDependencies",
+]

--- a/app/service/navigator_runtime/runtime_plan_request_builder.py
+++ b/app/service/navigator_runtime/runtime_plan_request_builder.py
@@ -3,74 +3,19 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from navigator.core.telemetry import Telemetry
 from navigator.core.value.message import Scope
 
 from .bundler import PayloadBundler
-from .contracts import NavigatorRuntimeContracts, RuntimeContractSelection
-from .reporter import NavigatorReporter
+from .contracts import NavigatorRuntimeContracts
+from .runtime_collaborator_factory import RuntimeCollaboratorFactory
+from .runtime_contract_selector import RuntimeContractSelector
 from .runtime_inputs import RuntimeCollaboratorRequest
 from .runtime_plan import RuntimePlanRequest
-from .tail_components import TailTelemetry
-from .types import MissingAlert
+from .runtime_plan_dependencies import (
+    RuntimeInstrumentationDependencies,
+    RuntimeNotificationDependencies,
+)
 from .usecases import NavigatorUseCases
-
-
-@dataclass(frozen=True)
-class RuntimeInstrumentationDependencies:
-    """Capture telemetry-related collaborators for runtime planning."""
-
-    telemetry: Telemetry | None = None
-    tail: TailTelemetry | None = None
-
-
-@dataclass(frozen=True)
-class RuntimeNotificationDependencies:
-    """Capture notification components required during runtime planning."""
-
-    reporter: NavigatorReporter | None = None
-    missing_alert: MissingAlert | None = None
-
-
-@dataclass(frozen=True)
-class RuntimeContractSelector:
-    """Build contract selections isolating domain knowledge."""
-
-    def select(
-        self,
-        *,
-        usecases: NavigatorUseCases | None = None,
-        contracts: NavigatorRuntimeContracts | None = None,
-    ) -> RuntimeContractSelection:
-        """Return a contract selection wrapper for runtime planning."""
-
-        return RuntimeContractSelection(usecases=usecases, contracts=contracts)
-
-
-@dataclass(frozen=True)
-class RuntimeCollaboratorFactory:
-    """Create collaborator requests decoupled from request orchestration."""
-
-    def create(
-        self,
-        *,
-        scope: Scope,
-        instrumentation: RuntimeInstrumentationDependencies | None = None,
-        notifications: RuntimeNotificationDependencies | None = None,
-        bundler: PayloadBundler | None = None,
-    ) -> RuntimeCollaboratorRequest:
-        """Return a collaborator request describing runtime auxiliaries."""
-
-        instrumentation = instrumentation or RuntimeInstrumentationDependencies()
-        notifications = notifications or RuntimeNotificationDependencies()
-        return RuntimeCollaboratorRequest(
-            scope=scope,
-            telemetry=instrumentation.telemetry,
-            reporter=notifications.reporter,
-            bundler=bundler,
-            tail_telemetry=instrumentation.tail,
-            missing_alert=notifications.missing_alert,
-        )
 
 
 @dataclass(frozen=True)
@@ -109,9 +54,5 @@ class RuntimePlanRequestBuilder:
 
 
 __all__ = [
-    "RuntimeCollaboratorFactory",
-    "RuntimeContractSelector",
     "RuntimePlanRequestBuilder",
-    "RuntimeInstrumentationDependencies",
-    "RuntimeNotificationDependencies",
 ]

--- a/app/service/navigator_runtime/runtime_planning.py
+++ b/app/service/navigator_runtime/runtime_planning.py
@@ -10,13 +10,13 @@ from .contracts import NavigatorRuntimeContracts, RuntimeContractSelection
 from .runtime_inputs import RuntimeCollaboratorRequest
 from .runtime_plan import RuntimePlanRequest
 from .bundler import PayloadBundler
-from .runtime_plan_request_builder import (
-    RuntimeCollaboratorFactory,
-    RuntimeContractSelector,
-    RuntimePlanRequestBuilder,
+from .runtime_collaborator_factory import RuntimeCollaboratorFactory
+from .runtime_contract_selector import RuntimeContractSelector
+from .runtime_plan_dependencies import (
     RuntimeInstrumentationDependencies,
     RuntimeNotificationDependencies,
 )
+from .runtime_plan_request_builder import RuntimePlanRequestBuilder
 from .usecases import NavigatorUseCases
 
 

--- a/presentation/telegram/back/retreat_providers/__init__.py
+++ b/presentation/telegram/back/retreat_providers/__init__.py
@@ -1,5 +1,6 @@
 """Provider factories composing retreat handler collaborators."""
 from .assembly import (
+    RetreatProviderModuleFactory,
     RetreatProviderModules,
     RetreatProvidersAssembler,
     default_retreat_providers,
@@ -19,6 +20,7 @@ __all__ = [
     "RetreatOrchestratorProvidersFactory",
     "RetreatOutcomeModule",
     "RetreatOutcomeProvidersFactory",
+    "RetreatProviderModuleFactory",
     "RetreatProviderModules",
     "RetreatProvidersAssembler",
     "RetreatWorkflowModule",

--- a/presentation/telegram/runtime_defaults.py
+++ b/presentation/telegram/runtime_defaults.py
@@ -1,0 +1,26 @@
+"""Default dependency factories for Telegram runtime assembly."""
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from navigator.adapters.navigator_runtime import bootstrap_runtime_assembler_resolver
+from navigator.app.service.navigator_runtime import RuntimeAssemblerResolver
+from navigator.contracts.runtime import NavigatorRuntimeInstrument
+
+from .instrumentation import instrument_for_router
+from .router import router as default_router
+
+
+def default_instrumentation_factory() -> Iterable[NavigatorRuntimeInstrument]:
+    """Return default instrumentation bound to the presentation router."""
+
+    return (instrument_for_router(default_router),)
+
+
+def default_runtime_resolver() -> RuntimeAssemblerResolver:
+    """Return the bootstrap resolver used for runtime assembly."""
+
+    return bootstrap_runtime_assembler_resolver()
+
+
+__all__ = ["default_instrumentation_factory", "default_runtime_resolver"]


### PR DESCRIPTION
## Summary
- introduce `TelegramRuntimeDependencies` and shared defaults to streamline Telegram runtime assembly wiring
- extract runtime plan dependency, contract selection, and collaborator factory helpers into dedicated modules and re-export them from the package
- rework retreat provider assembly to use an explicit module factory and avoid local circular imports

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d80daf1a848330a005c3d62647b550