### PR TITLE
Refine runtime activation planning workflow

### DIFF
--- a/app/service/navigator_runtime/__init__.py
+++ b/app/service/navigator_runtime/__init__.py
@@ -16,9 +16,8 @@ from .presentation import (
 )
 from .runtime_collaborator_factory import RuntimeCollaboratorFactory
 from .runtime_contract_selector import RuntimeContractSelector
-from .runtime_factory import (
-    NavigatorRuntimeAssembly,
-    build_navigator_runtime,
+from .runtime_factory import NavigatorRuntimeAssembly, build_navigator_runtime
+from .runtime_planning import (
     build_runtime_collaborators,
     build_runtime_contract_selection,
     create_runtime_plan_request,

--- a/app/service/navigator_runtime/runtime_activation_builder.py
+++ b/app/service/navigator_runtime/runtime_activation_builder.py
@@ -1,0 +1,22 @@
+"""Helpers assembling runtime instances from activation plans."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from navigator.app.locks.guard import Guardian
+
+from .runtime import NavigatorRuntime
+from .runtime_factory import NavigatorRuntimeAssembly, build_navigator_runtime
+from .runtime_plan import RuntimePlanRequest
+
+
+@dataclass(frozen=True)
+class RuntimeActivationBuilder:
+    """Convert activation requests into assembled runtime instances."""
+
+    def build(self, *, guard: Guardian, plan: RuntimePlanRequest) -> NavigatorRuntime:
+        assembly = NavigatorRuntimeAssembly(guard=guard, plan=plan)
+        return build_navigator_runtime(assembly=assembly)
+
+
+__all__ = ["RuntimeActivationBuilder"]

--- a/app/service/navigator_runtime/runtime_factory.py
+++ b/app/service/navigator_runtime/runtime_factory.py
@@ -10,19 +10,6 @@ from .runtime import NavigatorRuntime
 from .runtime_assembler import NavigatorRuntimeAssembler
 from .runtime_plan import RuntimeAssemblyPlan, RuntimePlanRequest, create_runtime_plan
 
-from .runtime_planning import (  # re-export for backwards compatibility
-    RuntimeCollaboratorPlanner,
-    RuntimeContractPlanner,
-    RuntimePlanRequestPlanner,
-    build_runtime_collaborators,
-    build_runtime_contract_selection,
-    create_runtime_plan_request,
-)
-from .runtime_plan_dependencies import (
-    RuntimeInstrumentationDependencies,
-    RuntimeNotificationDependencies,
-)
-
 
 @dataclass(frozen=True)
 class NavigatorRuntimeAssembly:
@@ -50,15 +37,7 @@ def build_navigator_runtime(*, assembly: NavigatorRuntimeAssembly) -> NavigatorR
 
 __all__ = [
     "NavigatorRuntimeAssembly",
-    "RuntimeCollaboratorPlanner",
-    "RuntimeContractPlanner",
-    "RuntimePlanRequestPlanner",
     "RuntimeAssemblyPlan",
-    "RuntimeInstrumentationDependencies",
-    "RuntimeNotificationDependencies",
     "build_navigator_runtime",
-    "build_runtime_collaborators",
-    "build_runtime_contract_selection",
     "create_runtime_plan",
-    "create_runtime_plan_request",
 ]


### PR DESCRIPTION
## Summary
- introduce a runtime plan request factory and activation builder to decouple plan construction from runtime assembly
- tighten runtime assembly exports and add a workflow helper around navigator assembly entrypoints
- split container factory builder defaults into dedicated selectors for request factories and collaborator resolvers

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'manual')*

------
https://chatgpt.com/codex/tasks/task_e_68d8121f00c88330960d4842fbb2a656