### PR TITLE
Refactor DI composition to reduce coupling

### DIFF
--- a/infra/di/container/builder.py
+++ b/infra/di/container/builder.py
@@ -1,43 +1,153 @@
 """Concrete container builder wiring the application composition root."""
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Protocol
+
 from navigator.bootstrap.navigator.container_types import ContainerBuilder, ContainerRequest
 
 from . import AppContainer, CoreBindings, IntegrationBindings, RuntimeBindings, UseCaseBindings
 
 
+class CoreFactory(Protocol):
+    """Build the core binding layer from an incoming request."""
+
+    def __call__(self, request: ContainerRequest) -> CoreBindings: ...
+
+
+class IntegrationFactory(Protocol):
+    """Build the integration bindings using the core layer."""
+
+    def __call__(
+        self,
+        *,
+        core: CoreBindings,
+        request: ContainerRequest,
+    ) -> IntegrationBindings: ...
+
+
+class UseCaseFactory(Protocol):
+    """Build use case bindings from the core and integration layers."""
+
+    def __call__(
+        self,
+        *,
+        core: CoreBindings,
+        integration: IntegrationBindings,
+        request: ContainerRequest,
+    ) -> UseCaseBindings: ...
+
+
+class RuntimeFactory(Protocol):
+    """Build runtime bindings from the core and use case layers."""
+
+    def __call__(
+        self,
+        *,
+        core: CoreBindings,
+        usecases: UseCaseBindings,
+        request: ContainerRequest,
+    ) -> RuntimeBindings: ...
+
+
+class AppContainerFactory(Protocol):
+    """Assemble the public application container from layer bindings."""
+
+    def __call__(
+        self,
+        *,
+        core: CoreBindings,
+        integration: IntegrationBindings,
+        usecases: UseCaseBindings,
+        runtime: RuntimeBindings,
+    ) -> AppContainer: ...
+
+
+@dataclass(frozen=True)
+class ContainerAssemblyPlan:
+    """Describe how to assemble the layered navigator container."""
+
+    core: CoreFactory
+    integration: IntegrationFactory
+    usecases: UseCaseFactory
+    runtime: RuntimeFactory
+    app: AppContainerFactory
+
+    def build(self, request: ContainerRequest) -> AppContainer:
+        """Execute the plan and return the assembled container."""
+
+        core = self.core(request)
+        integration = self.integration(core=core, request=request)
+        usecases = self.usecases(core=core, integration=integration, request=request)
+        runtime = self.runtime(core=core, usecases=usecases, request=request)
+        return self.app(core=core, integration=integration, usecases=usecases, runtime=runtime)
+
+
+def _default_core_factory(request: ContainerRequest) -> CoreBindings:
+    return CoreBindings(
+        event=request.event,
+        state=request.state,
+        ledger=request.ledger,
+        alert=request.alert,
+        telemetry=request.telemetry,
+    )
+
+
+def _default_integration_factory(
+    *, core: CoreBindings, request: ContainerRequest
+) -> IntegrationBindings:
+    return IntegrationBindings(
+        core=core,
+        telemetry=request.telemetry,
+        view_container=request.view_container,
+    )
+
+
+def _default_usecase_factory(
+    *, core: CoreBindings, integration: IntegrationBindings, request: ContainerRequest
+) -> UseCaseBindings:
+    return UseCaseBindings(core=core, integration=integration, telemetry=request.telemetry)
+
+
+def _default_runtime_factory(
+    *, core: CoreBindings, usecases: UseCaseBindings, request: ContainerRequest
+) -> RuntimeBindings:
+    return RuntimeBindings(core=core, usecases=usecases, telemetry=request.telemetry)
+
+
+def _default_app_factory(
+    *,
+    core: CoreBindings,
+    integration: IntegrationBindings,
+    usecases: UseCaseBindings,
+    runtime: RuntimeBindings,
+) -> AppContainer:
+    return AppContainer(
+        core=core,
+        integration=integration,
+        usecases=usecases,
+        runtime_bindings=runtime,
+    )
+
+
+def _create_default_plan() -> ContainerAssemblyPlan:
+    return ContainerAssemblyPlan(
+        core=_default_core_factory,
+        integration=_default_integration_factory,
+        usecases=_default_usecase_factory,
+        runtime=_default_runtime_factory,
+        app=_default_app_factory,
+    )
+
+
 class NavigatorContainerBuilder(ContainerBuilder):
     """Build navigator containers using dependency-injector bindings."""
 
+    def __init__(self, plan: ContainerAssemblyPlan | None = None) -> None:
+        self._plan = plan or _create_default_plan()
+
     def build(self, request: ContainerRequest) -> AppContainer:
-        core = CoreBindings(
-            event=request.event,
-            state=request.state,
-            ledger=request.ledger,
-            alert=request.alert,
-            telemetry=request.telemetry,
-        )
-        integration = IntegrationBindings(
-            core=core,
-            telemetry=request.telemetry,
-            view_container=request.view_container,
-        )
-        usecases = UseCaseBindings(
-            core=core,
-            integration=integration,
-            telemetry=request.telemetry,
-        )
-        runtime = RuntimeBindings(
-            core=core,
-            usecases=usecases,
-            telemetry=request.telemetry,
-        )
-        return AppContainer(
-            core=core,
-            integration=integration,
-            usecases=usecases,
-            runtime_bindings=runtime,
-        )
+        return self._plan.build(request)
 
 
 __all__ = ["NavigatorContainerBuilder"]

--- a/infra/di/container/usecases/tail.py
+++ b/infra/di/container/usecases/tail.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from dependency_injector import containers, providers
 
+from navigator.app.internal.policy import PrimeEntryFactory
 from navigator.app.service import TailHistoryMutator
 from navigator.app.service.tail_history import (
     TailHistoryAccess,
@@ -14,12 +15,119 @@ from navigator.app.service.tail_history import (
 )
 from navigator.app.usecase.last import Tailer
 from navigator.app.usecase.last.context import TailDecisionService, TailTelemetry
-from navigator.app.internal.policy import PrimeEntryFactory
 from navigator.app.usecase.last.delete import TailDeleteWorkflow
 from navigator.app.usecase.last.edit import TailEditWorkflow
 from navigator.app.usecase.last.inline import InlineEditCoordinator
 from navigator.app.usecase.last.mutation import MessageEditCoordinator
 from navigator.core.telemetry import Telemetry
+
+
+class TailHistoryContainer(containers.DeclarativeContainer):
+    """Provide access and journaling helpers for tail history operations."""
+
+    storage = providers.DependenciesContainer()
+    telemetry = providers.Dependency(instance_of=Telemetry)
+
+    journal = providers.Factory(
+        TailHistoryJournal.from_telemetry,
+        telemetry=telemetry,
+    )
+    access = providers.Factory(
+        TailHistoryAccess,
+        ledger=storage.chronicle,
+        latest=storage.latest,
+    )
+    reader = providers.Factory(
+        TailHistoryReader,
+        access=access,
+        journal=journal,
+    )
+    writer = providers.Factory(
+        TailHistoryWriter,
+        access=access,
+        journal=journal,
+    )
+    inline_trimmer = providers.Factory(
+        TailInlineTrimmer,
+        store=access.provided.store,
+    )
+    inline_history = providers.Factory(
+        TailInlineHistory,
+        trimmer=inline_trimmer,
+        journal=journal,
+    )
+
+
+class TailDecisionContainer(containers.DeclarativeContainer):
+    """Compose helpers that make tail decisions based on current context."""
+
+    core = providers.DependenciesContainer()
+    storage = providers.DependenciesContainer()
+
+    prime = providers.Factory(
+        PrimeEntryFactory,
+        clock=core.clock,
+        entities=storage.entities,
+    )
+    decision = providers.Factory(
+        TailDecisionService,
+        rendering=core.rendering,
+        prime=prime,
+    )
+
+
+class TailInlineContainer(containers.DeclarativeContainer):
+    """Manage inline edit orchestration and mutations for the tail."""
+
+    core = providers.DependenciesContainer()
+    view_support = providers.DependenciesContainer()
+    history = providers.DependenciesContainer()
+
+    mutator = providers.Factory(TailHistoryMutator)
+    inline = providers.Factory(
+        InlineEditCoordinator,
+        handler=view_support.inline,
+        executor=view_support.executor,
+        rendering=core.rendering,
+    )
+    mutation = providers.Factory(
+        MessageEditCoordinator,
+        executor=view_support.executor,
+        history=history.writer,
+        mutator=mutator,
+    )
+
+
+class TailWorkflowContainer(containers.DeclarativeContainer):
+    """Bundle tail workflows and expose high level executors."""
+
+    history = providers.DependenciesContainer()
+    inline = providers.DependenciesContainer()
+    decision = providers.DependenciesContainer()
+    telemetry = providers.Dependency(instance_of=Telemetry)
+
+    tail_telemetry = providers.Factory(TailTelemetry, telemetry=telemetry)
+    delete = providers.Factory(
+        TailDeleteWorkflow,
+        reader=history.reader,
+        inline_history=history.inline_history,
+        mutation=inline.mutation,
+        telemetry=tail_telemetry,
+    )
+    edit = providers.Factory(
+        TailEditWorkflow,
+        reader=history.reader,
+        decision=decision.decision,
+        inline=inline.inline,
+        mutation=inline.mutation,
+        telemetry=tail_telemetry,
+    )
+    tailer = providers.Factory(
+        Tailer,
+        history=history.reader,
+        delete=delete,
+        edit=edit,
+    )
 
 
 class TailUseCaseContainer(containers.DeclarativeContainer):
@@ -30,79 +138,43 @@ class TailUseCaseContainer(containers.DeclarativeContainer):
     view_support = providers.DependenciesContainer()
     telemetry = providers.Dependency(instance_of=Telemetry)
 
-    tail_history_journal = providers.Factory(
-        TailHistoryJournal.from_telemetry,
+    history = providers.Container(
+        TailHistoryContainer,
+        storage=storage,
         telemetry=telemetry,
     )
-    tail_history_access = providers.Factory(
-        TailHistoryAccess,
-        ledger=storage.chronicle,
-        latest=storage.latest,
+    decisions = providers.Container(
+        TailDecisionContainer,
+        core=core,
+        storage=storage,
     )
-    tail_history_reader = providers.Factory(
-        TailHistoryReader,
-        access=tail_history_access,
-        journal=tail_history_journal,
+    inline = providers.Container(
+        TailInlineContainer,
+        core=core,
+        view_support=view_support,
+        history=history,
     )
-    tail_history_writer = providers.Factory(
-        TailHistoryWriter,
-        access=tail_history_access,
-        journal=tail_history_journal,
+    workflows = providers.Container(
+        TailWorkflowContainer,
+        history=history,
+        inline=inline,
+        decision=decisions,
+        telemetry=telemetry,
     )
-    tail_inline_trimmer = providers.Factory(
-        TailInlineTrimmer,
-        store=tail_history_access.provided.store,
-    )
-    tail_inline_history = providers.Factory(
-        TailInlineHistory,
-        trimmer=tail_inline_trimmer,
-        journal=tail_history_journal,
-    )
-    tail_mutator = providers.Factory(TailHistoryMutator)
-    tail_prime = providers.Factory(
-        PrimeEntryFactory,
-        clock=core.clock,
-        entities=storage.entities,
-    )
-    tail_decision = providers.Factory(
-        TailDecisionService,
-        rendering=core.rendering,
-        prime=tail_prime,
-    )
-    tail_inline = providers.Factory(
-        InlineEditCoordinator,
-        handler=view_support.inline,
-        executor=view_support.executor,
-        rendering=core.rendering,
-    )
-    tail_mutation = providers.Factory(
-        MessageEditCoordinator,
-        executor=view_support.executor,
-        history=tail_history_writer,
-        mutator=tail_mutator,
-    )
-    tail_telemetry = providers.Factory(TailTelemetry, telemetry=telemetry)
-    tail_delete = providers.Factory(
-        TailDeleteWorkflow,
-        reader=tail_history_reader,
-        inline_history=tail_inline_history,
-        mutation=tail_mutation,
-        telemetry=tail_telemetry,
-    )
-    tail_edit = providers.Factory(
-        TailEditWorkflow,
-        reader=tail_history_reader,
-        decision=tail_decision,
-        inline=tail_inline,
-        mutation=tail_mutation,
-        telemetry=tail_telemetry,
-    )
-    tailer = providers.Factory(
-        Tailer,
-        history=tail_history_reader,
-        delete=tail_delete,
-        edit=tail_edit,
-    )
+
+    tail_history_journal = history.provided.journal
+    tail_history_access = history.provided.access
+    tail_history_reader = history.provided.reader
+    tail_history_writer = history.provided.writer
+    tail_inline_trimmer = history.provided.inline_trimmer
+    tail_inline_history = history.provided.inline_history
+    tail_prime = decisions.provided.prime
+    tail_decision = decisions.provided.decision
+    tail_inline = inline.provided.inline
+    tail_mutation = inline.provided.mutation
+    tail_delete = workflows.provided.delete
+    tail_edit = workflows.provided.edit
+    tailer = workflows.provided.tailer
 
 
 __all__ = ["TailUseCaseContainer"]


### PR DESCRIPTION
## Summary
- add an assembly plan abstraction for the navigator container builder to decouple layer wiring
- split the tail and view use case containers into focused sub-containers to reduce god-object responsibilities
- restructure the Telegram DI container and container factory builder to isolate infrastructure, view, and assembly concerns

## Testing
- pytest *(fails: requires optional manual package)*

------
https://chatgpt.com/codex/tasks/task_e_68d8166db31c8330a5d5961065870fe0