### PR TITLE
Refactor navigator assembly orchestration and telegram adapters

### DIFF
--- a/app/service/navigator_runtime/__init__.py
+++ b/app/service/navigator_runtime/__init__.py
@@ -2,13 +2,10 @@
 from __future__ import annotations
 
 from .assembly import build_runtime_from_dependencies
-from .entrypoints import (
-    NavigatorAssemblyService,
-    NavigatorFacadeFactory,
-    RuntimeAssemblyRequestFactory,
-    resolve_assembly_service,
-    assemble_navigator,
-)
+from .assembly_service import NavigatorAssemblyService, resolve_assembly_service
+from .entrypoints import assemble_navigator
+from .facade_factory import NavigatorFacadeFactory
+from .request_factory import RuntimeAssemblyRequestFactory
 from .presentation import (
     NavigatorRuntimeProvider,
     RuntimeAssemblyConfiguration,

--- a/app/service/navigator_runtime/assembly_service.py
+++ b/app/service/navigator_runtime/assembly_service.py
@@ -1,0 +1,109 @@
+"""Orchestration services coordinating navigator runtime assembly."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, Iterable, Type, TypeVar
+
+from navigator.contracts.runtime import (
+    NavigatorAssemblyOverrides,
+    NavigatorRuntimeInstrument,
+)
+from navigator.core.contracts import MissingAlert
+from navigator.core.port.factory import ViewLedger
+from navigator.core.value.message import Scope
+
+from .facade import NavigatorFacade
+from .facade_factory import NavigatorFacadeFactory
+from .request_factory import RuntimeAssemblyRequestFactory
+from .runtime_assembly_port import RuntimeAssemblyPort, RuntimeAssemblyRequest
+from .runtime_assembly_resolver import (
+    RuntimeAssemblerResolver,
+    RuntimeAssemblyProvider,
+)
+
+FacadeT = TypeVar("FacadeT", bound=NavigatorFacade)
+
+
+@dataclass(frozen=True)
+class NavigatorAssemblyService(Generic[FacadeT]):
+    """Coordinate request creation, assembler resolution and facade instantiation."""
+
+    request_factory: RuntimeAssemblyRequestFactory
+    resolver: RuntimeAssemblerResolver
+    facade_factory: NavigatorFacadeFactory[FacadeT]
+
+    async def assemble(
+        self,
+        *,
+        event: object,
+        state: object,
+        ledger: ViewLedger,
+        scope: Scope,
+        instrumentation: Iterable[NavigatorRuntimeInstrument] | None,
+        missing_alert: MissingAlert | None,
+        overrides: NavigatorAssemblyOverrides | None,
+        resolution: "ContainerResolution" | None,
+        facade_type: Type[FacadeT],
+        assembler: RuntimeAssemblyPort[RuntimeAssemblyRequest] | None,
+    ) -> FacadeT:
+        request = self.request_factory.create(
+            event=event,
+            state=state,
+            ledger=ledger,
+            scope=scope,
+            instrumentation=instrumentation,
+            missing_alert=missing_alert,
+            overrides=overrides,
+            resolution=resolution,
+        )
+        runtime_assembler = self.resolver.resolve(
+            assembler=assembler,
+            resolution=resolution,
+        )
+        runtime = await runtime_assembler.assemble(request)
+        return self.facade_factory.create(runtime, facade_type)
+
+
+def resolve_assembly_service(
+    *,
+    provider: RuntimeAssemblyProvider | None,
+    request_factory: RuntimeAssemblyRequestFactory | None,
+    assembler_resolver: RuntimeAssemblerResolver | None,
+    facade_factory: NavigatorFacadeFactory[FacadeT] | None,
+) -> NavigatorAssemblyService[FacadeT]:
+    """Instantiate a navigator assembly service with resolved collaborators."""
+
+    request_builder = request_factory or RuntimeAssemblyRequestFactory()
+    facade_builder = facade_factory or NavigatorFacadeFactory()
+    resolver = _resolve_resolver(
+        provider=provider,
+        assembler_resolver=assembler_resolver,
+    )
+    return NavigatorAssemblyService(
+        request_factory=request_builder,
+        resolver=resolver,
+        facade_factory=facade_builder,
+    )
+
+
+def _resolve_resolver(
+    *,
+    provider: RuntimeAssemblyProvider | None,
+    assembler_resolver: RuntimeAssemblerResolver | None,
+) -> RuntimeAssemblerResolver:
+    if assembler_resolver is not None:
+        return assembler_resolver
+    if provider is None:
+        raise RuntimeError("Runtime assembler provider is not configured")
+    return RuntimeAssemblerResolver(provider=provider)
+
+
+__all__ = ["NavigatorAssemblyService", "resolve_assembly_service"]
+
+
+if False:  # pragma: no cover - typing only
+    from collections.abc import Iterable
+    from typing import TypeVar
+
+    from .facade import NavigatorFacade
+    from navigator.bootstrap.navigator.container_resolution import ContainerResolution

--- a/app/service/navigator_runtime/entrypoints.py
+++ b/app/service/navigator_runtime/entrypoints.py
@@ -1,9 +1,7 @@
+"""High level entrypoints orchestrating navigator runtime assembly."""
 from __future__ import annotations
 
-from collections.abc import Iterable
-from dataclasses import dataclass
-
-from typing import TYPE_CHECKING, Generic, Iterable, Type, TypeVar
+from typing import TYPE_CHECKING, Iterable, Type, TypeVar
 
 from navigator.contracts.runtime import (
     NavigatorAssemblyOverrides,
@@ -13,7 +11,10 @@ from navigator.core.contracts import MissingAlert
 from navigator.core.port.factory import ViewLedger
 from navigator.core.value.message import Scope
 
+from .assembly_service import NavigatorAssemblyService, resolve_assembly_service
 from .facade import NavigatorFacade
+from .facade_factory import NavigatorFacadeFactory
+from .request_factory import RuntimeAssemblyRequestFactory
 from .runtime_assembly_port import RuntimeAssemblyPort, RuntimeAssemblyRequest
 from .runtime_assembly_resolver import (
     RuntimeAssemblerResolver,
@@ -21,116 +22,6 @@ from .runtime_assembly_resolver import (
 )
 
 FacadeT = TypeVar("FacadeT", bound=NavigatorFacade)
-
-
-@dataclass(frozen=True)
-class RuntimeAssemblyRequestFactory:
-    """Create runtime assembly requests from presentation inputs."""
-
-    def create(
-        self,
-        *,
-        event: object,
-        state: object,
-        ledger: ViewLedger,
-        scope: Scope,
-        instrumentation: Iterable[NavigatorRuntimeInstrument] | None,
-        missing_alert: MissingAlert | None,
-        overrides: NavigatorAssemblyOverrides | None,
-        resolution: "ContainerResolution" | None,
-    ) -> RuntimeAssemblyRequest:
-        return RuntimeAssemblyRequest(
-            event=event,
-            state=state,
-            ledger=ledger,
-            scope=scope,
-            instrumentation=instrumentation,
-            missing_alert=missing_alert,
-            overrides=overrides,
-            resolution=resolution,
-        )
-
-
-@dataclass(frozen=True)
-class NavigatorFacadeFactory(Generic[FacadeT]):
-    """Create navigator facades from assembled runtimes."""
-
-    def create(self, runtime: "NavigatorRuntime", facade_type: Type[FacadeT]) -> FacadeT:
-        return facade_type(runtime)
-
-
-@dataclass(frozen=True)
-class NavigatorAssemblyService(Generic[FacadeT]):
-    """Coordinate request creation, assembler resolution and facade instantiation."""
-
-    request_factory: RuntimeAssemblyRequestFactory
-    resolver: RuntimeAssemblerResolver
-    facade_factory: NavigatorFacadeFactory[FacadeT]
-
-    async def assemble(
-        self,
-        *,
-        event: object,
-        state: object,
-        ledger: ViewLedger,
-        scope: Scope,
-        instrumentation: Iterable[NavigatorRuntimeInstrument] | None,
-        missing_alert: MissingAlert | None,
-        overrides: NavigatorAssemblyOverrides | None,
-        resolution: "ContainerResolution" | None,
-        facade_type: Type[FacadeT],
-        assembler: RuntimeAssemblyPort[RuntimeAssemblyRequest] | None,
-    ) -> FacadeT:
-        request = self.request_factory.create(
-            event=event,
-            state=state,
-            ledger=ledger,
-            scope=scope,
-            instrumentation=instrumentation,
-            missing_alert=missing_alert,
-            overrides=overrides,
-            resolution=resolution,
-        )
-        runtime_assembler = self.resolver.resolve(
-            assembler=assembler,
-            resolution=resolution,
-        )
-        runtime = await runtime_assembler.assemble(request)
-        return self.facade_factory.create(runtime, facade_type)
-
-
-def resolve_assembly_service(
-    *,
-    provider: RuntimeAssemblyProvider | None,
-    request_factory: RuntimeAssemblyRequestFactory | None,
-    assembler_resolver: RuntimeAssemblerResolver | None,
-    facade_factory: NavigatorFacadeFactory[FacadeT] | None,
-) -> NavigatorAssemblyService[FacadeT]:
-    """Instantiate a navigator assembly service with resolved collaborators."""
-
-    request_builder = request_factory or RuntimeAssemblyRequestFactory()
-    facade_builder = facade_factory or NavigatorFacadeFactory()
-    resolver = _resolve_resolver(
-        provider=provider,
-        assembler_resolver=assembler_resolver,
-    )
-    return NavigatorAssemblyService(
-        request_factory=request_builder,
-        resolver=resolver,
-        facade_factory=facade_builder,
-    )
-
-
-def _resolve_resolver(
-    *,
-    provider: RuntimeAssemblyProvider | None,
-    assembler_resolver: RuntimeAssemblerResolver | None,
-) -> RuntimeAssemblerResolver:
-    if assembler_resolver is not None:
-        return assembler_resolver
-    if provider is None:
-        raise RuntimeError("Runtime assembler provider is not configured")
-    return RuntimeAssemblerResolver(provider=provider)
 
 
 async def assemble_navigator(
@@ -182,5 +73,5 @@ __all__ = [
 
 
 if TYPE_CHECKING:  # pragma: no cover - typing support only
-    from navigator.app.service.navigator_runtime.runtime import NavigatorRuntime
     from navigator.bootstrap.navigator.container_resolution import ContainerResolution
+    from .runtime import NavigatorRuntime

--- a/app/service/navigator_runtime/facade_factory.py
+++ b/app/service/navigator_runtime/facade_factory.py
@@ -1,0 +1,24 @@
+"""Factories instantiating Navigator facades."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Generic, Type, TypeVar
+
+from .facade import NavigatorFacade
+
+FacadeT = TypeVar("FacadeT", bound=NavigatorFacade)
+
+
+@dataclass(frozen=True)
+class NavigatorFacadeFactory(Generic[FacadeT]):
+    """Create navigator facades from assembled runtimes."""
+
+    def create(self, runtime: "NavigatorRuntime", facade_type: Type[FacadeT]) -> FacadeT:
+        return facade_type(runtime)
+
+
+__all__ = ["NavigatorFacadeFactory"]
+
+
+if False:  # pragma: no cover - typing only
+    from .runtime import NavigatorRuntime

--- a/app/service/navigator_runtime/request_factory.py
+++ b/app/service/navigator_runtime/request_factory.py
@@ -1,0 +1,50 @@
+"""Factories building runtime assembly requests."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from navigator.contracts.runtime import (
+    NavigatorAssemblyOverrides,
+    NavigatorRuntimeInstrument,
+)
+from navigator.core.contracts import MissingAlert
+from navigator.core.port.factory import ViewLedger
+from navigator.core.value.message import Scope
+
+from .runtime_assembly_port import RuntimeAssemblyRequest
+
+
+@dataclass(frozen=True)
+class RuntimeAssemblyRequestFactory:
+    """Create runtime assembly requests from presentation inputs."""
+
+    def create(
+        self,
+        *,
+        event: object,
+        state: object,
+        ledger: ViewLedger,
+        scope: Scope,
+        instrumentation: Iterable[NavigatorRuntimeInstrument] | None,
+        missing_alert: MissingAlert | None,
+        overrides: NavigatorAssemblyOverrides | None,
+        resolution: "ContainerResolution" | None,
+    ) -> RuntimeAssemblyRequest:
+        return RuntimeAssemblyRequest(
+            event=event,
+            state=state,
+            ledger=ledger,
+            scope=scope,
+            instrumentation=instrumentation,
+            missing_alert=missing_alert,
+            overrides=overrides,
+            resolution=resolution,
+        )
+
+
+__all__ = ["RuntimeAssemblyRequestFactory"]
+
+
+if False:  # pragma: no cover - typing only
+    from navigator.bootstrap.navigator.container_resolution import ContainerResolution

--- a/bootstrap/navigator/__init__.py
+++ b/bootstrap/navigator/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from .adapter import LedgerAdapter
 from .assembler import NavigatorAssembler, NavigatorAssemblerBuilder
 from .assembly import AssemblerServices, assemble, create_assembler_services
-from .container import ContainerFactory, ContainerFactoryBuilder
+from .container import ContainerFactory, ContainerFactoryBuilder, ContainerFactoryContext
 from .context import BootstrapContext
 from .runtime import ContainerRuntimeFactory, NavigatorFactory, NavigatorRuntimeBundle
 from .telemetry import TelemetryFactory, calibrate_telemetry
@@ -13,6 +13,7 @@ __all__ = [
     "BootstrapContext",
     "ContainerFactory",
     "ContainerFactoryBuilder",
+    "ContainerFactoryContext",
     "ContainerRuntimeFactory",
     "LedgerAdapter",
     "NavigatorAssembler",

--- a/bootstrap/navigator/runtime/provision.py
+++ b/bootstrap/navigator/runtime/provision.py
@@ -8,7 +8,7 @@ from navigator.app.service.navigator_runtime.snapshot import NavigatorRuntimeSna
 from navigator.core.telemetry import Telemetry
 
 from ..context import BootstrapContext, ViewContainerFactory
-from ..container import ContainerFactoryBuilder
+from ..container import ContainerFactoryBuilder, ContainerFactoryContext
 from ..container_types import ContainerBuilder, RuntimeContainer
 from ..inspection import inspect_container
 from ..telemetry import TelemetryFactory
@@ -48,12 +48,13 @@ class ContainerAssembler:
         self._builder = builder
 
     def assemble(self, telemetry: Telemetry, context: BootstrapContext) -> RuntimeContainer:
-        factory = ContainerFactoryBuilder(
+        context = ContainerFactoryContext(
             telemetry=telemetry,
             alert=self._missing_alert,
             view_container=self._view_container,
             builder=self._builder,
-        ).build()
+        )
+        factory = ContainerFactoryBuilder(context).build()
         return factory.create(context)
 
 

--- a/entrypoints/telegram/assemble.py
+++ b/entrypoints/telegram/assemble.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 
 
 async def assemble(event: Any, state: Any, ledger: ViewLedger) -> "Navigator":
-    assembler = TelegramNavigatorAssembler(
+    assembler = TelegramNavigatorAssembler.create(
         ledger, configuration=TelegramRuntimeConfiguration.create()
     )
     return await assembler.assemble(event, state)

--- a/presentation/telegram/assembly.py
+++ b/presentation/telegram/assembly.py
@@ -1,33 +1,25 @@
 """Assemblers bridging Telegram events with navigator runtime."""
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Sequence
-from dataclasses import dataclass
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, replace
 from typing import Protocol, cast
 
 from aiogram.fsm.context import FSMContext
 from aiogram.types import TelegramObject
 
-from navigator.app.service.navigator_runtime import (
-    NavigatorRuntimeProvider,
-    RuntimeAssemblyConfiguration,
-    RuntimeAssemblyProvider,
-    RuntimeAssemblerResolver,
-    assemble_navigator,
-    default_configuration,
-)
-from navigator.contracts.runtime import (
-    NavigatorAssemblyOverrides,
-    NavigatorRuntimeInstrument,
-)
-from navigator.core.contracts import MissingAlert
+from navigator.app.service.navigator_runtime import NavigatorRuntimeProvider
+from navigator.contracts.runtime import NavigatorAssemblyOverrides, NavigatorRuntimeInstrument
 from navigator.core.port.factory import ViewLedger
 from navigator.presentation.navigator import Navigator
 
-from .alerts import missing
-from .runtime_defaults import (
-    default_instrumentation_factory,
-    default_runtime_resolver,
+from .runtime_provider import (
+    AssemblyProvider,
+    RuntimeEntrypoint,
+    RuntimeResolver,
+    TelegramRuntimeConfiguration,
+    TelegramRuntimeDependencies,
+    TelegramRuntimeProviderFactory,
 )
 from .scope import outline
 
@@ -39,139 +31,45 @@ class NavigatorAssembler(Protocol):
 
 
 @dataclass(frozen=True)
-class TelegramRuntimeConfiguration:
-    """Configuration bundle describing runtime assembly policies."""
-
-    instrumentation: Sequence[NavigatorRuntimeInstrument]
-    missing_alert: MissingAlert
-    assembler_resolver: RuntimeAssemblerResolver | None = None
-    provider: RuntimeAssemblyProvider | None = None
-
-    @classmethod
-    def create(
-        cls,
-        *,
-        instrumentation: Iterable[NavigatorRuntimeInstrument] | None = None,
-        missing_alert: MissingAlert | None = None,
-        instrumentation_factory: Callable[[], Iterable[NavigatorRuntimeInstrument]] | None = None,
-        assembler_resolver: RuntimeAssemblerResolver | None = None,
-        provider: RuntimeAssemblyProvider | None = None,
-    ) -> "TelegramRuntimeConfiguration":
-        instruments: Sequence[NavigatorRuntimeInstrument]
-        if instrumentation is None:
-            candidates = instrumentation_factory() if instrumentation_factory else ()
-            instruments = tuple(candidates)
-        else:
-            instruments = tuple(instrumentation)
-        return cls(
-            instrumentation=instruments,
-            missing_alert=missing_alert or missing,
-            assembler_resolver=assembler_resolver,
-            provider=provider,
-        )
-
-    def as_configuration(self, overrides: NavigatorAssemblyOverrides | None) -> RuntimeAssemblyConfiguration[Navigator]:
-        """Translate Telegram configuration into a runtime configuration."""
-
-        return default_configuration(
-            instrumentation=tuple(self.instrumentation),
-            missing_alert=self.missing_alert,
-            overrides=overrides,
-            facade_type=Navigator,
-            assembler_resolver=self.assembler_resolver,
-            provider=self.provider,
-        )
-
-
-@dataclass(frozen=True)
-class TelegramRuntimeDependencies:
-    """Resolve runtime assembly collaborators for the Telegram façade."""
-
-    instrumentation_factory: Callable[[], Iterable[NavigatorRuntimeInstrument]]
-    assembler_resolver: RuntimeAssemblerResolver | None
-    provider: RuntimeAssemblyProvider | None
-
-    @classmethod
-    def create(
-        cls,
-        *,
-        instrumentation_factory: Callable[
-            [], Iterable[NavigatorRuntimeInstrument]
-        ] | None = None,
-        runtime_resolver: RuntimeAssemblerResolver | None = None,
-        assembly_provider: RuntimeAssemblyProvider | None = None,
-    ) -> "TelegramRuntimeDependencies":
-        """Build a dependency bundle using presentation defaults where required."""
-
-        factory = instrumentation_factory or default_instrumentation_factory
-        resolver = runtime_resolver or default_runtime_resolver()
-        return cls(
-            instrumentation_factory=factory,
-            assembler_resolver=resolver,
-            provider=assembly_provider,
-        )
-
-    def configuration(
-        self,
-        *,
-        base: TelegramRuntimeConfiguration | None = None,
-    ) -> TelegramRuntimeConfiguration:
-        """Return a runtime configuration resolved from provided dependencies."""
-
-        if base is not None:
-            return base
-        return TelegramRuntimeConfiguration.create(
-            instrumentation_factory=self.instrumentation_factory,
-            assembler_resolver=self.assembler_resolver,
-            provider=self.provider,
-        )
-
-    def provider_for(
-        self,
-        *,
-        configuration: TelegramRuntimeConfiguration,
-        overrides: NavigatorAssemblyOverrides | None,
-        provider: NavigatorRuntimeProvider[Navigator] | None,
-    ) -> NavigatorRuntimeProvider[Navigator]:
-        """Return a runtime provider configured for Telegram assembly."""
-
-        if provider is not None:
-            return provider
-        runtime_configuration = configuration.as_configuration(overrides)
-        return NavigatorRuntimeProvider(
-            assemble_navigator,
-            configuration=runtime_configuration,
-        )
-
-
-@dataclass(frozen=True)
 class TelegramNavigatorAssembler:
     """Concrete assembler translating Telegram primitives for navigator runtime."""
 
-    def __init__(
-        self,
+    _ledger: ViewLedger
+    _provider: NavigatorRuntimeProvider[Navigator]
+
+    @classmethod
+    def create(
+        cls,
         ledger: ViewLedger,
         *,
         configuration: TelegramRuntimeConfiguration | None = None,
         overrides: NavigatorAssemblyOverrides | None = None,
         provider: NavigatorRuntimeProvider[Navigator] | None = None,
-        runtime_resolver: RuntimeAssemblerResolver | None = None,
+        runtime_resolver: RuntimeResolver | None = None,
         instrumentation_factory: Callable[[], Iterable[NavigatorRuntimeInstrument]] | None = None,
-        assembly_provider: RuntimeAssemblyProvider | None = None,
-    ) -> None:
-        self._ledger = ledger
+        assembly_provider: AssemblyProvider | None = None,
+        entrypoint: RuntimeEntrypoint | None = None,
+    ) -> "TelegramNavigatorAssembler":
         dependencies = TelegramRuntimeDependencies.create(
             instrumentation_factory=instrumentation_factory,
             runtime_resolver=runtime_resolver,
             assembly_provider=assembly_provider,
+            entrypoint=entrypoint,
         )
-        resolved_configuration = dependencies.configuration(base=configuration)
-        self._configuration = resolved_configuration
-        self._provider = dependencies.provider_for(
+        resolved_configuration = dependencies.configuration(
+            base=configuration, facade_type=Navigator
+        )
+        if resolved_configuration.facade_type is None:
+            resolved_configuration = replace(
+                resolved_configuration, facade_type=Navigator
+            )
+        provider_factory = TelegramRuntimeProviderFactory(dependencies)
+        runtime_provider = provider_factory.create(
             configuration=resolved_configuration,
             overrides=overrides,
             provider=provider,
         )
+        return cls(ledger=ledger, provider=runtime_provider)
 
     async def assemble(self, event: TelegramObject, state: FSMContext) -> Navigator:
         navigator = await self._provider.assemble(
@@ -190,6 +88,6 @@ __all__ = [
     "NavigatorAssembler",
     "NavigatorInstrument",
     "TelegramNavigatorAssembler",
-    "TelegramRuntimeDependencies",
     "TelegramRuntimeConfiguration",
+    "TelegramRuntimeDependencies",
 ]

--- a/presentation/telegram/middleware.py
+++ b/presentation/telegram/middleware.py
@@ -46,9 +46,10 @@ class NavigatorMiddleware(BaseMiddleware):
         configuration = TelegramRuntimeConfiguration.create(
             instrumentation=instrumentation
         )
-        return cls(
-            TelegramNavigatorAssembler(ledger, configuration=configuration)
+        assembler = TelegramNavigatorAssembler.create(
+            ledger, configuration=configuration
         )
+        return cls(assembler)
 
     async def __call__(
             self,

--- a/presentation/telegram/runtime_provider.py
+++ b/presentation/telegram/runtime_provider.py
@@ -1,0 +1,165 @@
+"""Runtime provider utilities tailored for Telegram presentation layer."""
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass
+
+from navigator.app.service.navigator_runtime import (
+    NavigatorRuntimeProvider,
+    RuntimeAssemblyConfiguration,
+    RuntimeAssemblyEntrypoint,
+    RuntimeAssemblyProvider,
+    RuntimeAssemblerResolver,
+    assemble_navigator,
+    default_configuration,
+)
+from navigator.contracts.runtime import (
+    NavigatorAssemblyOverrides,
+    NavigatorRuntimeInstrument,
+)
+from navigator.core.contracts import MissingAlert
+
+from .alerts import missing
+from .runtime_defaults import (
+    default_instrumentation_factory,
+    default_runtime_resolver,
+)
+
+
+@dataclass(frozen=True)
+class TelegramRuntimeConfiguration:
+    """Configuration bundle describing runtime assembly policies."""
+
+    instrumentation: Sequence[NavigatorRuntimeInstrument]
+    missing_alert: MissingAlert
+    facade_type: type | None = None
+    assembler_resolver: RuntimeAssemblerResolver | None = None
+    provider: RuntimeAssemblyProvider | None = None
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        instrumentation: Iterable[NavigatorRuntimeInstrument] | None = None,
+        missing_alert: MissingAlert | None = None,
+        instrumentation_factory: Callable[[], Iterable[NavigatorRuntimeInstrument]] | None = None,
+        facade_type: type | None = None,
+        assembler_resolver: RuntimeAssemblerResolver | None = None,
+        provider: RuntimeAssemblyProvider | None = None,
+    ) -> "TelegramRuntimeConfiguration":
+        instruments: Sequence[NavigatorRuntimeInstrument]
+        if instrumentation is None:
+            candidates = instrumentation_factory() if instrumentation_factory else ()
+            instruments = tuple(candidates)
+        else:
+            instruments = tuple(instrumentation)
+        return cls(
+            instrumentation=instruments,
+            missing_alert=missing_alert or missing,
+            facade_type=facade_type,
+            assembler_resolver=assembler_resolver,
+            provider=provider,
+        )
+
+    def as_configuration(
+        self, overrides: NavigatorAssemblyOverrides | None
+    ) -> RuntimeAssemblyConfiguration:
+        """Translate Telegram configuration into a runtime configuration."""
+
+        return default_configuration(
+            instrumentation=tuple(self.instrumentation),
+            missing_alert=self.missing_alert,
+            overrides=overrides,
+            facade_type=self.facade_type,
+            assembler_resolver=self.assembler_resolver,
+            provider=self.provider,
+        )
+
+
+@dataclass(frozen=True)
+class TelegramRuntimeDependencies:
+    """Resolve runtime assembly collaborators for the Telegram façade."""
+
+    instrumentation_factory: Callable[[], Iterable[NavigatorRuntimeInstrument]]
+    assembler_resolver: RuntimeAssemblerResolver | None
+    provider: RuntimeAssemblyProvider | None
+    entrypoint: RuntimeAssemblyEntrypoint | None = None
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        instrumentation_factory: Callable[
+            [], Iterable[NavigatorRuntimeInstrument]
+        ] | None = None,
+        runtime_resolver: RuntimeAssemblerResolver | None = None,
+        assembly_provider: RuntimeAssemblyProvider | None = None,
+        entrypoint: RuntimeAssemblyEntrypoint | None = None,
+    ) -> "TelegramRuntimeDependencies":
+        """Build a dependency bundle using presentation defaults where required."""
+
+        factory = instrumentation_factory or default_instrumentation_factory
+        resolver = runtime_resolver or default_runtime_resolver()
+        return cls(
+            instrumentation_factory=factory,
+            assembler_resolver=resolver,
+            provider=assembly_provider,
+            entrypoint=entrypoint or assemble_navigator,
+        )
+
+    def configuration(
+        self,
+        *,
+        base: TelegramRuntimeConfiguration | None = None,
+        facade_type: type | None = None,
+    ) -> TelegramRuntimeConfiguration:
+        """Return a runtime configuration resolved from provided dependencies."""
+
+        if base is not None:
+            return base
+        return TelegramRuntimeConfiguration.create(
+            instrumentation_factory=self.instrumentation_factory,
+            assembler_resolver=self.assembler_resolver,
+            provider=self.provider,
+            facade_type=facade_type,
+        )
+
+
+@dataclass(frozen=True)
+class TelegramRuntimeProviderFactory:
+    """Create runtime providers bound to Telegram defaults."""
+
+    dependencies: TelegramRuntimeDependencies
+
+    def create(
+        self,
+        *,
+        configuration: TelegramRuntimeConfiguration,
+        overrides: NavigatorAssemblyOverrides | None,
+        provider: NavigatorRuntimeProvider | None,
+    ) -> NavigatorRuntimeProvider:
+        if provider is not None:
+            return provider
+        runtime_configuration = configuration.as_configuration(overrides)
+        entrypoint = self.dependencies.entrypoint or assemble_navigator
+        return NavigatorRuntimeProvider(
+            entrypoint,
+            configuration=runtime_configuration,
+        )
+
+
+NavigatorInstrument = NavigatorRuntimeInstrument
+RuntimeResolver = RuntimeAssemblerResolver
+AssemblyProvider = RuntimeAssemblyProvider
+RuntimeEntrypoint = RuntimeAssemblyEntrypoint
+
+
+__all__ = [
+    "NavigatorInstrument",
+    "RuntimeResolver",
+    "RuntimeEntrypoint",
+    "AssemblyProvider",
+    "TelegramRuntimeConfiguration",
+    "TelegramRuntimeDependencies",
+    "TelegramRuntimeProviderFactory",
+]


### PR DESCRIPTION
## Summary
- split navigator runtime assembly responsibilities into dedicated request, facade, and service modules while keeping the high-level entrypoint focused
- extract Telegram runtime provider wiring into its own module and simplify the assembler with a provider factory based constructor
- introduce a cohesive container factory context to reduce configuration sprawl in bootstrap wiring

## Testing
- pytest *(fails: ImportError while importing trial.py because module 'manual' is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68d81d238fb08330a0239a16a0bd8ff7