### PR TITLE
Refine navigator runtime assembly orchestration

### DIFF
--- a/presentation/bootstrap/composer.py
+++ b/presentation/bootstrap/composer.py
@@ -1,0 +1,56 @@
+"""Navigator composer responsible for building navigator runtimes."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, TYPE_CHECKING
+
+from navigator.app.locks.guard import Guardian
+from navigator.core.contracts import MissingAlert
+from navigator.core.value.message import Scope
+from navigator.presentation.navigator import Navigator
+
+from .runtime_gateway import NavigatorRuntimePort, RuntimeRequest
+
+if TYPE_CHECKING:
+    from navigator.app.service.navigator_runtime.snapshot import NavigatorRuntimeSnapshot
+    from navigator.app.service.navigator_runtime.runtime import NavigatorRuntime
+else:  # pragma: no cover - runtime typing fallback
+    NavigatorRuntimeSnapshot = Any
+    NavigatorRuntime = Any
+
+
+@dataclass(frozen=True)
+class NavigatorComposer:
+    """Compose navigators using an injected runtime factory."""
+
+    runtime_port: NavigatorRuntimePort
+
+    def build_runtime(
+        self,
+        dependencies: NavigatorRuntimeSnapshot,
+        scope: Scope,
+        *,
+        guard: Guardian | None = None,
+        missing_alert: MissingAlert | None = None,
+    ) -> NavigatorRuntime:
+        request = RuntimeRequest(scope=scope, guard=guard, missing_alert=missing_alert)
+        return self.runtime_port.create_runtime(dependencies, request)
+
+    def compose(
+        self,
+        dependencies: NavigatorRuntimeSnapshot,
+        scope: Scope,
+        *,
+        guard: Guardian | None = None,
+        missing_alert: MissingAlert | None = None,
+    ) -> Navigator:
+        runtime = self.build_runtime(
+            dependencies,
+            scope,
+            guard=guard,
+            missing_alert=missing_alert,
+        )
+        return Navigator(runtime)
+
+
+__all__ = ["NavigatorComposer", "NavigatorRuntimeSnapshot", "NavigatorRuntime"]

--- a/presentation/bootstrap/composition.py
+++ b/presentation/bootstrap/composition.py
@@ -1,0 +1,59 @@
+"""High level helpers building navigators from runtime dependencies."""
+from __future__ import annotations
+
+from navigator.app.locks.guard import Guardian
+from navigator.core.contracts import MissingAlert
+from navigator.core.value.message import Scope
+from navigator.presentation.navigator import Navigator
+
+from .composer import NavigatorComposer, NavigatorRuntime, NavigatorRuntimeSnapshot
+from .runtime_gateway import NavigatorRuntimePort, default_runtime_port
+
+
+def build_runtime(
+    dependencies: NavigatorRuntimeSnapshot,
+    scope: Scope,
+    *,
+    guard: Guardian | None = None,
+    missing_alert: MissingAlert | None = None,
+    runtime_port: NavigatorRuntimePort | None = None,
+) -> NavigatorRuntime:
+    """Construct a navigator runtime from resolved dependencies."""
+
+    port = runtime_port or default_runtime_port()
+    composer = NavigatorComposer(port)
+    return composer.build_runtime(
+        dependencies,
+        scope,
+        guard=guard,
+        missing_alert=missing_alert,
+    )
+
+
+def wrap_runtime(runtime: NavigatorRuntime) -> Navigator:
+    """Wrap the navigator runtime with presentation facade."""
+
+    return Navigator(runtime)
+
+
+def compose(
+    dependencies: NavigatorRuntimeSnapshot,
+    scope: Scope,
+    *,
+    guard: Guardian | None = None,
+    missing_alert: MissingAlert | None = None,
+    runtime_port: NavigatorRuntimePort | None = None,
+) -> Navigator:
+    """Construct a Navigator facade from resolved runtime dependencies."""
+
+    port = runtime_port or default_runtime_port()
+    composer = NavigatorComposer(port)
+    return composer.compose(
+        dependencies,
+        scope,
+        guard=guard,
+        missing_alert=missing_alert,
+    )
+
+
+__all__ = ["build_runtime", "compose", "wrap_runtime"]

--- a/presentation/bootstrap/navigator.py
+++ b/presentation/bootstrap/navigator.py
@@ -1,107 +1,13 @@
-from dataclasses import dataclass
-from typing import Any, TYPE_CHECKING
+"""Compatibility layer exposing navigator bootstrap helpers."""
+from __future__ import annotations
 
-from navigator.app.locks.guard import Guardian
-from navigator.core.contracts import MissingAlert
-from navigator.core.value.message import Scope
-from navigator.presentation.navigator import Navigator
-
-from .runtime_gateway import (
-    NavigatorRuntimePort,
-    RuntimeRequest,
-    default_runtime_port,
-)
-
-if TYPE_CHECKING:
-    from navigator.app.service.navigator_runtime.snapshot import NavigatorRuntimeSnapshot
-    from navigator.app.service.navigator_runtime.runtime import NavigatorRuntime
-else:  # pragma: no cover - runtime typing fallback
-    NavigatorRuntimeSnapshot = Any
-    NavigatorRuntime = Any
-
-
-@dataclass(frozen=True)
-class NavigatorComposer:
-    """Compose navigators using an injected runtime factory."""
-
-    runtime_port: NavigatorRuntimePort
-
-    def build_runtime(
-        self,
-        dependencies: NavigatorRuntimeSnapshot,
-        scope: Scope,
-        *,
-        guard: Guardian | None = None,
-        missing_alert: MissingAlert | None = None,
-    ) -> NavigatorRuntime:
-        request = RuntimeRequest(scope=scope, guard=guard, missing_alert=missing_alert)
-        return self.runtime_port.create_runtime(dependencies, request)
-
-    def compose(
-        self,
-        dependencies: NavigatorRuntimeSnapshot,
-        scope: Scope,
-        *,
-        guard: Guardian | None = None,
-        missing_alert: MissingAlert | None = None,
-    ) -> Navigator:
-        runtime = self.build_runtime(
-            dependencies,
-            scope,
-            guard=guard,
-            missing_alert=missing_alert,
-        )
-        return wrap_runtime(runtime)
-
-
-def build_runtime(
-    dependencies: NavigatorRuntimeSnapshot,
-    scope: Scope,
-    *,
-    guard: Guardian | None = None,
-    missing_alert: MissingAlert | None = None,
-    runtime_port: NavigatorRuntimePort | None = None,
-) -> NavigatorRuntime:
-    """Construct a navigator runtime from resolved dependencies."""
-
-    port = runtime_port or default_runtime_port()
-    composer = NavigatorComposer(port)
-    return composer.build_runtime(
-        dependencies,
-        scope,
-        guard=guard,
-        missing_alert=missing_alert,
-    )
-
-
-def wrap_runtime(runtime: NavigatorRuntime) -> Navigator:
-    """Wrap the navigator runtime with presentation facade."""
-
-    return Navigator(runtime)
-
-
-def compose(
-    dependencies: NavigatorRuntimeSnapshot,
-    scope: Scope,
-    *,
-    guard: Guardian | None = None,
-    missing_alert: MissingAlert | None = None,
-    runtime_port: NavigatorRuntimePort | None = None,
-) -> Navigator:
-    """Construct a Navigator facade from resolved runtime dependencies."""
-
-    port = runtime_port or default_runtime_port()
-    composer = NavigatorComposer(port)
-    return composer.compose(
-        dependencies,
-        scope,
-        guard=guard,
-        missing_alert=missing_alert,
-    )
-
+from .composer import NavigatorComposer, NavigatorRuntime, NavigatorRuntimeSnapshot
+from .composition import build_runtime, compose, wrap_runtime
 
 __all__ = [
     "NavigatorComposer",
+    "NavigatorRuntime",
+    "NavigatorRuntimeSnapshot",
     "build_runtime",
     "compose",
     "wrap_runtime",

--- a/presentation/telegram/assembly.py
+++ b/presentation/telegram/assembly.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Protocol, cast
 
 from aiogram.fsm.context import FSMContext
@@ -17,9 +17,8 @@ from .runtime_provider import (
     AssemblyProvider,
     RuntimeEntrypoint,
     RuntimeResolver,
+    TelegramRuntimeBuilder,
     TelegramRuntimeConfiguration,
-    TelegramRuntimeDependencies,
-    TelegramRuntimeProviderFactory,
 )
 from .scope import outline
 
@@ -50,24 +49,17 @@ class TelegramNavigatorAssembler:
         assembly_provider: AssemblyProvider | None = None,
         entrypoint: RuntimeEntrypoint | None = None,
     ) -> "TelegramNavigatorAssembler":
-        dependencies = TelegramRuntimeDependencies.create(
+        builder = TelegramRuntimeBuilder.create(
             instrumentation_factory=instrumentation_factory,
             runtime_resolver=runtime_resolver,
             assembly_provider=assembly_provider,
             entrypoint=entrypoint,
         )
-        resolved_configuration = dependencies.configuration(
-            base=configuration, facade_type=Navigator
-        )
-        if resolved_configuration.facade_type is None:
-            resolved_configuration = replace(
-                resolved_configuration, facade_type=Navigator
-            )
-        provider_factory = TelegramRuntimeProviderFactory(dependencies)
-        runtime_provider = provider_factory.create(
-            configuration=resolved_configuration,
+        runtime_provider = builder.build_provider(
+            base_configuration=configuration,
             overrides=overrides,
             provider=provider,
+            facade_type=Navigator,
         )
         return cls(ledger=ledger, provider=runtime_provider)
 
@@ -89,5 +81,5 @@ __all__ = [
     "NavigatorInstrument",
     "TelegramNavigatorAssembler",
     "TelegramRuntimeConfiguration",
-    "TelegramRuntimeDependencies",
+    "TelegramRuntimeBuilder",
 ]


### PR DESCRIPTION
## Summary
- introduce dedicated builder and configuration resolver abstractions for Telegram runtime assembly
- simplify the Telegram navigator assembler to delegate provider construction to the new builder
- split navigator bootstrap helpers into cohesive composer/composition modules and streamline runtime entrypoint orchestration

## Testing
- python -m compileall presentation/telegram presentation/bootstrap app/service/navigator_runtime

------
https://chatgpt.com/codex/tasks/task_e_68d821518db48330adb96b06654923c0