### PR TITLE
Refactor Telegram runtime and gateway helpers

### DIFF
--- a/adapters/telegram/gateway/edit.py
+++ b/adapters/telegram/gateway/edit.py
@@ -13,7 +13,7 @@ from navigator.core.telemetry import LogCode, TelemetryChannel
 from navigator.core.value.content import Payload
 from navigator.core.value.message import Scope
 
-from . import util
+from .targeting import resolve_targets
 from ..serializer.screen import SignatureScreen
 from .planner import (
     emit_telemetry,
@@ -68,7 +68,7 @@ async def rewrite(
     )
     emit_telemetry(channel, plan.telemetry)
     message = await bot.edit_message_text(
-        **util.targets(scope, identifier),
+        **resolve_targets(scope, identifier),
         text=plan.text,
         reply_markup=plan.markup,
         link_preview_options=plan.preview_options,
@@ -106,7 +106,7 @@ async def recast(
     message = await bot.edit_message_media(
         media=plan.media,
         reply_markup=plan.markup,
-        **util.targets(scope, identifier),
+        **resolve_targets(scope, identifier),
     )
     _log_success(channel, scope, payload, identifier, message)
     return message
@@ -135,7 +135,7 @@ async def retitle(
     )
     emit_telemetry(channel, plan.telemetry)
     message = await bot.edit_message_caption(
-        **util.targets(scope, identifier),
+        **resolve_targets(scope, identifier),
         caption=plan.caption,
         reply_markup=plan.markup,
         **screen.filter(bot.edit_message_caption, plan.extras.get("caption", {})),
@@ -155,7 +155,7 @@ async def remap(
 ):
     plan = prepare_markup_edit(payload, codec=codec)
     message = await bot.edit_message_reply_markup(
-        **util.targets(scope, identifier),
+        **resolve_targets(scope, identifier),
         reply_markup=plan.markup,
     )
     _log_success(channel, scope, payload, identifier, message)

--- a/adapters/telegram/gateway/editor.py
+++ b/adapters/telegram/gateway/editor.py
@@ -13,13 +13,13 @@ from navigator.core.telemetry import Telemetry, TelemetryChannel
 from navigator.core.value.content import Payload
 from navigator.core.value.message import Scope
 
-from . import util
+from .meta import extract_meta
 from .edit import recast, retitle, rewrite
 from ..serializer.screen import SignatureScreen
 
 
 def _message_result(outcome: object, identifier: int, payload: Payload, scope: Scope) -> Result:
-    meta = util.extract(outcome, payload, scope)
+    meta = extract_meta(outcome, payload, scope)
     result_id = getattr(outcome, "message_id", identifier)
     return Result(id=result_id, extra=[], meta=meta)
 

--- a/adapters/telegram/gateway/notifier.py
+++ b/adapters/telegram/gateway/notifier.py
@@ -8,7 +8,7 @@ from aiogram import Bot
 from navigator.core.telemetry import LogCode, Telemetry, TelemetryChannel
 from navigator.core.value.message import Scope
 
-from . import util
+from .targeting import resolve_targets
 
 
 class TelegramNotifier:
@@ -21,7 +21,7 @@ class TelegramNotifier:
     async def alert(self, scope: Scope, text: str) -> None:
         if scope.inline or not text:
             return
-        kwargs = util.targets(scope)
+        kwargs = resolve_targets(scope)
         await self._bot.send_message(text=text, **kwargs)
         self._channel.emit(
             logging.INFO,

--- a/adapters/telegram/gateway/send/context.py
+++ b/adapters/telegram/gateway/send/context.py
@@ -14,7 +14,7 @@ from navigator.core.telemetry import LogCode, TelemetryChannel
 from navigator.core.value.content import Payload
 from navigator.core.value.message import Scope
 
-from .. import util
+from ..targeting import resolve_targets
 from ..serializer import text as textkit
 
 
@@ -51,7 +51,7 @@ class SendContext:
         _ensure_inline_supported(scope)
         markup = textkit.decode(codec, payload.reply)
         preview_options = _preview_options(preview, payload)
-        targets = util.targets(scope)
+        targets = resolve_targets(scope)
         reporter = SendTelemetry(channel, scope, payload)
         return cls(
             markup=markup,

--- a/adapters/telegram/gateway/send/strategies.py
+++ b/adapters/telegram/gateway/send/strategies.py
@@ -1,7 +1,8 @@
 """Concrete send strategies for Telegram payload types."""
 from __future__ import annotations
 
-from typing import Iterable, Mapping
+from collections.abc import Awaitable, Callable, Iterable, Mapping
+from dataclasses import dataclass
 
 from aiogram import Bot
 from aiogram.types import Message
@@ -11,8 +12,7 @@ from navigator.core.value.message import Scope
 
 from ..media import assemble
 from ..serializer import caption as captionkit
-from ..serializer.screen import SignatureScreen
-from .. import util
+from ..meta import extract_meta
 
 from .context import SendContext
 from .dependencies import SendDependencies
@@ -80,13 +80,63 @@ class AlbumBundleBuilder:
         )
 
 
-class AlbumSender:
-    """Send album payloads via Telegram bot API."""
+@dataclass(frozen=True)
+class AlbumDispatchEnvelope:
+    """Describe the plan required to dispatch a media group."""
+
+    bundle: Iterable[object]
+    addition: Mapping[str, object]
+
+
+class AlbumSendPreparation:
+    """Produce dispatch envelopes using configured builders."""
 
     def __init__(self, dependencies: SendDependencies) -> None:
         self._extras = AlbumExtrasBuilder(dependencies)
         self._bundles = AlbumBundleBuilder(dependencies)
+
+    def plan(
+        self,
+        bot: Bot,
+        *,
+        scope: Scope,
+        payload: Payload,
+    ) -> AlbumDispatchEnvelope:
+        extras, addition = self._extras.build(bot, scope=scope, payload=payload)
+        bundle = self._bundles.build(payload.group, extras=extras)
+        return AlbumDispatchEnvelope(bundle=bundle, addition=addition)
+
+
+class AlbumSendFinalizer:
+    """Transform Telegram responses into navigator metadata."""
+
+    def __init__(self) -> None:
         self._clusters = GroupClusterBuilder()
+
+    def finalize(
+        self,
+        messages: list[Message],
+        *,
+        payload: Payload,
+        scope: Scope,
+        reporter: "SendTelemetry",
+    ) -> tuple[Message, list[int], GroupMeta]:
+        head = messages[0]
+        reporter.success(head.message_id, len(messages) - 1)
+        meta = GroupMeta(
+            clusters=self._clusters.build(messages, payload),
+            inline=scope.inline,
+        )
+        extras_ids = [message.message_id for message in messages[1:]]
+        return head, extras_ids, meta
+
+
+class AlbumSender:
+    """Send album payloads via Telegram bot API."""
+
+    def __init__(self, dependencies: SendDependencies) -> None:
+        self._preparation = AlbumSendPreparation(dependencies)
+        self._finalizer = AlbumSendFinalizer()
 
     async def send(
         self,
@@ -96,26 +146,39 @@ class AlbumSender:
         scope: Scope,
         context: SendContext,
     ) -> tuple[Message, list[int], GroupMeta]:
-        extras, addition = self._extras.build(bot, scope=scope, payload=payload)
-        bundle = self._bundles.build(payload.group, extras=extras)
+        envelope = self._preparation.plan(bot, scope=scope, payload=payload)
+        messages = await self._dispatch(bot, envelope, context)
+        return self._finalizer.finalize(
+            messages,
+            payload=payload,
+            scope=scope,
+            reporter=context.reporter,
+        )
 
+    async def _dispatch(
+        self,
+        bot: Bot,
+        envelope: AlbumDispatchEnvelope,
+        context: SendContext,
+    ) -> list[Message]:
         messages = await bot.send_media_group(
-            media=bundle,
+            media=envelope.bundle,
             **context.targets,
-            **addition,
+            **envelope.addition,
         )
-        head = messages[0]
-        context.reporter.success(head.message_id, len(messages) - 1)
-        meta = GroupMeta(
-            clusters=self._clusters.build(messages, payload),
-            inline=scope.inline,
-        )
-        extras_ids = [message.message_id for message in messages[1:]]
-        return head, extras_ids, meta
+        return list(messages)
 
 
-class SingleMediaSender:
-    """Send single media payloads."""
+@dataclass(frozen=True)
+class SingleMediaDispatchPlan:
+    """Instruction set required to deliver a single media payload."""
+
+    sender: Callable[..., Awaitable[Message]]
+    arguments: dict[str, object]
+
+
+class SingleMediaPreparation:
+    """Derive sender callable and arguments for media payloads."""
 
     def __init__(self, dependencies: SendDependencies, guard: LimitsGuardian) -> None:
         self._schema = dependencies.schema
@@ -123,7 +186,7 @@ class SingleMediaSender:
         self._policy = dependencies.policy
         self._guard = guard
 
-    async def send(
+    def plan(
         self,
         bot: Bot,
         payload: Payload,
@@ -131,12 +194,12 @@ class SingleMediaSender:
         scope: Scope,
         context: SendContext,
         truncate: bool,
-    ) -> tuple[Message, list[int], Meta]:
+    ) -> SingleMediaDispatchPlan:
         caption = captionkit.caption(payload)
         caption = self._guard.caption(caption, truncate, context.reporter)
         extras = self._schema.send(scope, payload.extra, span=len(caption or ""), media=True)
         sender = getattr(bot, f"send_{payload.media.type.value}")
-        arguments = {
+        arguments: dict[str, object] = {
             **context.targets,
             payload.media.type.value: self._policy.adapt(payload.media.path, native=True),
             "reply_markup": context.markup,
@@ -145,19 +208,31 @@ class SingleMediaSender:
             arguments["caption"] = caption
         arguments.update(self._screen.filter(sender, extras.get("caption", {})))
         arguments.update(self._screen.filter(sender, extras.get("media", {})))
-        message = await sender(**arguments)
-        context.reporter.success(message.message_id, 0)
-        meta = util.extract(message, payload, scope)
+        return SingleMediaDispatchPlan(sender=sender, arguments=arguments)
+
+
+class SingleMediaFinalizer:
+    """Create navigator metadata from Telegram media responses."""
+
+    def finalize(
+        self,
+        message: Message,
+        *,
+        payload: Payload,
+        scope: Scope,
+        reporter: "SendTelemetry",
+    ) -> tuple[Message, list[int], Meta]:
+        reporter.success(message.message_id, 0)
+        meta = extract_meta(message, payload, scope)
         return message, [], meta
 
 
-class TextSender:
-    """Send plain text payloads."""
+class SingleMediaSender:
+    """Send single media payloads."""
 
     def __init__(self, dependencies: SendDependencies, guard: LimitsGuardian) -> None:
-        self._schema = dependencies.schema
-        self._screen = dependencies.screen
-        self._guard = guard
+        self._preparation = SingleMediaPreparation(dependencies, guard)
+        self._finalizer = SingleMediaFinalizer()
 
     async def send(
         self,
@@ -168,18 +243,111 @@ class TextSender:
         context: SendContext,
         truncate: bool,
     ) -> tuple[Message, list[int], Meta]:
-        text = self._guard.text(payload.text, truncate, context.reporter)
+        plan = self._preparation.plan(
+            bot,
+            payload,
+            scope=scope,
+            context=context,
+            truncate=truncate,
+        )
+        message = await plan.sender(**plan.arguments)
+        return self._finalizer.finalize(
+            message,
+            payload=payload,
+            scope=scope,
+            reporter=context.reporter,
+        )
+
+
+@dataclass(frozen=True)
+class TextDispatchPlan:
+    """Capture prepared text payload data for dispatch."""
+
+    text: str
+    extras: Mapping[str, object]
+
+
+class TextMessagePreparation:
+    """Build text payload dispatch plans using configured dependencies."""
+
+    def __init__(self, dependencies: SendDependencies, guard: LimitsGuardian) -> None:
+        self._schema = dependencies.schema
+        self._screen = dependencies.screen
+        self._guard = guard
+
+    def plan(
+        self,
+        scope: Scope,
+        payload: Payload,
+        *,
+        truncate: bool,
+        reporter: "SendTelemetry",
+    ) -> TextDispatchPlan:
+        text = self._guard.text(payload.text, truncate, reporter)
         extras = self._schema.send(scope, payload.extra, span=len(text), media=False)
-        message = await bot.send_message(
+        return TextDispatchPlan(text=text, extras=extras)
+
+
+class TextMessageFinalizer:
+    """Convert Telegram responses for text payloads to navigator meta."""
+
+    def finalize(
+        self,
+        message: Message,
+        *,
+        payload: Payload,
+        scope: Scope,
+        reporter: "SendTelemetry",
+    ) -> tuple[Message, list[int], Meta]:
+        reporter.success(message.message_id, 0)
+        meta = extract_meta(message, payload, scope)
+        return message, [], meta
+
+
+class TextSender:
+    """Send plain text payloads."""
+
+    def __init__(self, dependencies: SendDependencies, guard: LimitsGuardian) -> None:
+        self._screen = dependencies.screen
+        self._preparation = TextMessagePreparation(dependencies, guard)
+        self._finalizer = TextMessageFinalizer()
+
+    async def send(
+        self,
+        bot: Bot,
+        payload: Payload,
+        *,
+        scope: Scope,
+        context: SendContext,
+        truncate: bool,
+    ) -> tuple[Message, list[int], Meta]:
+        plan = self._preparation.plan(
+            scope,
+            payload,
+            truncate=truncate,
+            reporter=context.reporter,
+        )
+        message = await self._dispatch(bot, context, plan)
+        return self._finalizer.finalize(
+            message,
+            payload=payload,
+            scope=scope,
+            reporter=context.reporter,
+        )
+
+    async def _dispatch(
+        self,
+        bot: Bot,
+        context: SendContext,
+        plan: TextDispatchPlan,
+    ) -> Message:
+        return await bot.send_message(
             **context.targets,
-            text=text,
+            text=plan.text,
             reply_markup=context.markup,
             link_preview_options=context.preview,
-            **self._screen.filter(bot.send_message, extras.get("text", {})),
+            **self._screen.filter(bot.send_message, plan.extras.get("text", {})),
         )
-        context.reporter.success(message.message_id, 0)
-        meta = util.extract(message, payload, scope)
-        return message, [], meta
 
 
 __all__ = ["AlbumSender", "SingleMediaSender", "TextSender"]

--- a/adapters/telegram/gateway/targeting.py
+++ b/adapters/telegram/gateway/targeting.py
@@ -1,0 +1,36 @@
+"""Helpers for deriving Telegram message targets."""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from navigator.core.value.message import Scope
+
+
+def resolve_targets(
+    scope: Scope,
+    message: Optional[int] = None,
+    *,
+    topical: bool = True,
+) -> Dict[str, Any]:
+    """Build keyword arguments describing Telegram addressing semantics."""
+
+    data: Dict[str, Any] = {}
+    if scope.inline:
+        data["inline_message_id"] = scope.inline
+    elif scope.business:
+        data["business_connection_id"] = scope.business
+        if message is not None:
+            data["message_id"] = message
+    else:
+        data["chat_id"] = scope.chat
+        if message is not None:
+            data["message_id"] = message
+    if topical and not scope.inline and scope.topic is not None:
+        if getattr(scope, "direct", False):
+            data["direct_messages_topic_id"] = scope.topic
+        else:
+            data["message_thread_id"] = scope.topic
+    return data
+
+
+__all__ = ["resolve_targets"]

--- a/presentation/telegram/assembly.py
+++ b/presentation/telegram/assembly.py
@@ -17,8 +17,9 @@ from .runtime_provider import (
     AssemblyProvider,
     RuntimeEntrypoint,
     RuntimeResolver,
-    TelegramRuntimeBuilder,
     TelegramRuntimeConfiguration,
+    TelegramRuntimeBuilder,
+    create_runtime_builder,
 )
 from .scope import outline
 
@@ -49,7 +50,7 @@ class TelegramNavigatorAssembler:
         assembly_provider: AssemblyProvider | None = None,
         entrypoint: RuntimeEntrypoint | None = None,
     ) -> "TelegramNavigatorAssembler":
-        builder = TelegramRuntimeBuilder.create(
+        builder = create_runtime_builder(
             instrumentation_factory=instrumentation_factory,
             runtime_resolver=runtime_resolver,
             assembly_provider=assembly_provider,

--- a/presentation/telegram/runtime/__init__.py
+++ b/presentation/telegram/runtime/__init__.py
@@ -1,0 +1,30 @@
+"""Telegram presentation runtime helpers."""
+from navigator.contracts.runtime import NavigatorRuntimeInstrument as NavigatorInstrument
+from navigator.app.service.navigator_runtime import (
+    RuntimeAssemblerResolver as RuntimeResolver,
+    RuntimeAssemblyProvider as AssemblyProvider,
+    RuntimeAssemblyEntrypoint as RuntimeEntrypoint,
+)
+
+from .builder import TelegramRuntimeBuilder, create_runtime_builder
+from .configuration import TelegramRuntimeConfiguration, TelegramInstrumentationPolicy
+from .dependencies import TelegramAssemblyCollaborators, TelegramRuntimeDependencies
+from .resolution import (
+    TelegramRuntimeConfigurationResolver,
+    TelegramRuntimeProviderFactory,
+)
+
+__all__ = [
+    "NavigatorInstrument",
+    "RuntimeResolver",
+    "RuntimeEntrypoint",
+    "AssemblyProvider",
+    "TelegramRuntimeBuilder",
+    "create_runtime_builder",
+    "TelegramRuntimeConfiguration",
+    "TelegramInstrumentationPolicy",
+    "TelegramAssemblyCollaborators",
+    "TelegramRuntimeDependencies",
+    "TelegramRuntimeConfigurationResolver",
+    "TelegramRuntimeProviderFactory",
+]

--- a/presentation/telegram/runtime/builder.py
+++ b/presentation/telegram/runtime/builder.py
@@ -1,0 +1,83 @@
+"""Builders orchestrating Telegram runtime provider creation."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from navigator.app.service.navigator_runtime import NavigatorRuntimeProvider
+from navigator.contracts.runtime import NavigatorAssemblyOverrides
+
+from .configuration import TelegramRuntimeConfiguration
+from .dependencies import TelegramRuntimeDependencies
+from .resolution import (
+    TelegramRuntimeConfigurationResolver,
+    TelegramRuntimeProviderFactory,
+)
+
+
+@dataclass(frozen=True)
+class TelegramRuntimeBuilder:
+    """Orchestrate the construction of navigator runtime providers."""
+
+    configuration_resolver: TelegramRuntimeConfigurationResolver
+    provider_factory: TelegramRuntimeProviderFactory
+
+    def build_provider(
+        self,
+        *,
+        base_configuration: TelegramRuntimeConfiguration | None,
+        overrides: NavigatorAssemblyOverrides | None,
+        provider: NavigatorRuntimeProvider | None,
+        facade_type: type | None,
+    ) -> NavigatorRuntimeProvider:
+        configuration = self.configuration_resolver.resolve(
+            base=base_configuration,
+            facade_type=facade_type,
+        )
+        configuration = configuration.with_facade(facade_type)
+        return self.provider_factory.create(
+            configuration=configuration,
+            overrides=overrides,
+            provider=provider,
+        )
+
+
+def create_runtime_builder(
+    *,
+    instrumentation_factory: "InstrumentationFactory" | None = None,
+    runtime_resolver: "RuntimeAssemblerResolver" | None = None,
+    assembly_provider: "RuntimeAssemblyProvider" | None = None,
+    entrypoint: "RuntimeAssemblyEntrypoint" | None = None,
+) -> TelegramRuntimeBuilder:
+    """Compose a :class:`TelegramRuntimeBuilder` with resolved dependencies."""
+
+    dependencies = TelegramRuntimeDependencies.create(
+        instrumentation_factory=instrumentation_factory,
+        runtime_resolver=runtime_resolver,
+        assembly_provider=assembly_provider,
+        entrypoint=entrypoint,
+    )
+    configuration_resolver = TelegramRuntimeConfigurationResolver(dependencies)
+    provider_factory = TelegramRuntimeProviderFactory(dependencies)
+    return TelegramRuntimeBuilder(
+        configuration_resolver=configuration_resolver,
+        provider_factory=provider_factory,
+    )
+
+
+__all__ = [
+    "TelegramRuntimeBuilder",
+    "create_runtime_builder",
+]
+
+
+if False:  # pragma: no cover - typing only
+    from collections.abc import Callable, Iterable
+
+    from navigator.contracts.runtime import NavigatorRuntimeInstrument
+    from navigator.app.service.navigator_runtime import (
+        RuntimeAssemblerResolver,
+        RuntimeAssemblyProvider,
+        RuntimeAssemblyEntrypoint,
+    )
+
+    InstrumentationFactory = Callable[[], Iterable[NavigatorRuntimeInstrument]]

--- a/presentation/telegram/runtime/configuration.py
+++ b/presentation/telegram/runtime/configuration.py
@@ -1,0 +1,93 @@
+"""Telegram-specific runtime configuration primitives."""
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass, replace
+
+from navigator.app.service.navigator_runtime import RuntimeAssemblyConfiguration, default_configuration
+from navigator.contracts.runtime import NavigatorAssemblyOverrides, NavigatorRuntimeInstrument
+from navigator.core.contracts import MissingAlert
+
+from ..runtime_defaults import default_instrumentation_factory
+from ..alerts import missing
+
+
+@dataclass(frozen=True)
+class TelegramRuntimeConfiguration:
+    """Configuration bundle describing runtime assembly policies."""
+
+    instrumentation: Sequence[NavigatorRuntimeInstrument]
+    missing_alert: MissingAlert
+    facade_type: type | None = None
+    assembler_resolver: "RuntimeAssemblerResolver" | None = None
+    provider: "RuntimeAssemblyProvider" | None = None
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        instrumentation: Iterable[NavigatorRuntimeInstrument] | None = None,
+        missing_alert: MissingAlert | None = None,
+        instrumentation_factory: Callable[[], Iterable[NavigatorRuntimeInstrument]] | None = None,
+        facade_type: type | None = None,
+        assembler_resolver: "RuntimeAssemblerResolver" | None = None,
+        provider: "RuntimeAssemblyProvider" | None = None,
+    ) -> "TelegramRuntimeConfiguration":
+        instruments: Sequence[NavigatorRuntimeInstrument]
+        if instrumentation is None:
+            candidates = instrumentation_factory() if instrumentation_factory else ()
+            instruments = tuple(candidates)
+        else:
+            instruments = tuple(instrumentation)
+        return cls(
+            instrumentation=instruments,
+            missing_alert=missing_alert or missing,
+            facade_type=facade_type,
+            assembler_resolver=assembler_resolver,
+            provider=provider,
+        )
+
+    def as_configuration(
+        self, overrides: NavigatorAssemblyOverrides | None
+    ) -> RuntimeAssemblyConfiguration:
+        """Translate Telegram configuration into a runtime configuration."""
+
+        return default_configuration(
+            instrumentation=tuple(self.instrumentation),
+            missing_alert=self.missing_alert,
+            overrides=overrides,
+            facade_type=self.facade_type,
+            assembler_resolver=self.assembler_resolver,
+            provider=self.provider,
+        )
+
+    def with_facade(self, facade_type: type | None) -> "TelegramRuntimeConfiguration":
+        """Ensure that a facade type is present, preserving explicit overrides."""
+
+        if facade_type is None or self.facade_type is not None:
+            return self
+        return replace(self, facade_type=facade_type)
+
+
+@dataclass(frozen=True)
+class TelegramInstrumentationPolicy:
+    """Describe how instrumentation for the runtime should be produced."""
+
+    factory: Callable[[], Iterable[NavigatorRuntimeInstrument]]
+
+    @classmethod
+    def create(
+        cls,
+        factory: Callable[[], Iterable[NavigatorRuntimeInstrument]] | None = None,
+    ) -> "TelegramInstrumentationPolicy":
+        return cls(factory=factory or default_instrumentation_factory)
+
+
+__all__ = [
+    "TelegramRuntimeConfiguration",
+    "TelegramInstrumentationPolicy",
+]
+
+
+if False:  # pragma: no cover - typing only
+    from navigator.app.service.navigator_runtime import RuntimeAssemblerResolver, RuntimeAssemblyProvider

--- a/presentation/telegram/runtime/dependencies.py
+++ b/presentation/telegram/runtime/dependencies.py
@@ -1,0 +1,74 @@
+"""Runtime dependency wiring specific to the Telegram presentation layer."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from collections.abc import Callable, Iterable
+
+from navigator.contracts.runtime import NavigatorRuntimeInstrument
+
+from navigator.app.service.navigator_runtime import (
+    RuntimeAssemblyEntrypoint,
+    RuntimeAssemblerResolver,
+    RuntimeAssemblyProvider,
+    assemble_navigator,
+)
+
+from .configuration import TelegramInstrumentationPolicy
+from ..runtime_defaults import default_runtime_resolver
+
+
+@dataclass(frozen=True)
+class TelegramAssemblyCollaborators:
+    """Capture collaborators required to assemble a runtime."""
+
+    assembler_resolver: RuntimeAssemblerResolver | None
+    provider: RuntimeAssemblyProvider | None
+    entrypoint: RuntimeAssemblyEntrypoint
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        runtime_resolver: RuntimeAssemblerResolver | None = None,
+        assembly_provider: RuntimeAssemblyProvider | None = None,
+        entrypoint: RuntimeAssemblyEntrypoint | None = None,
+    ) -> "TelegramAssemblyCollaborators":
+        resolver = runtime_resolver or default_runtime_resolver()
+        return cls(
+            assembler_resolver=resolver,
+            provider=assembly_provider,
+            entrypoint=entrypoint or assemble_navigator,
+        )
+
+
+@dataclass(frozen=True)
+class TelegramRuntimeDependencies:
+    """Group runtime collaborators with instrumentation policies."""
+
+    instrumentation: TelegramInstrumentationPolicy
+    assembly: TelegramAssemblyCollaborators
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        instrumentation_factory: Callable[[], Iterable[NavigatorRuntimeInstrument]] | None = None,
+        runtime_resolver: RuntimeAssemblerResolver | None = None,
+        assembly_provider: RuntimeAssemblyProvider | None = None,
+        entrypoint: RuntimeAssemblyEntrypoint | None = None,
+    ) -> "TelegramRuntimeDependencies":
+        instrumentation = TelegramInstrumentationPolicy.create(
+            factory=instrumentation_factory
+        )
+        assembly = TelegramAssemblyCollaborators.create(
+            runtime_resolver=runtime_resolver,
+            assembly_provider=assembly_provider,
+            entrypoint=entrypoint,
+        )
+        return cls(instrumentation=instrumentation, assembly=assembly)
+
+
+__all__ = [
+    "TelegramAssemblyCollaborators",
+    "TelegramRuntimeDependencies",
+]

--- a/presentation/telegram/runtime/resolution.py
+++ b/presentation/telegram/runtime/resolution.py
@@ -1,0 +1,68 @@
+"""Configuration resolution helpers for Telegram runtime providers."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from navigator.app.service.navigator_runtime import (
+    NavigatorRuntimeProvider,
+    RuntimeAssemblyProvider,
+    RuntimeAssemblerResolver,
+)
+from navigator.contracts.runtime import NavigatorAssemblyOverrides
+
+from .configuration import TelegramRuntimeConfiguration
+from .dependencies import TelegramRuntimeDependencies
+
+
+@dataclass(frozen=True)
+class TelegramRuntimeConfigurationResolver:
+    """Resolve configuration objects using the provided dependencies."""
+
+    dependencies: TelegramRuntimeDependencies
+
+    def resolve(
+        self,
+        *,
+        base: TelegramRuntimeConfiguration | None = None,
+        facade_type: type | None = None,
+    ) -> TelegramRuntimeConfiguration:
+        if base is not None:
+            return base
+        return TelegramRuntimeConfiguration.create(
+            instrumentation_factory=self.dependencies.instrumentation.factory,
+            assembler_resolver=self.dependencies.assembly.assembler_resolver,
+            provider=self.dependencies.assembly.provider,
+            facade_type=facade_type,
+        )
+
+
+@dataclass(frozen=True)
+class TelegramRuntimeProviderFactory:
+    """Create runtime providers bound to Telegram defaults."""
+
+    dependencies: TelegramRuntimeDependencies
+
+    def create(
+        self,
+        *,
+        configuration: TelegramRuntimeConfiguration,
+        overrides: NavigatorAssemblyOverrides | None,
+        provider: NavigatorRuntimeProvider | None,
+    ) -> NavigatorRuntimeProvider:
+        if provider is not None:
+            return provider
+        runtime_configuration = configuration.as_configuration(overrides)
+        return NavigatorRuntimeProvider(
+            self.dependencies.assembly.entrypoint,
+            configuration=runtime_configuration,
+        )
+
+
+__all__ = [
+    "TelegramRuntimeConfigurationResolver",
+    "TelegramRuntimeProviderFactory",
+]
+
+
+if False:  # pragma: no cover - typing only
+    from navigator.app.service.navigator_runtime import NavigatorRuntimeProvider

--- a/presentation/telegram/runtime_provider.py
+++ b/presentation/telegram/runtime_provider.py
@@ -1,249 +1,28 @@
-"""Runtime provider utilities tailored for Telegram presentation layer."""
+"""Backwards compatible exports for Telegram runtime helpers."""
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Sequence
-from dataclasses import dataclass, replace
-
 from navigator.app.service.navigator_runtime import (
-    NavigatorRuntimeProvider,
-    RuntimeAssemblyConfiguration,
+    RuntimeAssemblerResolver,
     RuntimeAssemblyEntrypoint,
     RuntimeAssemblyProvider,
-    RuntimeAssemblerResolver,
-    assemble_navigator,
-    default_configuration,
 )
-from navigator.contracts.runtime import (
-    NavigatorAssemblyOverrides,
-    NavigatorRuntimeInstrument,
+from navigator.contracts.runtime import NavigatorRuntimeInstrument
+
+from .runtime import (
+    TelegramAssemblyCollaborators,
+    TelegramRuntimeBuilder,
+    TelegramRuntimeConfiguration,
+    TelegramRuntimeConfigurationResolver,
+    TelegramRuntimeDependencies,
+    TelegramRuntimeProviderFactory,
+    TelegramInstrumentationPolicy,
+    create_runtime_builder,
 )
-from navigator.core.contracts import MissingAlert
-
-from .alerts import missing
-from .runtime_defaults import (
-    default_instrumentation_factory,
-    default_runtime_resolver,
-)
-
-
-@dataclass(frozen=True)
-class TelegramRuntimeConfiguration:
-    """Configuration bundle describing runtime assembly policies."""
-
-    instrumentation: Sequence[NavigatorRuntimeInstrument]
-    missing_alert: MissingAlert
-    facade_type: type | None = None
-    assembler_resolver: RuntimeAssemblerResolver | None = None
-    provider: RuntimeAssemblyProvider | None = None
-
-    @classmethod
-    def create(
-        cls,
-        *,
-        instrumentation: Iterable[NavigatorRuntimeInstrument] | None = None,
-        missing_alert: MissingAlert | None = None,
-        instrumentation_factory: Callable[[], Iterable[NavigatorRuntimeInstrument]] | None = None,
-        facade_type: type | None = None,
-        assembler_resolver: RuntimeAssemblerResolver | None = None,
-        provider: RuntimeAssemblyProvider | None = None,
-    ) -> "TelegramRuntimeConfiguration":
-        instruments: Sequence[NavigatorRuntimeInstrument]
-        if instrumentation is None:
-            candidates = instrumentation_factory() if instrumentation_factory else ()
-            instruments = tuple(candidates)
-        else:
-            instruments = tuple(instrumentation)
-        return cls(
-            instrumentation=instruments,
-            missing_alert=missing_alert or missing,
-            facade_type=facade_type,
-            assembler_resolver=assembler_resolver,
-            provider=provider,
-        )
-
-    def as_configuration(
-        self, overrides: NavigatorAssemblyOverrides | None
-    ) -> RuntimeAssemblyConfiguration:
-        """Translate Telegram configuration into a runtime configuration."""
-
-        return default_configuration(
-            instrumentation=tuple(self.instrumentation),
-            missing_alert=self.missing_alert,
-            overrides=overrides,
-            facade_type=self.facade_type,
-            assembler_resolver=self.assembler_resolver,
-            provider=self.provider,
-        )
-
-
-@dataclass(frozen=True)
-class TelegramInstrumentationPolicy:
-    """Describe how instrumentation for the runtime should be produced."""
-
-    factory: Callable[[], Iterable[NavigatorRuntimeInstrument]]
-
-    @classmethod
-    def create(
-        cls,
-        factory: Callable[[], Iterable[NavigatorRuntimeInstrument]] | None = None,
-    ) -> "TelegramInstrumentationPolicy":
-        return cls(factory=factory or default_instrumentation_factory)
-
-
-@dataclass(frozen=True)
-class TelegramAssemblyCollaborators:
-    """Capture collaborators required to assemble a runtime."""
-
-    assembler_resolver: RuntimeAssemblerResolver | None
-    provider: RuntimeAssemblyProvider | None
-    entrypoint: RuntimeAssemblyEntrypoint
-
-    @classmethod
-    def create(
-        cls,
-        *,
-        runtime_resolver: RuntimeAssemblerResolver | None = None,
-        assembly_provider: RuntimeAssemblyProvider | None = None,
-        entrypoint: RuntimeAssemblyEntrypoint | None = None,
-    ) -> "TelegramAssemblyCollaborators":
-        resolver = runtime_resolver or default_runtime_resolver()
-        return cls(
-            assembler_resolver=resolver,
-            provider=assembly_provider,
-            entrypoint=entrypoint or assemble_navigator,
-        )
-
-
-@dataclass(frozen=True)
-class TelegramRuntimeDependencies:
-    """Group runtime collaborators with instrumentation policies."""
-
-    instrumentation: TelegramInstrumentationPolicy
-    assembly: TelegramAssemblyCollaborators
-
-    @classmethod
-    def create(
-        cls,
-        *,
-        instrumentation_factory: Callable[
-            [], Iterable[NavigatorRuntimeInstrument]
-        ] | None = None,
-        runtime_resolver: RuntimeAssemblerResolver | None = None,
-        assembly_provider: RuntimeAssemblyProvider | None = None,
-        entrypoint: RuntimeAssemblyEntrypoint | None = None,
-    ) -> "TelegramRuntimeDependencies":
-        instrumentation = TelegramInstrumentationPolicy.create(
-            factory=instrumentation_factory
-        )
-        assembly = TelegramAssemblyCollaborators.create(
-            runtime_resolver=runtime_resolver,
-            assembly_provider=assembly_provider,
-            entrypoint=entrypoint,
-        )
-        return cls(instrumentation=instrumentation, assembly=assembly)
-
-
-@dataclass(frozen=True)
-class TelegramRuntimeConfigurationResolver:
-    """Resolve configuration objects using the provided dependencies."""
-
-    dependencies: TelegramRuntimeDependencies
-
-    def resolve(
-        self,
-        *,
-        base: TelegramRuntimeConfiguration | None = None,
-        facade_type: type | None = None,
-    ) -> TelegramRuntimeConfiguration:
-        if base is not None:
-            return base
-        return TelegramRuntimeConfiguration.create(
-            instrumentation_factory=self.dependencies.instrumentation.factory,
-            assembler_resolver=self.dependencies.assembly.assembler_resolver,
-            provider=self.dependencies.assembly.provider,
-            facade_type=facade_type,
-        )
-
-
-@dataclass(frozen=True)
-class TelegramRuntimeProviderFactory:
-    """Create runtime providers bound to Telegram defaults."""
-
-    dependencies: TelegramRuntimeDependencies
-
-    def create(
-        self,
-        *,
-        configuration: TelegramRuntimeConfiguration,
-        overrides: NavigatorAssemblyOverrides | None,
-        provider: NavigatorRuntimeProvider | None,
-    ) -> NavigatorRuntimeProvider:
-        if provider is not None:
-            return provider
-        runtime_configuration = configuration.as_configuration(overrides)
-        return NavigatorRuntimeProvider(
-            self.dependencies.assembly.entrypoint,
-            configuration=runtime_configuration,
-        )
-
-
-@dataclass(frozen=True)
-class TelegramRuntimeBuilder:
-    """Orchestrate the construction of navigator runtime providers."""
-
-    dependencies: TelegramRuntimeDependencies
-    configuration_resolver: TelegramRuntimeConfigurationResolver
-
-    @classmethod
-    def create(
-        cls,
-        *,
-        instrumentation_factory: Callable[
-            [], Iterable[NavigatorRuntimeInstrument]
-        ] | None = None,
-        runtime_resolver: RuntimeAssemblerResolver | None = None,
-        assembly_provider: RuntimeAssemblyProvider | None = None,
-        entrypoint: RuntimeAssemblyEntrypoint | None = None,
-    ) -> "TelegramRuntimeBuilder":
-        dependencies = TelegramRuntimeDependencies.create(
-            instrumentation_factory=instrumentation_factory,
-            runtime_resolver=runtime_resolver,
-            assembly_provider=assembly_provider,
-            entrypoint=entrypoint,
-        )
-        configuration_resolver = TelegramRuntimeConfigurationResolver(dependencies)
-        return cls(
-            dependencies=dependencies,
-            configuration_resolver=configuration_resolver,
-        )
-
-    def build_provider(
-        self,
-        *,
-        base_configuration: TelegramRuntimeConfiguration | None,
-        overrides: NavigatorAssemblyOverrides | None,
-        provider: NavigatorRuntimeProvider | None,
-        facade_type: type | None,
-    ) -> NavigatorRuntimeProvider:
-        configuration = self.configuration_resolver.resolve(
-            base=base_configuration,
-            facade_type=facade_type,
-        )
-        if configuration.facade_type is None and facade_type is not None:
-            configuration = replace(configuration, facade_type=facade_type)
-        factory = TelegramRuntimeProviderFactory(self.dependencies)
-        return factory.create(
-            configuration=configuration,
-            overrides=overrides,
-            provider=provider,
-        )
-
 
 NavigatorInstrument = NavigatorRuntimeInstrument
 RuntimeResolver = RuntimeAssemblerResolver
 AssemblyProvider = RuntimeAssemblyProvider
 RuntimeEntrypoint = RuntimeAssemblyEntrypoint
-
 
 __all__ = [
     "NavigatorInstrument",
@@ -251,8 +30,11 @@ __all__ = [
     "RuntimeEntrypoint",
     "AssemblyProvider",
     "TelegramRuntimeConfiguration",
+    "TelegramInstrumentationPolicy",
+    "TelegramAssemblyCollaborators",
     "TelegramRuntimeDependencies",
     "TelegramRuntimeConfigurationResolver",
     "TelegramRuntimeProviderFactory",
     "TelegramRuntimeBuilder",
+    "create_runtime_builder",
 ]


### PR DESCRIPTION
## Summary
- extract Telegram runtime configuration, dependency wiring, and builder orchestration into dedicated modules while keeping runtime_provider as a compatibility façade
- add a RuntimeAssemblyPipeline so NavigatorAssemblyService composes smaller steps instead of performing request creation, resolution, and assembly inline
- split the Telegram gateway utility helpers into focused targeting/meta modules and refactor send strategies to delegate preparation and finalization responsibilities

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'manual')*


------
https://chatgpt.com/codex/tasks/task_e_68d824f3145c833088c1bc81385583fd